### PR TITLE
feat(accounting): enforce journal-entry balance invariant at SQLite data layer (GIV-665)

### DIFF
--- a/src-tauri/migrations/20260714000001_enforce_journal_balance.sql
+++ b/src-tauri/migrations/20260714000001_enforce_journal_balance.sql
@@ -1,0 +1,80 @@
+-- =============================================================================
+-- ENFORCE JOURNAL-ENTRY BALANCE INVARIANT AT THE DATA LAYER (GIV-665)
+--
+-- Closes three verified holes in the journal-entry lifecycle:
+--   1. Born-posted entries bypass balance validation (DEFAULT 1 + no INSERT trigger)
+--   2. Lines of a posted entry can be mutated, silently unbalancing the ledger
+--   3. Zero-line entries post successfully (NULL > 0.01 is false in SQLite)
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Prevent born-posted entries
+--    Lines cannot exist before the header row, so a born-posted entry can
+--    never have been balance-checked.
+-- ---------------------------------------------------------------------------
+CREATE TRIGGER IF NOT EXISTS journal_entries_no_born_posted
+BEFORE INSERT ON journal_entries
+WHEN NEW.is_posted = 1
+BEGIN
+    SELECT RAISE(ABORT, 'Journal entries must be created as drafts and posted after balance validation');
+END;
+
+-- ---------------------------------------------------------------------------
+-- 2. Posted-entry line immutability
+--    Once posted, lines are frozen.  To correct: void the entry, create a
+--    new correcting entry.
+-- ---------------------------------------------------------------------------
+
+-- 2a. Block INSERT of a line onto a posted entry
+CREATE TRIGGER IF NOT EXISTS journal_entry_lines_no_insert_posted
+BEFORE INSERT ON journal_entry_lines
+WHEN (SELECT is_posted FROM journal_entries WHERE id = NEW.journal_entry_id) = 1
+BEGIN
+    SELECT RAISE(ABORT, 'Lines of a posted journal entry are immutable; void the entry and create a correcting entry');
+END;
+
+-- 2b. Block UPDATE of a line on a posted entry (also blocks re-pointing onto a posted entry)
+CREATE TRIGGER IF NOT EXISTS journal_entry_lines_no_update_posted
+BEFORE UPDATE ON journal_entry_lines
+WHEN (SELECT is_posted FROM journal_entries WHERE id = OLD.journal_entry_id) = 1
+  OR (SELECT is_posted FROM journal_entries WHERE id = NEW.journal_entry_id) = 1
+BEGIN
+    SELECT RAISE(ABORT, 'Lines of a posted journal entry are immutable; void the entry and create a correcting entry');
+END;
+
+-- 2c. Block DELETE of a line from a posted entry
+CREATE TRIGGER IF NOT EXISTS journal_entry_lines_no_delete_posted
+BEFORE DELETE ON journal_entry_lines
+WHEN (SELECT is_posted FROM journal_entries WHERE id = OLD.journal_entry_id) = 1
+BEGIN
+    SELECT RAISE(ABORT, 'Lines of a posted journal entry are immutable; void the entry and create a correcting entry');
+END;
+
+-- ---------------------------------------------------------------------------
+-- 3. Replace the posting balance trigger
+--    Closes the NULL hole (zero lines) and requires at least 2 lines.
+-- ---------------------------------------------------------------------------
+DROP TRIGGER IF EXISTS validate_journal_entry_balance;
+
+CREATE TRIGGER validate_journal_entry_balance
+BEFORE UPDATE OF is_posted ON journal_entries
+WHEN NEW.is_posted = 1 AND OLD.is_posted = 0
+BEGIN
+    SELECT CASE
+        WHEN (
+            SELECT COUNT(*)
+            FROM journal_entry_lines
+            WHERE journal_entry_id = NEW.id
+        ) < 2
+        THEN RAISE(ABORT, 'Journal entry must have at least 2 lines (debit and credit)')
+    END;
+    SELECT CASE
+        WHEN COALESCE(
+            (SELECT ABS(SUM(debit_amount) - SUM(credit_amount))
+             FROM journal_entry_lines
+             WHERE journal_entry_id = NEW.id),
+            1e18
+        ) > 0.01
+        THEN RAISE(ABORT, 'Journal entry debits must equal credits')
+    END;
+END;

--- a/src-tauri/src/api/accounting.rs
+++ b/src-tauri/src/api/accounting.rs
@@ -559,13 +559,12 @@ pub async fn post_journal_entry(
     }
 
     // Friendly line-count check (DB trigger is the authority, this gives a better message)
-    let line_count: (i64,) = sqlx::query_as(
-        "SELECT COUNT(*) FROM journal_entry_lines WHERE journal_entry_id = ?",
-    )
-    .bind(id)
-    .fetch_one(&state.pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let line_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM journal_entry_lines WHERE journal_entry_id = ?")
+            .bind(id)
+            .fetch_one(&state.pool)
+            .await
+            .map_err(|e| e.to_string())?;
 
     if line_count.0 == 0 {
         return Err("Cannot post: entry has no lines".to_string());
@@ -940,7 +939,13 @@ mod tests {
     }
 
     /// Adds a balanced pair of lines (debit + credit) to the given entry.
-    async fn add_balanced_lines(pool: &SqlitePool, entry_id: i64, debit_acct: i64, credit_acct: i64, amount: f64) {
+    async fn add_balanced_lines(
+        pool: &SqlitePool,
+        entry_id: i64,
+        debit_acct: i64,
+        credit_acct: i64,
+        amount: f64,
+    ) {
         sqlx::query(
             "INSERT INTO journal_entry_lines (journal_entry_id, gl_account_id, debit_amount, credit_amount, line_number) VALUES (?, ?, ?, 0, 1)",
         )
@@ -1007,7 +1012,10 @@ mod tests {
         .execute(&pool)
         .await;
 
-        assert!(result.is_err(), "INSERT line on posted entry should be rejected");
+        assert!(
+            result.is_err(),
+            "INSERT line on posted entry should be rejected"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("immutable"),
@@ -1036,7 +1044,10 @@ mod tests {
         .execute(&pool)
         .await;
 
-        assert!(result.is_err(), "UPDATE line on posted entry should be rejected");
+        assert!(
+            result.is_err(),
+            "UPDATE line on posted entry should be rejected"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("immutable"),
@@ -1065,7 +1076,10 @@ mod tests {
         .execute(&pool)
         .await;
 
-        assert!(result.is_err(), "DELETE line on posted entry should be rejected");
+        assert!(
+            result.is_err(),
+            "DELETE line on posted entry should be rejected"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("immutable"),
@@ -1125,7 +1139,10 @@ mod tests {
             .execute(&pool)
             .await;
 
-        assert!(result.is_err(), "Posting zero-line entry should be rejected");
+        assert!(
+            result.is_err(),
+            "Posting zero-line entry should be rejected"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("at least 2 lines"),
@@ -1165,7 +1182,10 @@ mod tests {
             .execute(&pool)
             .await;
 
-        assert!(result.is_err(), "Posting unbalanced entry should be rejected");
+        assert!(
+            result.is_err(),
+            "Posting unbalanced entry should be rejected"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("debits must equal credits"),
@@ -1249,7 +1269,10 @@ mod tests {
             .execute(&pool)
             .await;
 
-        assert!(result.is_err(), "Posting single-line entry should be rejected");
+        assert!(
+            result.is_err(),
+            "Posting single-line entry should be rejected"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("at least 2 lines"),
@@ -1300,7 +1323,10 @@ mod tests {
         .execute(&pool)
         .await;
 
-        assert!(result.is_err(), "Re-pointing line onto posted entry should be rejected");
+        assert!(
+            result.is_err(),
+            "Re-pointing line onto posted entry should be rejected"
+        );
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("immutable"),

--- a/src-tauri/src/api/accounting.rs
+++ b/src-tauri/src/api/accounting.rs
@@ -558,9 +558,25 @@ pub async fn post_journal_entry(
         return Err("Cannot post a reversed entry".to_string());
     }
 
+    // Friendly line-count check (DB trigger is the authority, this gives a better message)
+    let line_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM journal_entry_lines WHERE journal_entry_id = ?",
+    )
+    .bind(id)
+    .fetch_one(&state.pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    if line_count.0 == 0 {
+        return Err("Cannot post: entry has no lines".to_string());
+    }
+    if line_count.0 < 2 {
+        return Err("Cannot post: entry needs at least 2 lines (debit and credit)".to_string());
+    }
+
     // Validate balance before posting (the DB trigger also enforces this)
     let balance: (f64,) = sqlx::query_as(
-        "SELECT ABS(SUM(debit_amount) - SUM(credit_amount)) FROM journal_entry_lines WHERE journal_entry_id = ?",
+        "SELECT ABS(COALESCE(SUM(debit_amount) - SUM(credit_amount), 1e18)) FROM journal_entry_lines WHERE journal_entry_id = ?",
     )
     .bind(id)
     .fetch_one(&state.pool)
@@ -870,4 +886,425 @@ pub async fn get_draft_journal_entry_count(state: State<'_, DatabaseState>) -> R
     .map_err(|e| e.to_string())?;
 
     Ok(row.0)
+}
+
+// ============================================================================
+// Tests — Journal-Entry Balance Invariant (GIV-665)
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use sqlx::sqlite::SqlitePoolOptions;
+    use sqlx::SqlitePool;
+
+    /// Creates an in-memory SQLite pool with all migrations applied.
+    async fn setup_test_db() -> SqlitePool {
+        let pool = SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .expect("Failed to create in-memory SQLite pool");
+
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+
+        pool
+    }
+
+    /// Returns two GL account IDs from the seed data (1000=Cash, 4000=Income).
+    async fn get_test_accounts(pool: &SqlitePool) -> (i64, i64) {
+        let (acct_a,): (i64,) =
+            sqlx::query_as("SELECT id FROM gl_accounts WHERE account_number = '1000'")
+                .fetch_one(pool)
+                .await
+                .expect("Seed account 1000 should exist");
+        let (acct_b,): (i64,) =
+            sqlx::query_as("SELECT id FROM gl_accounts WHERE account_number = '4000'")
+                .fetch_one(pool)
+                .await
+                .expect("Seed account 4000 should exist");
+        (acct_a, acct_b)
+    }
+
+    /// Creates a draft journal entry and returns its id.
+    async fn create_draft_entry(pool: &SqlitePool) -> i64 {
+        let result = sqlx::query(
+            "INSERT INTO journal_entries (entry_date, entry_number, description, is_posted, created_by) VALUES ('2026-01-01', 'TEST-001', 'Test entry', 0, 'test')",
+        )
+        .execute(pool)
+        .await
+        .expect("Failed to create draft entry");
+
+        result.last_insert_rowid()
+    }
+
+    /// Adds a balanced pair of lines (debit + credit) to the given entry.
+    async fn add_balanced_lines(pool: &SqlitePool, entry_id: i64, debit_acct: i64, credit_acct: i64, amount: f64) {
+        sqlx::query(
+            "INSERT INTO journal_entry_lines (journal_entry_id, gl_account_id, debit_amount, credit_amount, line_number) VALUES (?, ?, ?, 0, 1)",
+        )
+        .bind(entry_id)
+        .bind(debit_acct)
+        .bind(amount)
+        .execute(pool)
+        .await
+        .expect("Failed to add debit line");
+
+        sqlx::query(
+            "INSERT INTO journal_entry_lines (journal_entry_id, gl_account_id, debit_amount, credit_amount, line_number) VALUES (?, ?, 0, ?, 2)",
+        )
+        .bind(entry_id)
+        .bind(credit_acct)
+        .bind(amount)
+        .execute(pool)
+        .await
+        .expect("Failed to add credit line");
+    }
+
+    // ---- Born-posted INSERT rejected ----
+
+    #[tokio::test]
+    async fn born_posted_insert_rejected() {
+        let pool = setup_test_db().await;
+
+        let result = sqlx::query(
+            "INSERT INTO journal_entries (entry_date, entry_number, description, is_posted, created_by) VALUES ('2026-01-01', 'BP-001', 'Born posted', 1, 'test')",
+        )
+        .execute(&pool)
+        .await;
+
+        assert!(result.is_err(), "Born-posted INSERT should be rejected");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("must be created as drafts"),
+            "Error should mention drafts, got: {err}"
+        );
+    }
+
+    // ---- Line immutability on posted entries ----
+
+    #[tokio::test]
+    async fn insert_line_on_posted_entry_rejected() {
+        let pool = setup_test_db().await;
+        let (acct_a, acct_b) = get_test_accounts(&pool).await;
+        let entry_id = create_draft_entry(&pool).await;
+        add_balanced_lines(&pool, entry_id, acct_a, acct_b, 100.0).await;
+
+        // Post it
+        sqlx::query("UPDATE journal_entries SET is_posted = 1 WHERE id = ?")
+            .bind(entry_id)
+            .execute(&pool)
+            .await
+            .expect("Posting balanced entry should succeed");
+
+        // Try to insert a new line
+        let result = sqlx::query(
+            "INSERT INTO journal_entry_lines (journal_entry_id, gl_account_id, debit_amount, credit_amount, line_number) VALUES (?, ?, 50, 0, 3)",
+        )
+        .bind(entry_id)
+        .bind(acct_a)
+        .execute(&pool)
+        .await;
+
+        assert!(result.is_err(), "INSERT line on posted entry should be rejected");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("immutable"),
+            "Error should mention immutability, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_line_on_posted_entry_rejected() {
+        let pool = setup_test_db().await;
+        let (acct_a, acct_b) = get_test_accounts(&pool).await;
+        let entry_id = create_draft_entry(&pool).await;
+        add_balanced_lines(&pool, entry_id, acct_a, acct_b, 100.0).await;
+
+        sqlx::query("UPDATE journal_entries SET is_posted = 1 WHERE id = ?")
+            .bind(entry_id)
+            .execute(&pool)
+            .await
+            .expect("Posting balanced entry should succeed");
+
+        // Try to update a line
+        let result = sqlx::query(
+            "UPDATE journal_entry_lines SET debit_amount = 200 WHERE journal_entry_id = ? AND line_number = 1",
+        )
+        .bind(entry_id)
+        .execute(&pool)
+        .await;
+
+        assert!(result.is_err(), "UPDATE line on posted entry should be rejected");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("immutable"),
+            "Error should mention immutability, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_line_on_posted_entry_rejected() {
+        let pool = setup_test_db().await;
+        let (acct_a, acct_b) = get_test_accounts(&pool).await;
+        let entry_id = create_draft_entry(&pool).await;
+        add_balanced_lines(&pool, entry_id, acct_a, acct_b, 100.0).await;
+
+        sqlx::query("UPDATE journal_entries SET is_posted = 1 WHERE id = ?")
+            .bind(entry_id)
+            .execute(&pool)
+            .await
+            .expect("Posting balanced entry should succeed");
+
+        // Try to delete a line
+        let result = sqlx::query(
+            "DELETE FROM journal_entry_lines WHERE journal_entry_id = ? AND line_number = 1",
+        )
+        .bind(entry_id)
+        .execute(&pool)
+        .await;
+
+        assert!(result.is_err(), "DELETE line on posted entry should be rejected");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("immutable"),
+            "Error should mention immutability, got: {err}"
+        );
+    }
+
+    // ---- Draft entry line ops still allowed ----
+
+    #[tokio::test]
+    async fn crud_lines_on_draft_entry_allowed() {
+        let pool = setup_test_db().await;
+        let (acct_a, acct_b) = get_test_accounts(&pool).await;
+        let entry_id = create_draft_entry(&pool).await;
+
+        // INSERT
+        sqlx::query(
+            "INSERT INTO journal_entry_lines (journal_entry_id, gl_account_id, debit_amount, credit_amount, line_number) VALUES (?, ?, 100, 0, 1)",
+        )
+        .bind(entry_id)
+        .bind(acct_a)
+        .execute(&pool)
+        .await
+        .expect("INSERT line on draft should succeed");
+
+        // UPDATE
+        sqlx::query(
+            "UPDATE journal_entry_lines SET debit_amount = 200 WHERE journal_entry_id = ? AND line_number = 1",
+        )
+        .bind(entry_id)
+        .execute(&pool)
+        .await
+        .expect("UPDATE line on draft should succeed");
+
+        // DELETE
+        sqlx::query(
+            "DELETE FROM journal_entry_lines WHERE journal_entry_id = ? AND line_number = 1",
+        )
+        .bind(entry_id)
+        .execute(&pool)
+        .await
+        .expect("DELETE line on draft should succeed");
+
+        // Re-add balanced lines for completeness
+        add_balanced_lines(&pool, entry_id, acct_a, acct_b, 50.0).await;
+    }
+
+    // ---- Zero-line entry post rejected ----
+
+    #[tokio::test]
+    async fn zero_line_entry_post_rejected() {
+        let pool = setup_test_db().await;
+        let entry_id = create_draft_entry(&pool).await;
+
+        let result = sqlx::query("UPDATE journal_entries SET is_posted = 1 WHERE id = ?")
+            .bind(entry_id)
+            .execute(&pool)
+            .await;
+
+        assert!(result.is_err(), "Posting zero-line entry should be rejected");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("at least 2 lines"),
+            "Error should mention minimum lines, got: {err}"
+        );
+    }
+
+    // ---- Unbalanced post rejected (direct SQL, proves trigger) ----
+
+    #[tokio::test]
+    async fn unbalanced_post_rejected_via_direct_sql() {
+        let pool = setup_test_db().await;
+        let (acct_a, acct_b) = get_test_accounts(&pool).await;
+        let entry_id = create_draft_entry(&pool).await;
+
+        // Add unbalanced lines: debit 100, credit 50
+        sqlx::query(
+            "INSERT INTO journal_entry_lines (journal_entry_id, gl_account_id, debit_amount, credit_amount, line_number) VALUES (?, ?, 100, 0, 1)",
+        )
+        .bind(entry_id)
+        .bind(acct_a)
+        .execute(&pool)
+        .await
+        .expect("Insert debit line");
+
+        sqlx::query(
+            "INSERT INTO journal_entry_lines (journal_entry_id, gl_account_id, debit_amount, credit_amount, line_number) VALUES (?, ?, 0, 50, 2)",
+        )
+        .bind(entry_id)
+        .bind(acct_b)
+        .execute(&pool)
+        .await
+        .expect("Insert credit line");
+
+        let result = sqlx::query("UPDATE journal_entries SET is_posted = 1 WHERE id = ?")
+            .bind(entry_id)
+            .execute(&pool)
+            .await;
+
+        assert!(result.is_err(), "Posting unbalanced entry should be rejected");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("debits must equal credits"),
+            "Error should mention balance, got: {err}"
+        );
+    }
+
+    // ---- Happy path: create draft -> balanced lines -> post -> void ----
+
+    #[tokio::test]
+    async fn happy_path_draft_post_void() {
+        let pool = setup_test_db().await;
+        let (acct_a, acct_b) = get_test_accounts(&pool).await;
+
+        // Create draft
+        let entry_id = create_draft_entry(&pool).await;
+
+        // Verify it's a draft
+        let (is_posted,): (bool,) =
+            sqlx::query_as("SELECT is_posted FROM journal_entries WHERE id = ?")
+                .bind(entry_id)
+                .fetch_one(&pool)
+                .await
+                .expect("Should fetch entry");
+        assert!(!is_posted, "Entry should start as draft");
+
+        // Add balanced lines
+        add_balanced_lines(&pool, entry_id, acct_a, acct_b, 100.0).await;
+
+        // Post
+        sqlx::query("UPDATE journal_entries SET is_posted = 1 WHERE id = ?")
+            .bind(entry_id)
+            .execute(&pool)
+            .await
+            .expect("Posting balanced entry should succeed");
+
+        let (is_posted,): (bool,) =
+            sqlx::query_as("SELECT is_posted FROM journal_entries WHERE id = ?")
+                .bind(entry_id)
+                .fetch_one(&pool)
+                .await
+                .expect("Should fetch entry");
+        assert!(is_posted, "Entry should be posted");
+
+        // Void
+        sqlx::query("UPDATE journal_entries SET is_reversed = 1 WHERE id = ?")
+            .bind(entry_id)
+            .execute(&pool)
+            .await
+            .expect("Voiding entry should succeed");
+
+        let (is_reversed,): (bool,) =
+            sqlx::query_as("SELECT is_reversed FROM journal_entries WHERE id = ?")
+                .bind(entry_id)
+                .fetch_one(&pool)
+                .await
+                .expect("Should fetch entry");
+        assert!(is_reversed, "Entry should be voided");
+    }
+
+    // ---- Single-line entry post rejected ----
+
+    #[tokio::test]
+    async fn single_line_entry_post_rejected() {
+        let pool = setup_test_db().await;
+        let (acct_a, _acct_b) = get_test_accounts(&pool).await;
+        let entry_id = create_draft_entry(&pool).await;
+
+        // Add only one line
+        sqlx::query(
+            "INSERT INTO journal_entry_lines (journal_entry_id, gl_account_id, debit_amount, credit_amount, line_number) VALUES (?, ?, 100, 0, 1)",
+        )
+        .bind(entry_id)
+        .bind(acct_a)
+        .execute(&pool)
+        .await
+        .expect("Insert single line");
+
+        let result = sqlx::query("UPDATE journal_entries SET is_posted = 1 WHERE id = ?")
+            .bind(entry_id)
+            .execute(&pool)
+            .await;
+
+        assert!(result.is_err(), "Posting single-line entry should be rejected");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("at least 2 lines"),
+            "Error should mention minimum lines, got: {err}"
+        );
+    }
+
+    // ---- Re-pointing a line onto a posted entry is blocked ----
+
+    #[tokio::test]
+    async fn repoint_line_onto_posted_entry_rejected() {
+        let pool = setup_test_db().await;
+        let (acct_a, acct_b) = get_test_accounts(&pool).await;
+
+        // Create and post entry A
+        let entry_a = create_draft_entry(&pool).await;
+        add_balanced_lines(&pool, entry_a, acct_a, acct_b, 100.0).await;
+        sqlx::query("UPDATE journal_entries SET is_posted = 1 WHERE id = ?")
+            .bind(entry_a)
+            .execute(&pool)
+            .await
+            .expect("Post entry A");
+
+        // Create draft entry B with a line
+        let result_b = sqlx::query(
+            "INSERT INTO journal_entries (entry_date, entry_number, description, is_posted, created_by) VALUES ('2026-01-02', 'TEST-002', 'Entry B', 0, 'test')",
+        )
+        .execute(&pool)
+        .await
+        .expect("Create entry B");
+        let entry_b = result_b.last_insert_rowid();
+
+        sqlx::query(
+            "INSERT INTO journal_entry_lines (journal_entry_id, gl_account_id, debit_amount, credit_amount, line_number) VALUES (?, ?, 50, 0, 1)",
+        )
+        .bind(entry_b)
+        .bind(acct_a)
+        .execute(&pool)
+        .await
+        .expect("Add line to draft entry B");
+
+        // Try to re-point entry B's line onto posted entry A
+        let result = sqlx::query(
+            "UPDATE journal_entry_lines SET journal_entry_id = ? WHERE journal_entry_id = ? AND line_number = 1",
+        )
+        .bind(entry_a)
+        .bind(entry_b)
+        .execute(&pool)
+        .await;
+
+        assert!(result.is_err(), "Re-pointing line onto posted entry should be rejected");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("immutable"),
+            "Error should mention immutability, got: {err}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Enforces the journal-entry balance invariant at the SQLite data layer, closing three verified holes (GIV-665):

- **Born-posted prevention**: `BEFORE INSERT` trigger on `journal_entries` rejects rows with `is_posted = 1` — entries must be created as drafts and posted after balance validation
- **Posted-entry line immutability**: `BEFORE INSERT/UPDATE/DELETE` triggers on `journal_entry_lines` prevent any mutation when the parent entry is posted (including re-pointing lines onto a posted entry)
- **Balance validation hardening**: Replaced `validate_journal_entry_balance` trigger to require ≥2 lines and close the NULL-sum hole via `COALESCE` (zero-line entries previously passed because `NULL > 0.01` evaluates to false in SQLite)

### Changes

- **New migration**: `src-tauri/migrations/20260714000001_enforce_journal_balance.sql` (append-only; existing migration files untouched)
- **Rust**: `post_journal_entry()` adds friendly line-count pre-check + `COALESCE` in the balance query  
- **Tests**: 10 new Rust tests using in-memory SQLite with `sqlx::migrate!`, all passing

### Test coverage

| Test | Validates |
|------|-----------|
| `born_posted_insert_rejected` | Trigger blocks `INSERT` with `is_posted = 1` |
| `insert_line_on_posted_entry_rejected` | Trigger blocks `INSERT` on `journal_entry_lines` for posted entry |
| `update_line_on_posted_entry_rejected` | Trigger blocks `UPDATE` on `journal_entry_lines` for posted entry |
| `delete_line_on_posted_entry_rejected` | Trigger blocks `DELETE` on `journal_entry_lines` for posted entry |
| `crud_lines_on_draft_entry_allowed` | INSERT/UPDATE/DELETE still work on draft entries |
| `zero_line_entry_post_rejected` | Posting with 0 lines now fails (was a bug) |
| `single_line_entry_post_rejected` | Posting with 1 line fails (need ≥2) |
| `unbalanced_post_rejected_via_direct_sql` | Direct `UPDATE SET is_posted=1` proves trigger enforcement |
| `happy_path_draft_post_void` | Full lifecycle: draft -> balanced lines -> post -> void |
| `repoint_line_onto_posted_entry_rejected` | Moving a line from draft entry to posted entry blocked |

## Test plan

- [x] All 10 new tests pass (cargo test --lib api::accounting::tests)
- [x] Full test suite passes (181 tests, 0 failures)
- [x] cargo clippy -- -D warnings passes clean
- [ ] CI green on PR