### PR TITLE
fix: add explicit GITHUB_TOKEN permissions to CI workflow (GIV-595)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -256,6 +259,9 @@ jobs:
   security:
     name: Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Fixes CodeQL code-scanning alert [#51](https://github.com/GiveProtocolFoundation/Pacioli/security/code-scanning/51) — `actions/missing-workflow-permissions` (CWE-275, medium severity).

**Root cause:** No `permissions` block in `ci.yml` meant all jobs inherited the repository default, which can be read-write — violating least-privilege.

**Changes:**
- Added top-level `permissions: contents: read` — restricts the `GITHUB_TOKEN` to read-only across all jobs (`lint`, `type-check`, `build-frontend`, `build-rust`, `e2e`)
- Added job-level override on `security`: `contents: read` + `security-events: write` — the extra scope is required by `gitleaks/gitleaks-action@v2` to upload SARIF results to GitHub Advanced Security

**No functional change** to any build/test/lint/security step — only the `GITHUB_TOKEN` scope is narrowed.

## Test plan

- [ ] CI passes (no jobs need write to `contents`; artifacts still upload via `actions/upload-artifact` which uses its own auth)
- [ ] `Security Scan` job / Gitleaks still succeeds (has `security-events: write`)
- [ ] CodeQL alert #51 should auto-close on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)