### PR TITLE
fix(ui): resolve residual JS-0415 nesting in UserRow and RoleCard (GIV-582)

### DIFF
--- a/src/app/settings/UsersPermissions.tsx
+++ b/src/app/settings/UsersPermissions.tsx
@@ -253,6 +253,20 @@ const InviteUserModal: React.FC<{
   </div>
 )
 
+/** Circular avatar showing the user's initials */
+const UserAvatar: React.FC<{ name: string }> = ({ name }) => (
+  <div className="w-10 h-10 rounded-full bg-[#294050]/10 dark:bg-[#294050]/20 flex items-center justify-center">
+    <span className="text-sm font-medium text-[#294050] dark:text-[#F09988]">
+      {name
+        .split(' ')
+        .map(n => n[0])
+        .join('')
+        .slice(0, 2)
+        .toUpperCase()}
+    </span>
+  </div>
+)
+
 /** Single row in the users table displaying user info, role, status, and actions */
 const UserRow: React.FC<UserRowProps> = ({
   user,
@@ -262,16 +276,7 @@ const UserRow: React.FC<UserRowProps> = ({
   <tr className="hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
     <td className="px-6 py-4 whitespace-nowrap">
       <div className="flex items-center">
-        <div className="w-10 h-10 rounded-full bg-[#294050]/10 dark:bg-[#294050]/20 flex items-center justify-center">
-          <span className="text-sm font-medium text-[#294050] dark:text-[#F09988]">
-            {user.name
-              .split(' ')
-              .map(n => n[0])
-              .join('')
-              .slice(0, 2)
-              .toUpperCase()}
-          </span>
-        </div>
+        <UserAvatar name={user.name} />
         <div className="ml-4">
           <div className="text-sm font-medium text-gray-900 dark:text-white">
             {user.name}
@@ -416,14 +421,19 @@ const UsersTable: React.FC<UsersTableProps> = ({
   </>
 )
 
+/** Rounded icon badge for a role card */
+const RoleIconBadge: React.FC = () => (
+  <div className="w-10 h-10 rounded-lg bg-[#294050]/10 dark:bg-[#294050]/20 flex items-center justify-center">
+    <Shield className="w-5 h-5 text-[#294050] dark:text-[#F09988]" />
+  </div>
+)
+
 /** Card displaying a single role with its description and assigned user count */
 const RoleCard: React.FC<RoleCardProps> = ({ role, userCount }) => (
   <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6 bg-white dark:bg-gray-900">
     <div className="flex items-start justify-between mb-4">
       <div className="flex items-center">
-        <div className="w-10 h-10 rounded-lg bg-[#294050]/10 dark:bg-[#294050]/20 flex items-center justify-center">
-          <Shield className="w-5 h-5 text-[#294050] dark:text-[#F09988]" />
-        </div>
+        <RoleIconBadge />
         <div className="ml-3">
           <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
             {role.name}


### PR DESCRIPTION
## Summary
- Extract `UserAvatar` from `UserRow` — moves the avatar circle+initials into its own component, reducing nesting from 5 to 3 levels
- Extract `RoleIconBadge` from `RoleCard` — moves the role shield icon into its own component, reducing nesting from 5 to 3 levels
- Follow-up to PR #202 which resolved the original 8 DeepSource issues; DeepSource re-scan flagged these 2 residual JS-0415 sites

## Test plan
- [x] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] CI: Build Frontend
- [ ] CI: Type Check
- [ ] CI: E2E tests (no behavioral change — pure extraction)
- [ ] DeepSource re-scan confirms no remaining JS-0415 in this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)