### PR TITLE
docs: accounting model conventions + Stage 1 Phase 0 approval (GIV-668)

### DIFF
--- a/docs/accounting-model.md
+++ b/docs/accounting-model.md
@@ -6,7 +6,7 @@ intended to be read by a reviewing CPA. Every convention here was proposed
 in the Stage 1 Phase 0 recon (`docs/stage1-progress.md` §5–§6) and approved
 by the board on 2026-07-15 (GIV-668).
 
-Sections marked *(reserved)* will be completed in the phase that implements
+Sections marked _(reserved)_ will be completed in the phase that implements
 them; nothing in a reserved section is implemented yet.
 
 ## 1. Ledger structure
@@ -20,7 +20,7 @@ them; nothing in a reserved section is implemented yet.
   functional-currency measurement.
 - **Layered records.** Raw imported blockchain transactions are Layer 1
   evidence and are immutable: classification creates journal entries that
-  *reference* raw transactions, never modifies them.
+  _reference_ raw transactions, never modifies them.
 
 ## 2. Amount representation (approved Q1)
 
@@ -49,7 +49,7 @@ An entry is postable only if **both** of the following hold:
    balanced lines.
 2. **Per-asset quantity balance for asset movements.** For every
    currency/asset that appears on an entry's lines with a quantity, the
-   entry's debit quantities equal its credit quantities *for that asset*,
+   entry's debit quantities equal its credit quantities _for that asset_,
    unless the difference is explicitly carried by measurement lines
    (below). Assets are never treated as fungible with each other.
 
@@ -67,11 +67,11 @@ framework).
 
 Example — swap 10 A (basis $100, fair value $150) for 4 B:
 
-| Line | Account | Asset | Qty | Debit | Credit |
-|------|---------|-------|-----|-------|--------|
-| 1 | Digital assets — B | B | +4 | $150.00 | |
-| 2 | Digital assets — A | A | −10 | | $100.00 |
-| 3 | Realized gain on digital assets | — | | | $50.00 |
+| Line | Account                         | Asset | Qty | Debit   | Credit  |
+| ---- | ------------------------------- | ----- | --- | ------- | ------- |
+| 1    | Digital assets — B              | B     | +4  | $150.00 |         |
+| 2    | Digital assets — A              | A     | −10 |         | $100.00 |
+| 3    | Realized gain on digital assets | —     |     |         | $50.00  |
 
 Lines 1–2 balance each asset's quantity movement; line 3 is the
 measurement line carrying the valuation difference to net income. The
@@ -116,16 +116,16 @@ Every entry records:
 - Single entity books, US GAAP, USD functional currency. No IFRS, no
   parallel books, no multi-entity consolidation.
 
-## 8. Transfers between own wallets *(reserved — Phase 7)*
+## 8. Transfers between own wallets _(reserved — Phase 7)_
 
 Treatment of lot movement without realization will be documented when the
 cost-basis engine lands.
 
-## 9. Cost basis *(reserved — Phase 7)*
+## 9. Cost basis _(reserved — Phase 7)_
 
 FIFO lot relief, per wallet per asset; method documented with the engine.
 
-## 10. Fair-value measurement *(reserved — Phase 8)*
+## 10. Fair-value measurement _(reserved — Phase 8)_
 
 ASU 2023-08 remeasurement conventions, price sources, and override policy
 will be documented with the measurement framework.

--- a/docs/accounting-model.md
+++ b/docs/accounting-model.md
@@ -1,0 +1,131 @@
+# Pacioli Accounting Model
+
+This document records the accounting conventions the Pacioli engine
+implements. It is the companion document to the financial statements and is
+intended to be read by a reviewing CPA. Every convention here was proposed
+in the Stage 1 Phase 0 recon (`docs/stage1-progress.md` §5–§6) and approved
+by the board on 2026-07-15 (GIV-668).
+
+Sections marked *(reserved)* will be completed in the phase that implements
+them; nothing in a reserved section is implemented yet.
+
+## 1. Ledger structure
+
+- **Double entry, per-entity.** Every journal entry belongs to an entity
+  and consists of a header and two or more lines. Each line debits or
+  credits exactly one general-ledger account.
+- **Functional currency: USD.** All entries are measured in the entity's
+  functional currency (USD in Stage 1). Token quantities are carried
+  alongside as sub-ledger measures, never as a substitute for
+  functional-currency measurement.
+- **Layered records.** Raw imported blockchain transactions are Layer 1
+  evidence and are immutable: classification creates journal entries that
+  *reference* raw transactions, never modifies them.
+
+## 2. Amount representation (approved Q1)
+
+- **Functional-currency values are stored as INTEGER minor units**
+  (USD cents) in SQLite. Integer storage is exact and summable by
+  database triggers, so the balance invariant is enforced with **zero
+  tolerance** — not a rounding window.
+- **Token quantities are stored as TEXT canonical decimals** and parsed
+  with `rust_decimal` in the engine. Chain-native assets carry up to 18
+  decimal places, which overflows a 64-bit integer at minor-unit scale;
+  text-encoded exact decimals avoid both overflow and float error.
+- **Floating-point numbers never represent money or quantities** in the
+  accounting path — not in the database, not in Rust structs, not in the
+  UI arithmetic that feeds persistence. Prices from external feeds may
+  arrive as floats but are converted to exact decimals at the accounting
+  boundary, and the conversion is the recorded measurement.
+
+## 3. Balance invariant (approved Q2)
+
+An entry is postable only if **both** of the following hold:
+
+1. **Functional-currency balance, always.** The sum of debit values equals
+   the sum of credit values in functional-currency minor units, exactly
+   (tolerance zero). This is enforced by SQLite triggers at posting time
+   and by the Rust `PostedEntry` type, which is constructible only from
+   balanced lines.
+2. **Per-asset quantity balance for asset movements.** For every
+   currency/asset that appears on an entry's lines with a quantity, the
+   entry's debit quantities equal its credit quantities *for that asset*,
+   unless the difference is explicitly carried by measurement lines
+   (below). Assets are never treated as fungible with each other.
+
+### Measurement lines (cross-asset events)
+
+Events that cross assets — a swap of token A for token B, a gift of tokens
+measured in USD, fees paid in a third asset — do not balance per asset by
+nature. They balance through **explicit measurement lines**: lines in the
+functional currency that record the valuation applied to each asset leg
+(e.g., realized gain/loss, income, or expense at fair value on the
+transaction date). The measurement is therefore a visible, auditable line
+in the entry, not an implicit conversion. Every measurement line records
+the price used and its source (see §6 provenance and the Phase 8 price
+framework).
+
+Example — swap 10 A (basis $100, fair value $150) for 4 B:
+
+| Line | Account | Asset | Qty | Debit | Credit |
+|------|---------|-------|-----|-------|--------|
+| 1 | Digital assets — B | B | +4 | $150.00 | |
+| 2 | Digital assets — A | A | −10 | | $100.00 |
+| 3 | Realized gain on digital assets | — | | | $50.00 |
+
+Lines 1–2 balance each asset's quantity movement; line 3 is the
+measurement line carrying the valuation difference to net income. The
+entry balances in USD exactly ($150.00 = $100.00 + $50.00).
+
+## 4. Entry lifecycle and append-only corrections (approved Q4)
+
+- **Lifecycle:** `draft → approved → posted`, with `voided` as the only
+  terminal correction state. Drafts may be edited freely. Posted entries
+  are immutable at the data layer (enforced by triggers).
+- **Corrections are reversing entries.** A posted entry is never edited or
+  deleted. Voiding a posted entry generates and posts a full reversing
+  entry, links the pair (`reversed_by_entry_id`), and records who voided
+  it and why. (The legacy flag-flip void is replaced in Phase 2.)
+- Adjustments follow the same rule: new adjusting entries, never edits.
+
+## 5. Approval gate
+
+Every journal entry — human-drafted or system-generated (e.g., Phase 8
+remeasurement drafts) — enters the ledger through the approval queue. The
+system never posts silently on its own behalf.
+
+## 6. Provenance
+
+Every entry records:
+
+- **origin** — how it was drafted: `manual` (Stage 1), `rule` or `model`
+  (reserved for Stage 2; the schema accepts them from day one so the audit
+  trail never needs a migration to tell humans from machines apart).
+- **approver and timestamps** — who approved it and when, and when it was
+  posted, distinct from who created it.
+- **evidence links** — references to the raw transaction(s) the entry
+  classifies, where applicable.
+
+## 7. Scope boundaries (Stage 1)
+
+- Desktop (SQLite) is the system of record through Gate 1; the web
+  (IndexedDB) journal path is deferred (approved Q5).
+- The pre-existing `auto_classify_transaction` heuristic is parked:
+  Stage 1 classification is manual-only. If re-enabled in Stage 2 its
+  entries carry `origin='rule'` (approved Q3).
+- Single entity books, US GAAP, USD functional currency. No IFRS, no
+  parallel books, no multi-entity consolidation.
+
+## 8. Transfers between own wallets *(reserved — Phase 7)*
+
+Treatment of lot movement without realization will be documented when the
+cost-basis engine lands.
+
+## 9. Cost basis *(reserved — Phase 7)*
+
+FIFO lot relief, per wallet per asset; method documented with the engine.
+
+## 10. Fair-value measurement *(reserved — Phase 8)*
+
+ASU 2023-08 remeasurement conventions, price sources, and override policy
+will be documented with the measurement framework.

--- a/docs/stage1-progress.md
+++ b/docs/stage1-progress.md
@@ -4,15 +4,17 @@ Session constitution: `SCOPE.md` (repo root). Stage 1 mandate: GIV-668.
 Gate 1: CPA-reviewed statements from real imported transactions, manually
 classified through the approval queue.
 
-**Current phase: 0 (Reconnaissance) — report below; migration plan awaiting
-board approval.**
+**Current phase: 1 (Balance enforcement at the data layer) — migration plan
+M1–M3 + recommendations Q1–Q5 approved by board 2026-07-15; implementation
+delegated to Engineer. Conventions doc: `docs/accounting-model.md`.**
 
 ## Phase Checklist
 
 - [x] **Phase 0 — Reconnaissance and tracker** (report below; migration plan
-      proposed, pending board approval)
+      approved by board 2026-07-15)
 - [ ] **Phase 1 — Balance enforcement at the data layer**
-      (~40% pre-landed by GIV-665, see report §3)
+      (~40% pre-landed by GIV-665, see report §3; M1–M3 + `PostedEntry`
+      delegated to Engineer, `docs/accounting-model.md` authored)
 - [ ] **Phase 2 — Posting engine and general ledger**
 - [ ] **Phase 3 — Approval queue and manual journal entry UI**
 - [ ] **Phase 4 — Classification workflow: raw transactions → draft entries**
@@ -176,9 +178,26 @@ persistence path; `f64` removed from accounting money structs.
 - 2026-07-14 — Phase 0 recon complete; GIV-665 (data-layer balance
   triggers) recognized as pre-landed Phase-1 work. Migration plan M1–M3
   submitted to board for approval (GIV-668 confirmation).
+- 2026-07-15 — **Board APPROVED the Phase 1 plan and all five
+  recommendations** (GIV-668 confirmation `a32590f3`, no overrides):
+  Q1 = INTEGER minor units + TEXT `rust_decimal` quantities, zero
+  tolerance; Q2 = functional-currency balance always + per-asset quantity
+  balance with explicit measurement lines; Q3 = `auto_classify_transaction`
+  parked, manual-only Stage 1, `origin='rule'` on Stage-2 re-enable;
+  Q4 = void → generated reversing entries (Phase 2); Q5 = web/IndexedDB
+  journal path deferred past Gate 1, SQLite is the system of record.
+  Conventions written up in `docs/accounting-model.md`.
 
 ### 8. Session log
 
 - **Session 1 (2026-07-14, CTO):** Phase 0 recon + this tracker. No
   functional changes. Next step: on board approval of §5/§6 → delegate
   Phase 1 implementation (M1–M3 + `PostedEntry` type + tests).
+- **Session 2 (2026-07-15, CTO):** Phase 0 acceptance gate cleared (board
+  approval). Authored `docs/accounting-model.md` (approved conventions,
+  measurement-line worked example, reserved sections for Phases 7/8).
+  Delegated Phase 1 implementation to Engineer as a GIV-668 child issue:
+  M1 (lifecycle + provenance columns), M2 (exact-decimal amounts), M3
+  (per-asset balance), Rust `PostedEntry` constructible only from balanced
+  lines, and the acceptance test that no public API path can persist an
+  unbalanced posted entry. Docs-only session; no engine code touched.

--- a/docs/stage1-progress.md
+++ b/docs/stage1-progress.md
@@ -92,15 +92,15 @@ but NOT in the accounting engine.
 
 ### 3. Conflicts with the seven invariants
 
-| # | Invariant | Finding |
-|---|-----------|---------|
-| 1 | Balance structural | Partially met (GIV-665 triggers). Gaps: balance is checked as ONE aggregate sum across all assets (not per currency/asset); no Rust type-level enforcement; 0.01 float tolerance. |
-| 2 | No floats | **Violated end-to-end.** `accounting.rs` money structs are `f64` (debit/credit/balances, lines 127–224); SQLite `DECIMAL(18,2)` has NUMERIC affinity = stored as float; frontend sums amounts as JS `number` (`JournalEntries.tsx:330–438`); frontend FIFO in JS numbers. Balance trigger compares float sums to 0.01. |
-| 3 | Append-only | **Violated:** `void_journal_entry` (accounting.rs:604) just flips `is_reversed=1`; no reversing entry is generated; `reversed_by_entry_id` is never populated. Posted-line immutability (GIV-665) does hold. |
-| 4 | Reports are views | Met so far (trial balance is a query; reporting views derive). |
-| 5 | Raw tx immutable | Met in classification path (`auto_classify_transaction` only reads `multi_chain_transactions`); no code mutates raw tx during classification. |
-| 6 | Read-only wallets | Met; nothing here touches signing. |
-| 7 | Provenance | **Absent:** no origin/approver/timestamps beyond created_by/created_at. |
+| #   | Invariant          | Finding                                                                                                                                                                                                                                                                                                                |
+| --- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Balance structural | Partially met (GIV-665 triggers). Gaps: balance is checked as ONE aggregate sum across all assets (not per currency/asset); no Rust type-level enforcement; 0.01 float tolerance.                                                                                                                                      |
+| 2   | No floats          | **Violated end-to-end.** `accounting.rs` money structs are `f64` (debit/credit/balances, lines 127–224); SQLite `DECIMAL(18,2)` has NUMERIC affinity = stored as float; frontend sums amounts as JS `number` (`JournalEntries.tsx:330–438`); frontend FIFO in JS numbers. Balance trigger compares float sums to 0.01. |
+| 3   | Append-only        | **Violated:** `void_journal_entry` (accounting.rs:604) just flips `is_reversed=1`; no reversing entry is generated; `reversed_by_entry_id` is never populated. Posted-line immutability (GIV-665) does hold.                                                                                                           |
+| 4   | Reports are views  | Met so far (trial balance is a query; reporting views derive).                                                                                                                                                                                                                                                         |
+| 5   | Raw tx immutable   | Met in classification path (`auto_classify_transaction` only reads `multi_chain_transactions`); no code mutates raw tx during classification.                                                                                                                                                                          |
+| 6   | Read-only wallets  | Met; nothing here touches signing.                                                                                                                                                                                                                                                                                     |
+| 7   | Provenance         | **Absent:** no origin/approver/timestamps beyond created_by/created_at.                                                                                                                                                                                                                                                |
 
 ### 4. Float inventory (Invariant 2 remediation targets)
 
@@ -121,6 +121,7 @@ but NOT in the accounting engine.
 All migrations append-only, SQLite path first (web path lags per mandate).
 
 **M1 — journal-entry header lifecycle + provenance**
+
 - Add to `journal_entries`: `entity_id` (FK `entities`, nullable initially),
   `status` TEXT CHECK('draft','approved','posted','voided') backfilled from
   `is_posted`; `origin` TEXT CHECK('manual','rule','model') DEFAULT
@@ -131,12 +132,14 @@ All migrations append-only, SQLite path first (web path lags per mandate).
   column during transition so existing code keeps working, then retire it.
 
 **M2 — exact-decimal amounts (the decision point, §6 Q1)**
+
 - Recommended: new columns storing amounts as INTEGER minor units in the
   functional currency (exactly trigger-summable) + `quantity` as TEXT
   canonical decimal validated by `rust_decimal` in Rust; balance trigger
   compares integer sums for exact equality (tolerance 0, not 0.01).
 
 **M3 — per-asset balance**
+
 - Add `asset_id`/currency dimension to `journal_entry_lines` (generalize
   `token_id`; fiat 'USD' included); posting trigger validates balance PER
   asset group; measurement lines (functional-currency valuation) carry the


### PR DESCRIPTION
## Summary
- Adds `docs/accounting-model.md` — the CPA-facing conventions document recording the board-approved Stage 1 decisions (GIV-668 confirmation `a32590f3`, 2026-07-15): INTEGER minor-unit values + TEXT rust_decimal quantities with zero balance tolerance (Q1); functional-currency balance always + per-asset quantity balance via explicit measurement lines, with a worked swap example (Q2); manual-only classification with the heuristic parked (Q3); void → reversing entries (Q4); web journal path deferred past Gate 1 (Q5). Reserved sections for Phases 7/8.
- Updates `docs/stage1-progress.md`: Phase 0 acceptance gate cleared, decisions log + session 2 entry, Phase 1 delegated to Engineer.

Docs-only; no engine code touched.

## Test plan
- [x] Docs-only change — CI green suffices

🤖 Generated with [Claude Code](https://claude.com/claude-code)