### PR TITLE
feat(GIV-511): configurable price source + persist API key

### DIFF
--- a/src-tauri/src/api/price_feeds/coingecko.rs
+++ b/src-tauri/src/api/price_feeds/coingecko.rs
@@ -36,6 +36,18 @@ impl CoinGeckoClient {
         Self { api_key, base_url }
     }
 
+    /// Create a new CoinGecko client with a custom base URL.
+    /// Falls back to the default URL selection (pro vs free) if base_url is None.
+    pub fn with_base_url(api_key: Option<String>, base_url: Option<String>) -> Self {
+        match base_url {
+            Some(url) => Self {
+                api_key,
+                base_url: url,
+            },
+            None => Self::new(api_key),
+        }
+    }
+
     /// Get current price for a cryptocurrency
     ///
     /// # Arguments

--- a/src-tauri/src/api/prices.rs
+++ b/src-tauri/src/api/prices.rs
@@ -54,12 +54,14 @@ pub struct BatchHistoricalPriceResponse {
 pub async fn get_crypto_price(
     coin_id: String,
     vs_currency: Option<String>,
+    api_key: Option<String>,
+    base_url: Option<String>,
 ) -> Result<PriceResponse, String> {
     let currency = vs_currency.unwrap_or_else(|| "usd".to_string());
 
-    // Load API key from environment if available
-    let api_key = std::env::var(ENV_COINGECKO_API_KEY).ok();
-    let client = CoinGeckoClient::new(api_key);
+    // Use passed api_key, fall back to environment variable
+    let resolved_key = api_key.or_else(|| std::env::var(ENV_COINGECKO_API_KEY).ok());
+    let client = CoinGeckoClient::with_base_url(resolved_key, base_url);
 
     let price = client
         .get_price(&coin_id, &currency)
@@ -82,11 +84,13 @@ pub async fn get_crypto_price(
 pub async fn get_crypto_prices(
     coin_ids: Vec<String>,
     vs_currency: Option<String>,
+    api_key: Option<String>,
+    base_url: Option<String>,
 ) -> Result<HashMap<String, String>, String> {
     let currency = vs_currency.unwrap_or_else(|| "usd".to_string());
 
-    let api_key = std::env::var(ENV_COINGECKO_API_KEY).ok();
-    let client = CoinGeckoClient::new(api_key);
+    let resolved_key = api_key.or_else(|| std::env::var(ENV_COINGECKO_API_KEY).ok());
+    let client = CoinGeckoClient::with_base_url(resolved_key, base_url);
 
     let ids: Vec<&str> = coin_ids.iter().map(|s| s.as_str()).collect();
     let prices = client
@@ -108,11 +112,13 @@ pub async fn get_historical_crypto_price(
     coin_id: String,
     date: String,
     vs_currency: Option<String>,
+    api_key: Option<String>,
+    base_url: Option<String>,
 ) -> Result<HistoricalPriceResponse, String> {
     let currency = vs_currency.unwrap_or_else(|| "usd".to_string());
 
-    let api_key = std::env::var(ENV_COINGECKO_API_KEY).ok();
-    let client = CoinGeckoClient::new(api_key);
+    let resolved_key = api_key.or_else(|| std::env::var(ENV_COINGECKO_API_KEY).ok());
+    let client = CoinGeckoClient::with_base_url(resolved_key, base_url);
 
     let price = client
         .get_historical_price(&coin_id, &date, &currency)
@@ -142,11 +148,13 @@ pub async fn get_batch_historical_prices(
     coin_ids: Vec<String>,
     date: String,
     vs_currency: Option<String>,
+    api_key: Option<String>,
+    base_url: Option<String>,
 ) -> Result<BatchHistoricalPriceResponse, String> {
     let currency = vs_currency.unwrap_or_else(|| "usd".to_string());
 
-    let api_key = std::env::var(ENV_COINGECKO_API_KEY).ok();
-    let client = CoinGeckoClient::new(api_key);
+    let resolved_key = api_key.or_else(|| std::env::var(ENV_COINGECKO_API_KEY).ok());
+    let client = CoinGeckoClient::with_base_url(resolved_key, base_url);
 
     let mut prices: HashMap<String, Result<String, String>> = HashMap::new();
 

--- a/src/app/settings/Currencies.tsx
+++ b/src/app/settings/Currencies.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 import {
   Save,
   X,
@@ -15,6 +15,8 @@ import {
 } from '../../types/currency'
 import { FIAT_CURRENCIES, CRYPTO_CURRENCIES } from '../../constants'
 import { useCurrency } from '../../contexts/CurrencyContext'
+import { persistence } from '../../services/persistence'
+import { clearPriceFeedConfigCache } from '../../services/blockchain/priceService'
 
 interface CurrencySettings {
   primaryCurrency: string
@@ -28,6 +30,8 @@ interface CurrencySettings {
   cacheExchangeRates: boolean
   coingeckoApiKey?: string
   fixerApiKey?: string
+  priceFeedProvider?: string
+  priceFeedBaseUrl?: string
 }
 
 interface ChangeActionsProps {
@@ -123,10 +127,37 @@ const Currencies: React.FC = () => {
     ...contextSettings,
     coingeckoApiKey: '',
     fixerApiKey: '',
+    priceFeedProvider: 'coingecko',
+    priceFeedBaseUrl: '',
   }))
 
   const [showApiKeys, setShowApiKeys] = useState(false)
   const [hasChanges, setHasChanges] = useState(false)
+
+  // Load persisted price-feed settings on mount
+  useEffect(() => {
+    let cancelled = false
+    const load = async () => {
+      try {
+        const [apiKey, provider, baseUrl] = await Promise.all([
+          persistence.getSetting('price_feed_api_key'),
+          persistence.getSetting('price_feed_provider'),
+          persistence.getSetting('price_feed_base_url'),
+        ])
+        if (cancelled) return
+        setLocalSettings(prev => ({
+          ...prev,
+          coingeckoApiKey: apiKey ?? '',
+          priceFeedProvider: provider ?? 'coingecko',
+          priceFeedBaseUrl: baseUrl ?? '',
+        }))
+      } catch {
+        // Persistence unavailable on first run — keep defaults
+      }
+    }
+    load()
+    return () => { cancelled = true }
+  }, [])
 
   const handleChange = useCallback(
     <K extends keyof CurrencySettings>(key: K, value: CurrencySettings[K]) => {
@@ -147,24 +178,82 @@ const Currencies: React.FC = () => {
     })
   }, [])
 
-  const handleSave = useCallback(() => {
-    // Update context with new settings (excluding API keys for now)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { coingeckoApiKey, fixerApiKey, ...settingsToSave } = localSettings
+  const handleSave = useCallback(async () => {
+    const {
+      coingeckoApiKey,
+      fixerApiKey: _fixerApiKey,
+      priceFeedProvider,
+      priceFeedBaseUrl,
+      ...settingsToSave
+    } = localSettings
     updateContextSettings(settingsToSave)
 
-    // API keys backend persistence via Tauri command not yet implemented
+    // Persist price-feed settings
+    try {
+      const ops: Promise<void>[] = []
+      if (coingeckoApiKey) {
+        ops.push(persistence.setSetting('price_feed_api_key', coingeckoApiKey))
+      } else {
+        ops.push(persistence.deleteSetting('price_feed_api_key'))
+      }
+      if (priceFeedProvider && priceFeedProvider !== 'coingecko') {
+        ops.push(
+          persistence.setSetting('price_feed_provider', priceFeedProvider)
+        )
+      } else {
+        ops.push(persistence.deleteSetting('price_feed_provider'))
+      }
+      if (priceFeedBaseUrl) {
+        ops.push(
+          persistence.setSetting('price_feed_base_url', priceFeedBaseUrl)
+        )
+      } else {
+        ops.push(persistence.deleteSetting('price_feed_base_url'))
+      }
+      await Promise.all(ops)
+      clearPriceFeedConfigCache()
+    } catch (err) {
+      console.error('[Currencies] Failed to persist price-feed settings:', err)
+    }
+
     setHasChanges(false)
   }, [localSettings, updateContextSettings])
 
   const handleReset = useCallback(() => {
-    // Reset to context settings
+    // Reset to context settings — reload persisted values
     setLocalSettings({
       ...contextSettings,
       coingeckoApiKey: '',
       fixerApiKey: '',
+      priceFeedProvider: 'coingecko',
+      priceFeedBaseUrl: '',
     })
     setHasChanges(false)
+    // Re-load persisted values
+    persistence
+      .getSetting('price_feed_api_key')
+      .then(key =>
+        setLocalSettings(prev => ({ ...prev, coingeckoApiKey: key ?? '' }))
+      )
+      .catch(() => {})
+    persistence
+      .getSetting('price_feed_provider')
+      .then(p =>
+        setLocalSettings(prev => ({
+          ...prev,
+          priceFeedProvider: p ?? 'coingecko',
+        }))
+      )
+      .catch(() => {})
+    persistence
+      .getSetting('price_feed_base_url')
+      .then(url =>
+        setLocalSettings(prev => ({
+          ...prev,
+          priceFeedBaseUrl: url ?? '',
+        }))
+      )
+      .catch(() => {})
   }, [contextSettings])
 
   // Format number based on decimal separator standard
@@ -281,6 +370,20 @@ const Currencies: React.FC = () => {
   const handleFixerKeyChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       handleChange('fixerApiKey', e.target.value)
+    },
+    [handleChange]
+  )
+
+  const handleProviderChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      handleChange('priceFeedProvider', e.target.value)
+    },
+    [handleChange]
+  )
+
+  const handleBaseUrlChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      handleChange('priceFeedBaseUrl', e.target.value)
     },
     [handleChange]
   )
@@ -626,6 +729,49 @@ const Currencies: React.FC = () => {
               Configure API keys for external exchange rate providers. These are
               optional but recommended for production use.
             </p>
+
+            <div className="space-y-4 mb-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label
+                    htmlFor="price-feed-provider"
+                    className="block text-sm font-medium text-[#1a1815] dark:text-[#b8b3ac] mb-2"
+                  >
+                    Price Feed Provider
+                  </label>
+                  <select
+                    id="price-feed-provider"
+                    value={localSettings.priceFeedProvider || 'coingecko'}
+                    onChange={handleProviderChange}
+                    className="select-input w-full px-3 pr-8 py-2 border border-[rgba(201,169,97,0.15)] rounded-lg focus:outline-none focus:ring-2 focus:ring-[#c9a961]"
+                  >
+                    <option value="coingecko">CoinGecko</option>
+                  </select>
+                  <p className="text-xs text-[#696557] dark:text-[#b8b3ac] mt-1">
+                    Select the provider for cryptocurrency price data.
+                  </p>
+                </div>
+                <div>
+                  <label
+                    htmlFor="price-feed-base-url"
+                    className="block text-sm font-medium text-[#1a1815] dark:text-[#b8b3ac] mb-2"
+                  >
+                    Custom Base URL (optional)
+                  </label>
+                  <input
+                    id="price-feed-base-url"
+                    type="text"
+                    value={localSettings.priceFeedBaseUrl || ''}
+                    onChange={handleBaseUrlChange}
+                    placeholder="e.g. https://pro-api.coingecko.com/api/v3"
+                    className="w-full px-3 py-2 border border-[rgba(201,169,97,0.15)] rounded-lg bg-[#fafaf8] dark:bg-[#1a1815] text-[#1a1815] dark:text-[#f5f3f0] focus:outline-none focus:ring-2 focus:ring-[#c9a961]"
+                  />
+                  <p className="text-xs text-[#696557] dark:text-[#b8b3ac] mt-1">
+                    Override the API endpoint for self-hosted or compatible oracles.
+                  </p>
+                </div>
+              </div>
+            </div>
 
             {showApiKeys && (
               <div className="space-y-4">

--- a/src/app/settings/Currencies.tsx
+++ b/src/app/settings/Currencies.tsx
@@ -156,7 +156,9 @@ const Currencies: React.FC = () => {
       }
     }
     load()
-    return () => { cancelled = true }
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   const handleChange = useCallback(
@@ -767,7 +769,8 @@ const Currencies: React.FC = () => {
                     className="w-full px-3 py-2 border border-[rgba(201,169,97,0.15)] rounded-lg bg-[#fafaf8] dark:bg-[#1a1815] text-[#1a1815] dark:text-[#f5f3f0] focus:outline-none focus:ring-2 focus:ring-[#c9a961]"
                   />
                   <p className="text-xs text-[#696557] dark:text-[#b8b3ac] mt-1">
-                    Override the API endpoint for self-hosted or compatible oracles.
+                    Override the API endpoint for self-hosted or compatible
+                    oracles.
                   </p>
                 </div>
               </div>

--- a/src/services/__tests__/priceServiceConfig.test.ts
+++ b/src/services/__tests__/priceServiceConfig.test.ts
@@ -89,7 +89,11 @@ describe('priceService config read-through', () => {
       if (key === 'price_feed_base_url') return 'https://pro.example.com/v3'
       return null
     })
-    mockInvoke.mockResolvedValue({ coin_id: 'polkadot', price: '7.50', currency: 'usd' })
+    mockInvoke.mockResolvedValue({
+      coin_id: 'polkadot',
+      price: '7.50',
+      currency: 'usd',
+    })
 
     const price = await getCurrentPrice('polkadot', 'usd')
 
@@ -104,7 +108,11 @@ describe('priceService config read-through', () => {
 
   it('getCurrentPrice omits apiKey/baseUrl when settings are empty', async () => {
     mockGetSetting.mockResolvedValue(null)
-    mockInvoke.mockResolvedValue({ coin_id: 'polkadot', price: '6.25', currency: 'usd' })
+    mockInvoke.mockResolvedValue({
+      coin_id: 'polkadot',
+      price: '6.25',
+      currency: 'usd',
+    })
 
     await getCurrentPrice('polkadot', 'usd')
 

--- a/src/services/__tests__/priceServiceConfig.test.ts
+++ b/src/services/__tests__/priceServiceConfig.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock persistence before importing priceService
+vi.mock('../persistence', () => ({
+  persistence: {
+    getSetting: vi.fn(),
+    setSetting: vi.fn(),
+    deleteSetting: vi.fn(),
+  },
+}))
+
+// Mock Tauri invoke — not available in test
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+// Mock the Tauri availability check — default to true so invoke paths run
+vi.mock('../../utils/tauri', () => ({
+  isTauriAvailable: vi.fn(() => true),
+  warnIfNotTauri: vi.fn(),
+}))
+
+import { persistence } from '../persistence'
+import { invoke } from '@tauri-apps/api/core'
+import {
+  loadPriceFeedConfig,
+  clearPriceFeedConfigCache,
+  getCurrentPrice,
+} from '../blockchain/priceService'
+
+const mockGetSetting = vi.mocked(persistence.getSetting)
+const mockInvoke = vi.mocked(invoke)
+
+describe('priceService config read-through', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearPriceFeedConfigCache()
+  })
+
+  it('loadPriceFeedConfig reads api_key and base_url from persistence', async () => {
+    mockGetSetting.mockImplementation(async (key: string) => {
+      if (key === 'price_feed_api_key') return 'test-api-key-123'
+      if (key === 'price_feed_base_url')
+        return 'https://custom.coingecko.example/api/v3'
+      return null
+    })
+
+    const config = await loadPriceFeedConfig()
+
+    expect(mockGetSetting).toHaveBeenCalledWith('price_feed_api_key')
+    expect(mockGetSetting).toHaveBeenCalledWith('price_feed_base_url')
+    expect(config.apiKey).toBe('test-api-key-123')
+    expect(config.baseUrl).toBe('https://custom.coingecko.example/api/v3')
+  })
+
+  it('loadPriceFeedConfig returns nulls when no settings stored', async () => {
+    mockGetSetting.mockResolvedValue(null)
+
+    const config = await loadPriceFeedConfig()
+
+    expect(config.apiKey).toBeNull()
+    expect(config.baseUrl).toBeNull()
+  })
+
+  it('loadPriceFeedConfig caches results for subsequent calls', async () => {
+    mockGetSetting.mockResolvedValue(null)
+
+    await loadPriceFeedConfig()
+    await loadPriceFeedConfig()
+
+    // getSetting should only be called once (2 keys) due to caching
+    expect(mockGetSetting).toHaveBeenCalledTimes(2)
+  })
+
+  it('clearPriceFeedConfigCache forces a re-read on next call', async () => {
+    mockGetSetting.mockResolvedValue(null)
+
+    await loadPriceFeedConfig()
+    clearPriceFeedConfigCache()
+    await loadPriceFeedConfig()
+
+    // 2 keys per call * 2 calls = 4
+    expect(mockGetSetting).toHaveBeenCalledTimes(4)
+  })
+
+  it('getCurrentPrice passes configured apiKey and baseUrl to invoke', async () => {
+    mockGetSetting.mockImplementation(async (key: string) => {
+      if (key === 'price_feed_api_key') return 'my-pro-key'
+      if (key === 'price_feed_base_url') return 'https://pro.example.com/v3'
+      return null
+    })
+    mockInvoke.mockResolvedValue({ coin_id: 'polkadot', price: '7.50', currency: 'usd' })
+
+    const price = await getCurrentPrice('polkadot', 'usd')
+
+    expect(price).toBe(7.5)
+    expect(mockInvoke).toHaveBeenCalledWith('get_crypto_price', {
+      coinId: 'polkadot',
+      vsCurrency: 'usd',
+      apiKey: 'my-pro-key',
+      baseUrl: 'https://pro.example.com/v3',
+    })
+  })
+
+  it('getCurrentPrice omits apiKey/baseUrl when settings are empty', async () => {
+    mockGetSetting.mockResolvedValue(null)
+    mockInvoke.mockResolvedValue({ coin_id: 'polkadot', price: '6.25', currency: 'usd' })
+
+    await getCurrentPrice('polkadot', 'usd')
+
+    expect(mockInvoke).toHaveBeenCalledWith('get_crypto_price', {
+      coinId: 'polkadot',
+      vsCurrency: 'usd',
+      apiKey: undefined,
+      baseUrl: undefined,
+    })
+  })
+
+  it('loadPriceFeedConfig handles persistence failure gracefully', async () => {
+    mockGetSetting.mockRejectedValue(new Error('DB unavailable'))
+
+    const config = await loadPriceFeedConfig()
+
+    expect(config.apiKey).toBeNull()
+    expect(config.baseUrl).toBeNull()
+  })
+})

--- a/src/services/blockchain/priceService.ts
+++ b/src/services/blockchain/priceService.ts
@@ -7,6 +7,7 @@
 
 import { invoke } from '@tauri-apps/api/core'
 import { isTauriAvailable } from '../../utils/tauri'
+import { persistence } from '../persistence'
 
 /** Response from single price lookup */
 export interface PriceResponse {
@@ -79,6 +80,49 @@ const NETWORK_NATIVE_TOKENS: Record<string, string> = {
   solana: 'solana',
 }
 
+/** Cached price feed settings to avoid reading persistence on every call */
+let cachedPriceFeedConfig: {
+  apiKey: string | null
+  baseUrl: string | null
+  loadedAt: number
+} | null = null
+
+const SETTINGS_CACHE_TTL_MS = 60_000 // re-read settings every 60s
+
+/**
+ * Load price-feed configuration from persistence (API key + base URL).
+ * Results are cached for 60 seconds.
+ */
+export async function loadPriceFeedConfig(): Promise<{
+  apiKey: string | null
+  baseUrl: string | null
+}> {
+  const now = Date.now()
+  if (
+    cachedPriceFeedConfig &&
+    now - cachedPriceFeedConfig.loadedAt < SETTINGS_CACHE_TTL_MS
+  ) {
+    return cachedPriceFeedConfig
+  }
+
+  try {
+    const [apiKey, baseUrl] = await Promise.all([
+      persistence.getSetting('price_feed_api_key'),
+      persistence.getSetting('price_feed_base_url'),
+    ])
+    cachedPriceFeedConfig = { apiKey, baseUrl, loadedAt: now }
+    return { apiKey, baseUrl }
+  } catch {
+    // If persistence fails (e.g. first run), fall back to no overrides
+    return { apiKey: null, baseUrl: null }
+  }
+}
+
+/** Clear the cached price-feed config (e.g. after settings save) */
+export function clearPriceFeedConfigCache(): void {
+  cachedPriceFeedConfig = null
+}
+
 /**
  * Get CoinGecko ID for a token symbol
  */
@@ -119,9 +163,12 @@ export async function getCurrentPrice(
   }
 
   try {
+    const config = await loadPriceFeedConfig()
     const response = await invoke<PriceResponse>('get_crypto_price', {
       coinId,
       vsCurrency,
+      apiKey: config.apiKey ?? undefined,
+      baseUrl: config.baseUrl ?? undefined,
     })
     return parseFloat(response.price)
   } catch (error) {
@@ -143,9 +190,12 @@ export async function getCurrentPrices(
   }
 
   try {
+    const config = await loadPriceFeedConfig()
     const response = await invoke<Record<string, string>>('get_crypto_prices', {
       coinIds,
       vsCurrency,
+      apiKey: config.apiKey ?? undefined,
+      baseUrl: config.baseUrl ?? undefined,
     })
     const result: Record<string, number> = {}
     for (const [coinId, price] of Object.entries(response)) {
@@ -175,12 +225,15 @@ export async function getHistoricalPrice(
 
   try {
     const dateStr = toCoinGeckoDate(date)
+    const config = await loadPriceFeedConfig()
     const response = await invoke<HistoricalPriceResponse>(
       'get_historical_crypto_price',
       {
         coinId,
         date: dateStr,
         vsCurrency,
+        apiKey: config.apiKey ?? undefined,
+        baseUrl: config.baseUrl ?? undefined,
       }
     )
     return parseFloat(response.price)
@@ -211,12 +264,15 @@ export async function getBatchHistoricalPrices(
 
   try {
     const dateStr = toCoinGeckoDate(date)
+    const config = await loadPriceFeedConfig()
     const response = await invoke<BatchHistoricalPriceResponse>(
       'get_batch_historical_prices',
       {
         coinIds,
         date: dateStr,
         vsCurrency,
+        apiKey: config.apiKey ?? undefined,
+        baseUrl: config.baseUrl ?? undefined,
       }
     )
 
@@ -343,4 +399,6 @@ export const priceService = {
   getBatchHistoricalPrices,
   calculateUsdValue,
   batchCalculateUsdValues,
+  loadPriceFeedConfig,
+  clearPriceFeedConfigCache,
 }


### PR DESCRIPTION
## Summary

- **Persist CoinGecko API key** in `Currencies.tsx`: no longer dropped on save; stored via `persistence.setSetting('price_feed_api_key', …)` and loaded on mount.
- **Add configurable source settings**: `price_feed_provider` (default `coingecko`), `price_feed_base_url` (optional override for self-hosted oracles) — surfaced in the Currencies settings page.
- **Wire priceService → Tauri → Rust**: `priceService.ts` reads settings (cached 60 s), passes `apiKey`/`baseUrl` through to all 4 price Tauri commands. Rust `prices.rs` uses passed values with env-var fallback. `CoinGeckoClient::with_base_url()` supports custom endpoints.

## Files changed

| File | Change |
|------|--------|
| `src/app/settings/Currencies.tsx` | Persist API key + provider/base_url; load on mount; UI fields |
| `src/services/blockchain/priceService.ts` | `loadPriceFeedConfig()` + pass config to all invokes |
| `src-tauri/src/api/prices.rs` | Accept optional `api_key`/`base_url` params, env fallback |
| `src-tauri/src/api/price_feeds/coingecko.rs` | `with_base_url()` constructor |
| `src/services/__tests__/priceServiceConfig.test.ts` | 7 unit tests for settings read-through |

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint` on touched files — clean
- `cargo check` + `cargo fmt --check` — clean
- New tests: 7/7 pass
- Existing tests: `costBasisService` (72), `polkadotService`, `CostBasisReport` — all green

## Test plan

- [ ] Verify API key persists across page reload in Currencies settings
- [ ] Verify `price_feed_base_url` override reaches Rust (logs or custom endpoint)
- [ ] Confirm existing sync price enrichment still works (env-var fallback)
- [ ] Run full CI


🤖 Generated with [Claude Code](https://claude.com/claude-code)