### PR TITLE
fix(ci): restore @playwright/test and update CI for Node.js 22 (GIV-492)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: 10
 
@@ -70,7 +70,7 @@ jobs:
           node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: 10
 
@@ -108,7 +108,7 @@ jobs:
           node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: 10
 
@@ -208,7 +208,7 @@ jobs:
           node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: 10
 
@@ -274,7 +274,7 @@ jobs:
           node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         with:
           version: 10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint:
     name: Lint
@@ -22,10 +25,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 10
 
@@ -64,10 +67,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 10
 
@@ -102,10 +105,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 10
 
@@ -202,10 +205,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 10
 
@@ -224,7 +227,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium --with-deps
@@ -268,10 +271,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 10
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.46.0",
     "vite": "^7.3.2",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "@playwright/test": "^1.52.0"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
## Summary
- Restore `@playwright/test` devDependency accidentally removed by Dependabot vitest bump (PR #191) — this caused pnpm-lock.yaml desync breaking all 5 CI jobs
- Update Node.js from 20 to 22 (current LTS) across all CI jobs
- Update `pnpm/action-setup` from v3 to v4
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` workflow env to address GitHub Actions Node.js 20 runtime deprecation (effective June 16, 2026)
- Fix E2E job to use `--frozen-lockfile` for consistency

## Root Cause
The Dependabot vitest bump (PR #191, commit `255ce01`) replaced the last two lines of devDependencies with the updated vitest entry, accidentally deleting `@playwright/test` which was the final entry. This caused `pnpm install --frozen-lockfile` to fail in CI because the lockfile still referenced `@playwright/test` but `package.json` no longer listed it.

## Test plan
- [x] `pnpm install --frozen-lockfile` passes locally
- [x] `pnpm run type-check` passes locally
- [x] `pnpm run lint` passes locally
- [x] `pnpm run build` passes locally
- [ ] CI pipeline passes on this PR

Generated with [Claude Code](https://claude.com/claude-code)