### PR TITLE
fix: clippy 1.97 useless_borrows_in_formatting (unblocks CI)

### DIFF
--- a/src-tauri/src/api/accounting.rs
+++ b/src-tauri/src/api/accounting.rs
@@ -474,7 +474,7 @@ pub async fn create_journal_entry(
     let entry_date = NaiveDateTime::parse_from_str(&input.entry_date, "%Y-%m-%dT%H:%M:%S")
         .or_else(|_| {
             NaiveDateTime::parse_from_str(
-                &format!("{}T00:00:00", &input.entry_date),
+                &format!("{}T00:00:00", input.entry_date),
                 "%Y-%m-%dT%H:%M:%S",
             )
         })

--- a/src-tauri/src/api/auth.rs
+++ b/src-tauri/src/api/auth.rs
@@ -410,7 +410,7 @@ pub async fn register(
         "#,
     )
     .bind(&profile_id)
-    .bind(format!("{}'s Workspace", &input.display_name))
+    .bind(format!("{}'s Workspace", input.display_name))
     .bind(now)
     .bind(now)
     .execute(pool)

--- a/src-tauri/src/api/wallet_auth.rs
+++ b/src-tauri/src/api/wallet_auth.rs
@@ -434,7 +434,7 @@ pub async fn link_wallet_to_account(
         "success",
         Some(&format!(
             "Linked {} wallet: {}",
-            wallet_type, &request.wallet_address
+            wallet_type, request.wallet_address
         )),
     )
     .await;


### PR DESCRIPTION
## Summary
- CI runner's clippy updated to 1.97.0, adding `useless_borrows_in_formatting`; with `-D warnings` the `Build Rust Backend` job now fails on any fresh run (first surfaced on PR #205, which only touches ci.yml)
- Removes the 3 redundant `&` in `format!` args: `api/accounting.rs:477`, `api/auth.rs:413`, `api/wallet_auth.rs:437`
- Zero behavior change; local `cargo check` + `cargo fmt --check` clean

## Test plan
- [ ] Build Rust Backend job green on this PR (authoritative — runner has clippy 1.97)

🤖 Generated with [Claude Code](https://claude.com/claude-code)