### PR TITLE
feat: conditional router + web deploy SPA fallback (GIV-506)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:web": "vite build",
+    "build:desktop": "tauri build",
     "preview": "vite preview",
     "tauri": "tauri",
     "tauri:dev": "WEBKIT_DISABLE_COMPOSITING_MODE=1 GDK_BACKEND=x11 tauri dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from 'react'
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
+import { BrowserRouter, HashRouter, Routes, Route, Navigate } from 'react-router-dom'
 import Navigation from './components/layout/Navigation'
+import { isTauriAvailable } from './utils/tauri'
 import { TransactionProvider } from './contexts/TransactionContext'
 import { TokenProvider } from './contexts/TokenContext'
 import { WalletAliasProvider } from './contexts/WalletAliasContext'
@@ -177,11 +178,13 @@ const MainRoutes: React.FC = () => (
   </Navigation>
 )
 
+const Router = isTauriAvailable() ? HashRouter : BrowserRouter
+
 /**
  * Root application component with routing and provider hierarchy.
  */
 const App: React.FC = () => (
-  <BrowserRouter>
+  <Router>
     <LanguageProvider>
       <AppProvider>
         <AppWrapper>
@@ -209,7 +212,7 @@ const App: React.FC = () => (
         </AppWrapper>
       </AppProvider>
     </LanguageProvider>
-  </BrowserRouter>
+  </Router>
 )
 
 export default App

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,11 @@
 import React, { Suspense } from 'react'
-import { BrowserRouter, HashRouter, Routes, Route, Navigate } from 'react-router-dom'
+import {
+  BrowserRouter,
+  HashRouter,
+  Routes,
+  Route,
+  Navigate,
+} from 'react-router-dom'
 import Navigation from './components/layout/Navigation'
 import { isTauriAvailable } from './utils/tauri'
 import { TransactionProvider } from './contexts/TransactionContext'
@@ -37,15 +43,9 @@ const Team = React.lazy(() => import('./app/team/Team'))
 const JournalEntries = React.lazy(
   () => import('./app/journal-entries/JournalEntries')
 )
-const ChartOfAccounts = React.lazy(
-  () => import('./app/ledger/ChartOfAccounts')
-)
-const TrialBalance = React.lazy(
-  () => import('./app/ledger/TrialBalance')
-)
-const Reconciliation = React.lazy(
-  () => import('./app/ledger/Reconciliation')
-)
+const ChartOfAccounts = React.lazy(() => import('./app/ledger/ChartOfAccounts'))
+const TrialBalance = React.lazy(() => import('./app/ledger/TrialBalance'))
+const Reconciliation = React.lazy(() => import('./app/ledger/Reconciliation'))
 
 // Loading fallback component
 const LoadingFallback: React.FC = () => (

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
- **Conditional router**: `App.tsx` now picks `HashRouter` (Tauri/desktop, file:// protocol) vs `BrowserRouter` (web) at runtime via the existing `isTauriAvailable()` utility. Prevents deep-link/refresh breakage on `tauri build`.
- **SPA fallback**: Added `vercel.json` with catch-all rewrite `/(.*) -> /index.html` so `BrowserRouter` deep links work on Vercel static hosting.
- **Build aliases**: Added `build:web` (`vite build`) and `build:desktop` (`tauri build`) npm scripts for clarity alongside the existing `build`/`tauri:build`.

## Web deploy instructions
```bash
# Build the static web bundle
pnpm build:web        # outputs to /dist

# Deploy to Vercel (one-time setup)
npx vercel --prod     # uses vercel.json for SPA rewrites

# Or deploy via Vercel CLI link
npx vercel link && npx vercel deploy --prod
```

The existing CI `build-frontend` job already runs `pnpm build` and uploads the `dist/` artifact. To enable automatic Vercel deploys, connect the GitHub repo in the Vercel dashboard — the `vercel.json` rewrites will be picked up automatically.

## Files changed
- `src/App.tsx` — conditional `HashRouter`/`BrowserRouter` selection
- `vercel.json` — SPA rewrite rule for Vercel hosting
- `package.json` — `build:web` and `build:desktop` script aliases

## Test plan
- [ ] `pnpm type-check` passes (verified locally)
- [ ] `pnpm lint` passes (verified locally)
- [ ] E2E tests pass (baseline: 27 pass / 3 skip per GIV-483)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)