### PR TITLE
Fix TS2339 by declaring __TAURI__ on Window type

### DIFF
--- a/src/types/tauri.d.ts
+++ b/src/types/tauri.d.ts
@@ -1,0 +1,7 @@
+declare global {
+  interface Window {
+    __TAURI__?: unknown
+  }
+}
+
+export {}


### PR DESCRIPTION
Add a global type declaration for the optional __TAURI__ property on Window so isTauri() in src/utils/env.ts type-checks correctly.