### PR TITLE
fix(GIV-586): guard balance invoke calls with isTauriAvailable check

### DIFF
--- a/src/api/chains.ts
+++ b/src/api/chains.ts
@@ -6,6 +6,7 @@
  */
 
 import { invoke } from '@tauri-apps/api/core'
+import { isTauriAvailable } from '../utils/tauri'
 import type {
   ChainInfo,
   ChainTransaction,
@@ -77,6 +78,9 @@ export async function fetchBalances(
   chainId: string,
   address: string
 ): Promise<WalletBalances> {
+  if (!isTauriAvailable()) {
+    throw new Error('Balance fetching requires the desktop app')
+  }
   return invoke<WalletBalances>('chain_fetch_balances', { chainId, address })
 }
 
@@ -103,6 +107,9 @@ export async function fetchTransaction(
 export async function fetchAllBalances(
   addresses: WalletAddress[]
 ): Promise<WalletBalances[]> {
+  if (!isTauriAvailable()) {
+    return []
+  }
   const pairs: [string, string][] = addresses.map(w => [w.chainId, w.address])
   return invoke<WalletBalances[]>('chain_fetch_all_balances', {
     addresses: pairs,

--- a/src/api/chains.ts
+++ b/src/api/chains.ts
@@ -19,7 +19,7 @@ import type {
  *
  * @returns List of supported chains with their configuration
  */
-export async function getSupportedChains(): Promise<ChainInfo[]> {
+export function getSupportedChains(): Promise<ChainInfo[]> {
   return invoke<ChainInfo[]>('chain_get_supported_chains')
 }
 
@@ -29,7 +29,7 @@ export async function getSupportedChains(): Promise<ChainInfo[]> {
  * @param chainId - Chain identifier (name or numeric ID)
  * @returns True if the chain is supported
  */
-export async function isChainSupported(chainId: string): Promise<boolean> {
+export function isChainSupported(chainId: string): Promise<boolean> {
   return invoke<boolean>('chain_is_supported', { chainId })
 }
 
@@ -40,7 +40,7 @@ export async function isChainSupported(chainId: string): Promise<boolean> {
  * @param address - Address to validate
  * @returns True if the address is valid for the chain
  */
-export async function validateAddress(
+export function validateAddress(
   chainId: string,
   address: string
 ): Promise<boolean> {
@@ -55,7 +55,7 @@ export async function validateAddress(
  * @param fromBlock - Optional starting block number
  * @returns List of transactions
  */
-export async function fetchTransactions(
+export function fetchTransactions(
   chainId: string,
   address: string,
   fromBlock?: number
@@ -74,12 +74,14 @@ export async function fetchTransactions(
  * @param address - Wallet address
  * @returns Wallet balances including native and token balances
  */
-export async function fetchBalances(
+export function fetchBalances(
   chainId: string,
   address: string
 ): Promise<WalletBalances> {
   if (!isTauriAvailable()) {
-    throw new Error('Balance fetching requires the desktop app')
+    return Promise.reject(
+      new Error('Balance fetching requires the desktop app')
+    )
   }
   return invoke<WalletBalances>('chain_fetch_balances', { chainId, address })
 }
@@ -91,7 +93,7 @@ export async function fetchBalances(
  * @param hash - Transaction hash
  * @returns Transaction details
  */
-export async function fetchTransaction(
+export function fetchTransaction(
   chainId: string,
   hash: string
 ): Promise<ChainTransaction> {
@@ -104,11 +106,11 @@ export async function fetchTransaction(
  * @param addresses - List of chain/address pairs
  * @returns List of wallet balances
  */
-export async function fetchAllBalances(
+export function fetchAllBalances(
   addresses: WalletAddress[]
 ): Promise<WalletBalances[]> {
   if (!isTauriAvailable()) {
-    return []
+    return Promise.resolve([])
   }
   const pairs: [string, string][] = addresses.map(w => [w.chainId, w.address])
   return invoke<WalletBalances[]>('chain_fetch_all_balances', {
@@ -124,7 +126,7 @@ export async function fetchAllBalances(
  * @param fromBlock - Optional starting block number
  * @returns Combined list of transactions sorted by timestamp
  */
-export async function fetchAllTransactions(
+export function fetchAllTransactions(
   address: string,
   chainIds: string[],
   fromBlock?: number
@@ -142,7 +144,7 @@ export async function fetchAllTransactions(
  * @param chainId - Chain identifier
  * @returns Connection status message
  */
-export async function connectChain(chainId: string): Promise<string> {
+export function connectChain(chainId: string): Promise<string> {
   return invoke<string>('chain_connect', { chainId })
 }
 
@@ -178,6 +180,6 @@ export async function setRpcUrl(
  * @param chainId - Chain identifier
  * @returns Current block number
  */
-export async function getBlockNumber(chainId: string): Promise<number> {
+export function getBlockNumber(chainId: string): Promise<number> {
   return invoke<number>('chain_get_block_number', { chainId })
 }


### PR DESCRIPTION
## Summary
- `fetchAllBalances` now returns `[]` when Tauri is not available (web/browser context), showing an empty balances state instead of crashing
- `fetchBalances` now throws `'Balance fetching requires the desktop app'` instead of the cryptic Tauri error
- Follows the same `isTauriAvailable()` guard pattern already used in `priceService.ts` and `persistence/index.ts`

**Root cause:** `src/api/chains.ts` called `invoke()` directly without checking `window.__TAURI_INTERNALS__`, causing an unhandled error on the `/wallet` page in the web build.

## Test plan
- [ ] Open `/wallet` page in the web build — should show empty balances, no error toast
- [ ] Open `/wallet` page in the Tauri desktop app — balances load as before
- [ ] TypeScript check: no new errors introduced (`chains.ts` clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)