### PR TITLE
feat(accounting): Phase 3 approval queue + manual journal entry UI (GIV-678)

### DIFF
--- a/docs/stage1-progress.md
+++ b/docs/stage1-progress.md
@@ -4,9 +4,9 @@ Session constitution: `SCOPE.md` (repo root). Stage 1 mandate: GIV-668.
 Gate 1: CPA-reviewed statements from real imported transactions, manually
 classified through the approval queue.
 
-**Current phase: 2 (Posting engine and general ledger) — Phase 1 landed;
-Phase 2 implemented by Engineer (GIV-677): approval gate, atomic idempotent
-posting, reversing entries, per-asset balances.**
+**Current phase: 3 (Approval queue and manual journal entry UI) — Phases 1-2
+landed; Phase 3 implemented by Engineer (GIV-678): approval queue view,
+manual journal entry form, entry detail view with reversal linkage.**
 
 ## Phase Checklist
 
@@ -19,7 +19,10 @@ posting, reversing entries, per-asset balances.**
 - [x] **Phase 2 — Posting engine and general ledger**
       (GIV-677: approval gate, atomic idempotent posting, reversing entries,
       per-asset balances, trial balance verification — Engineer)
-- [ ] **Phase 3 — Approval queue and manual journal entry UI**
+- [x] **Phase 3 — Approval queue and manual journal entry UI**
+      (GIV-678: approval queue with all lifecycle tabs, approve/post/void/demote
+      actions, manual journal entry form with integer-math balance indicator,
+      entry detail view with reversal linkage, per-asset quantity hints — Engineer)
 - [ ] **Phase 4 — Classification workflow: raw transactions → draft entries**
 - [ ] **Phase 5 — Periods, close, and lock**
 - [ ] **Phase 6 — Financial statements v1**
@@ -319,3 +322,35 @@ is_reversed=1, reversed_by_entry_id=<new_id>`. Both entries remain in
      regression): entry numbers derive from `COUNT(*)+1`, collidable if rows are
      ever deleted — same scheme as `create_journal_entry`; fold into a future
      sequence-table fix.
+- **Session 7 (2026-07-15, Engineer — GIV-678):** Implemented Phase 3
+  (approval queue + manual journal entry UI):
+  - **Approval queue view** (`JournalEntries.tsx`): five-tab filter
+    (All/Draft/Approved/Posted/Voided), per-row actions wired to Tauri
+    commands — Approve (draft→approved), Post (approved→posted), Void
+    (posted→voided with confirmation dialog explaining reversing entry),
+    Demote (approved→draft by voiding + re-creating as draft for editing).
+    Origin column shows manual/rule/model provenance. Expanded rows show
+    approver, timestamps, reference. Backend errors surfaced verbatim.
+  - **Manual journal entry form** (`JournalEntryDrawer.tsx`): create/edit
+    drafts only. Line items with account picker, debit/credit in decimal
+    strings converted to integer minor units via `toMinorUnits()` (string
+    parsing, no floats touch money). Optional quantity + asset_id per line.
+    Live balance indicator uses integer math (exact zero comparison, not
+    float tolerance). Per-asset quantity balance hints for multi-asset
+    entries.
+  - **Entry detail view** (`JournalEntryDetail.tsx`): full lines with
+    account, asset, quantity, debit/credit, memo. Lifecycle timeline
+    (created→approved→posted→voided with timestamps and actors). Reversal
+    linkage: voided entries link to reversing entry, reversing entries link
+    back to original. Both visibly marked per `docs/accounting-model.md`
+    corrections convention.
+  - **Shared utilities** (`journalEntryUtils.ts`): `toMinorUnits()`,
+    `minorToDollars()`, `computeBalance()`, `displayStatus()`,
+    `formatDate()`, `formatDateTime()` — extracted for testability.
+  - **Tests:** 31 Vitest tests covering: `toMinorUnits` (whole dollars,
+    cents, single-digit cents, truncation, empty/non-numeric, float-trap
+    avoidance for 0.1+0.2 and 19.99+0.01), `minorToDollars` (formatting,
+    negatives, padding), roundtrip identity, `computeBalance` (balanced,
+    unbalanced, all-zeros, multi-line swap from accounting-model.md,
+    float-error immunity), `displayStatus` (all statuses + unknown
+    fallback), `formatDate` (null, string, Date).

--- a/docs/stage1-progress.md
+++ b/docs/stage1-progress.md
@@ -362,7 +362,7 @@ is_reversed=1, reversed_by_entry_id=<new_id>`. Both entries remain in
      creates a posted reversal — wrong tool for an unposted entry. Added a
      dedicated `demote_journal_entry` Tauri command: race-safe conditional
      `UPDATE … SET status='draft', approved_by=NULL, approved_at=NULL
-     WHERE status='approved'` (the M5 state machine explicitly allows
+WHERE status='approved'` (the M5 state machine explicitly allows
      approved→draft). UI now calls it directly.
   2. **"Update Draft" created duplicates.** Editing a draft re-invoked
      `create_journal_entry`, leaving the old draft behind. Added
@@ -384,8 +384,8 @@ is_reversed=1, reversed_by_entry_id=<new_id>`. Both entries remain in
      `'current-user'` placeholder (Inv-7 provenance; backend `created_by`
      is still hardcoded `'system'` in the create path — pre-existing debt,
      same bucket as the entry-number sequence fix).
-  New tests: 4 Rust SQL-semantics tests (demote approved→draft clears
-  approval provenance; conditional demote is a 0-row no-op on posted;
-  draft lines replaceable; posted lines still immutable) + 6 Vitest cases
-  (negative-sign regression, leading decimal point). 38 accounting tests +
-  33 utils tests green; tsc + eslint clean.
+     New tests: 4 Rust SQL-semantics tests (demote approved→draft clears
+     approval provenance; conditional demote is a 0-row no-op on posted;
+     draft lines replaceable; posted lines still immutable) + 6 Vitest cases
+     (negative-sign regression, leading decimal point). 38 accounting tests +
+     33 utils tests green; tsc + eslint clean.

--- a/docs/stage1-progress.md
+++ b/docs/stage1-progress.md
@@ -354,3 +354,38 @@ is_reversed=1, reversed_by_entry_id=<new_id>`. Both entries remain in
     unbalanced, all-zeros, multi-line swap from accounting-model.md,
     float-error immunity), `displayStatus` (all statuses + unknown
     fallback), `formatDate` (null, string, Date).
+- **Session 8 (2026-07-15, CTO — GIV-678 review hardening):** Four gaps
+  fixed before merge:
+  1. **Demote was guaranteed to fail and conceptually wrong.** The UI
+     demoted approved→draft by calling `void_journal_entry` + re-create,
+     but void only accepts POSTED entries (`WHERE status='posted'`) and
+     creates a posted reversal — wrong tool for an unposted entry. Added a
+     dedicated `demote_journal_entry` Tauri command: race-safe conditional
+     `UPDATE … SET status='draft', approved_by=NULL, approved_at=NULL
+     WHERE status='approved'` (the M5 state machine explicitly allows
+     approved→draft). UI now calls it directly.
+  2. **"Update Draft" created duplicates.** Editing a draft re-invoked
+     `create_journal_entry`, leaving the old draft behind. Added
+     `update_journal_entry` (draft-only, ONE transaction: conditional
+     header update `WHERE status='draft'` + full line replacement; a
+     concurrent approve/post rolls the whole edit back). Posted-line
+     immutability triggers are untouched — only draft lines are mutable.
+  3. **Invoke payloads could not deserialize.** `NewJournalEntryInput` /
+     `JournalEntryLineInput` are `#[serde(rename_all = "camelCase")]` and
+     Tauri v2 expects camelCase arg keys, but the UI sent snake_case
+     (`entry_date`, `gl_account_id`, `status_filter`, …) — create/save
+     failed against the real backend, and the always-null `status_filter`
+     was silently masked by the client-side tab filter. All payloads now
+     camelCase.
+  4. **`toMinorUnits('-0.50')` returned +50.** `parseInt('-0')` is `-0`,
+     which is not `< 0`, so sub-dollar negatives silently flipped sign.
+     Sign is now parsed from the string. Also: `approve_journal_entry` now
+     records the real authenticated user (email) as approver instead of the
+     `'current-user'` placeholder (Inv-7 provenance; backend `created_by`
+     is still hardcoded `'system'` in the create path — pre-existing debt,
+     same bucket as the entry-number sequence fix).
+  New tests: 4 Rust SQL-semantics tests (demote approved→draft clears
+  approval provenance; conditional demote is a 0-row no-op on posted;
+  draft lines replaceable; posted lines still immutable) + 6 Vitest cases
+  (negative-sign regression, leading decimal point). 38 accounting tests +
+  33 utils tests green; tsc + eslint clean.

--- a/src-tauri/src/api/accounting.rs
+++ b/src-tauri/src/api/accounting.rs
@@ -1038,6 +1038,156 @@ pub async fn void_journal_entry(
     get_journal_entry(state, id).await
 }
 
+/// Demotes an approved journal entry back to draft for editing.
+/// The DB state machine explicitly allows approved -> draft (M5).
+/// Race-safe: conditional UPDATE demotes exactly once; a concurrent
+/// post/demote makes this a clean error instead of a silent overwrite.
+#[tauri::command]
+pub async fn demote_journal_entry(
+    state: State<'_, DatabaseState>,
+    id: i64,
+) -> Result<JournalEntryWithLines, String> {
+    let entry = sqlx::query_as::<_, JournalEntry>("SELECT * FROM journal_entries WHERE id = ?")
+        .bind(id)
+        .fetch_optional(&state.pool)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "Journal entry not found".to_string())?;
+
+    if entry.status == "voided" {
+        return Err("Cannot demote a voided entry".to_string());
+    }
+    if entry.status == "posted" {
+        return Err("Cannot demote a posted entry — void it instead".to_string());
+    }
+    if entry.status == "draft" {
+        return Err("Journal entry is already a draft".to_string());
+    }
+
+    let result = sqlx::query(
+        "UPDATE journal_entries SET status = 'draft', approved_by = NULL, approved_at = NULL WHERE id = ? AND status = 'approved'",
+    )
+    .bind(id)
+    .execute(&state.pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    if result.rows_affected() == 0 {
+        return Err("Journal entry is no longer approved (concurrently modified)".to_string());
+    }
+
+    get_journal_entry(state, id).await
+}
+
+/// Updates a DRAFT journal entry in place: header fields plus a full
+/// replacement of its lines, in ONE transaction. Only drafts are editable;
+/// the conditional header UPDATE (`WHERE status = 'draft'`) makes a
+/// concurrent approve/post roll the whole edit back. Line-level input is
+/// validated with the same rules as `create_journal_entry`.
+#[tauri::command]
+pub async fn update_journal_entry(
+    state: State<'_, DatabaseState>,
+    id: i64,
+    input: NewJournalEntryInput,
+) -> Result<JournalEntryWithLines, String> {
+    if input.lines.is_empty() {
+        return Err("Journal entry must have at least one line".to_string());
+    }
+
+    for line in &input.lines {
+        if line.debit_minor < 0 || line.credit_minor < 0 {
+            return Err("Line amounts must be non-negative".to_string());
+        }
+        if (line.debit_minor > 0 && line.credit_minor > 0)
+            || (line.debit_minor == 0 && line.credit_minor == 0)
+        {
+            return Err("Each line must have exactly one of debit or credit amount".to_string());
+        }
+    }
+
+    let entry_date = NaiveDateTime::parse_from_str(&input.entry_date, "%Y-%m-%dT%H:%M:%S")
+        .or_else(|_| {
+            NaiveDateTime::parse_from_str(
+                &format!("{}T00:00:00", input.entry_date),
+                "%Y-%m-%dT%H:%M:%S",
+            )
+        })
+        .map_err(|e| format!("Invalid date format: {e}"))?;
+
+    let mut tx = state.pool.begin().await.map_err(|e| e.to_string())?;
+
+    let entry = sqlx::query_as::<_, JournalEntry>("SELECT * FROM journal_entries WHERE id = ?")
+        .bind(id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "Journal entry not found".to_string())?;
+
+    if entry.status != "draft" {
+        return Err("Only draft entries can be edited".to_string());
+    }
+
+    // Conditional header update: if the entry stopped being a draft between
+    // the read above and this write, 0 rows are affected and we roll back.
+    let header = sqlx::query(
+        "UPDATE journal_entries SET entry_date = ?, description = ?, reference_number = ? WHERE id = ? AND status = 'draft'",
+    )
+    .bind(entry_date)
+    .bind(&input.description)
+    .bind(&input.reference_number)
+    .bind(id)
+    .execute(&mut *tx)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    if header.rows_affected() == 0 {
+        return Err("Journal entry is no longer a draft (concurrently modified)".to_string());
+    }
+
+    // Full line replacement (draft lines are mutable; posted-line
+    // immutability triggers only protect posted entries).
+    sqlx::query("DELETE FROM journal_entry_lines WHERE journal_entry_id = ?")
+        .bind(id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    for (i, line) in input.lines.iter().enumerate() {
+        let debit_amount = line.debit_minor as f64 / 100.0;
+        let credit_amount = line.credit_minor as f64 / 100.0;
+        sqlx::query(
+            r#"
+            INSERT INTO journal_entry_lines (
+                journal_entry_id, gl_account_id, token_id,
+                debit_amount, credit_amount,
+                debit_minor, credit_minor,
+                quantity, asset_id,
+                description, line_number
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(id)
+        .bind(line.gl_account_id)
+        .bind(line.token_id)
+        .bind(debit_amount)
+        .bind(credit_amount)
+        .bind(line.debit_minor)
+        .bind(line.credit_minor)
+        .bind(&line.quantity)
+        .bind(&line.asset_id)
+        .bind(&line.description)
+        .bind(i as i64 + 1)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| e.to_string())?;
+    }
+
+    tx.commit().await.map_err(|e| e.to_string())?;
+
+    get_journal_entry(state, id).await
+}
+
 // ============================================================================
 // Auto-Classify Command
 // ============================================================================
@@ -2727,6 +2877,104 @@ mod tests {
             second.rows_affected(),
             0,
             "Second void must be a 0-row no-op so the caller rolls back its duplicate reversal"
+        );
+    }
+
+    // ---- Demote: approved -> draft is allowed, clears approval provenance ----
+    #[tokio::test]
+    async fn demote_approved_entry_returns_to_draft() {
+        let pool = setup_test_db().await;
+        let (acct_a, acct_b) = get_test_accounts(&pool).await;
+        let entry_id = create_named_draft_entry(&pool, "DEMOTE-001").await;
+        add_balanced_lines(&pool, entry_id, acct_a, acct_b, 5000).await;
+        approve_entry(&pool, entry_id).await;
+
+        // Conditional demote (the SQL demote_journal_entry relies on)
+        let result = sqlx::query(
+            "UPDATE journal_entries SET status = 'draft', approved_by = NULL, approved_at = NULL WHERE id = ? AND status = 'approved'",
+        )
+        .bind(entry_id)
+        .execute(&pool)
+        .await
+        .expect("Demote of an approved entry must succeed (M5 allows approved->draft)");
+        assert_eq!(result.rows_affected(), 1);
+
+        let (status, approved_by): (String, Option<String>) =
+            sqlx::query_as("SELECT status, approved_by FROM journal_entries WHERE id = ?")
+                .bind(entry_id)
+                .fetch_one(&pool)
+                .await
+                .expect("Fetch demoted entry");
+        assert_eq!(status, "draft");
+        assert!(
+            approved_by.is_none(),
+            "Demote must clear approval provenance"
+        );
+    }
+
+    // ---- Demote race: conditional UPDATE is a 0-row no-op on non-approved ----
+    #[tokio::test]
+    async fn demote_non_approved_entry_is_noop() {
+        let pool = setup_test_db().await;
+        let (acct_a, acct_b) = get_test_accounts(&pool).await;
+        let entry_id = create_named_draft_entry(&pool, "DEMOTE-002").await;
+        add_balanced_lines(&pool, entry_id, acct_a, acct_b, 5000).await;
+        approve_and_post_entry(&pool, entry_id).await;
+
+        // Posted entry: the WHERE clause filters it out before the state
+        // machine trigger could fire — clean 0-row no-op, caller errors.
+        let result = sqlx::query(
+            "UPDATE journal_entries SET status = 'draft', approved_by = NULL, approved_at = NULL WHERE id = ? AND status = 'approved'",
+        )
+        .bind(entry_id)
+        .execute(&pool)
+        .await
+        .expect("Conditional demote of a posted entry must not error");
+        assert_eq!(result.rows_affected(), 0);
+    }
+
+    // ---- Draft edit: draft lines are mutable (delete + reinsert works) ----
+    #[tokio::test]
+    async fn draft_lines_can_be_replaced() {
+        let pool = setup_test_db().await;
+        let (acct_a, acct_b) = get_test_accounts(&pool).await;
+        let entry_id = create_named_draft_entry(&pool, "EDIT-001").await;
+        add_balanced_lines(&pool, entry_id, acct_a, acct_b, 5000).await;
+
+        sqlx::query("DELETE FROM journal_entry_lines WHERE journal_entry_id = ?")
+            .bind(entry_id)
+            .execute(&pool)
+            .await
+            .expect("Draft lines must be deletable");
+
+        add_balanced_lines(&pool, entry_id, acct_a, acct_b, 7500).await;
+
+        let (total,): (i64,) = sqlx::query_as(
+            "SELECT COALESCE(SUM(debit_minor), 0) FROM journal_entry_lines WHERE journal_entry_id = ?",
+        )
+        .bind(entry_id)
+        .fetch_one(&pool)
+        .await
+        .expect("Sum replaced lines");
+        assert_eq!(total, 7500, "Replaced draft lines must be the new amounts");
+    }
+
+    // ---- Posted lines stay immutable: delete must be rejected ----
+    #[tokio::test]
+    async fn posted_lines_cannot_be_deleted() {
+        let pool = setup_test_db().await;
+        let (acct_a, acct_b) = get_test_accounts(&pool).await;
+        let entry_id = create_named_draft_entry(&pool, "EDIT-002").await;
+        add_balanced_lines(&pool, entry_id, acct_a, acct_b, 5000).await;
+        approve_and_post_entry(&pool, entry_id).await;
+
+        let result = sqlx::query("DELETE FROM journal_entry_lines WHERE journal_entry_id = ?")
+            .bind(entry_id)
+            .execute(&pool)
+            .await;
+        assert!(
+            result.is_err(),
+            "Deleting lines of a posted entry must be rejected by the immutability trigger"
         );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -436,6 +436,8 @@ pub fn run() {
             api::accounting::approve_journal_entry,
             api::accounting::post_journal_entry,
             api::accounting::void_journal_entry,
+            api::accounting::demote_journal_entry,
+            api::accounting::update_journal_entry,
             api::accounting::auto_classify_transaction,
             api::accounting::update_transaction_classification,
             api::accounting::get_account_balances,

--- a/src/app/journal-entries/JournalEntries.tsx
+++ b/src/app/journal-entries/JournalEntries.tsx
@@ -305,10 +305,7 @@ const JournalEntries: React.FC = () => {
 
   const handleDismissError = useCallback(() => setActionError(null), [])
 
-  const handleDismissVoidConfirm = useCallback(
-    () => setVoidConfirmId(null),
-    []
-  )
+  const handleDismissVoidConfirm = useCallback(() => setVoidConfirmId(null), [])
 
   const resolveAccountName = useCallback(
     (glAccountId: number) => {
@@ -596,9 +593,7 @@ const JournalEntries: React.FC = () => {
                           <table className="w-full text-sm">
                             <thead>
                               <tr className="text-xs uppercase text-[#294050] dark:text-[#9FB4BE]">
-                                <th className="text-left py-1 pr-4">
-                                  Account
-                                </th>
+                                <th className="text-left py-1 pr-4">Account</th>
                                 <th className="text-right py-1 px-4 w-32">
                                   Debit
                                 </th>

--- a/src/app/journal-entries/JournalEntries.tsx
+++ b/src/app/journal-entries/JournalEntries.tsx
@@ -13,6 +13,7 @@ import {
   ChevronRight,
 } from 'lucide-react'
 import { useNavBadges } from '../../contexts/NavBadgeContext'
+import { useAuth } from '../../contexts/AuthContext'
 import type { JournalEntryWithLines, GLAccount } from '../../types/database'
 import JournalEntryDrawer from './JournalEntryDrawer'
 import JournalEntryDetail from './JournalEntryDetail'
@@ -114,6 +115,7 @@ const JournalEntries: React.FC = () => {
   >()
   const [voidConfirmId, setVoidConfirmId] = useState<number | null>(null)
   const { refreshCounts } = useNavBadges()
+  const { user } = useAuth()
 
   const accountMap = useMemo(() => {
     const m = new Map<number, GLAccount>()
@@ -124,15 +126,21 @@ const JournalEntries: React.FC = () => {
   const fetchEntries = useCallback(async () => {
     setLoading(true)
     try {
+      // Backend buckets: 'draft' = unposted (drafts AND approved), 'posted',
+      // 'void'. 'approved' has no backend bucket, so fetch the unposted
+      // bucket and let the exact client-side status filter narrow it.
       const statusFilter =
         filterParam === 'all'
           ? null
           : filterParam === 'voided'
             ? 'void'
-            : filterParam
+            : filterParam === 'approved'
+              ? 'draft'
+              : filterParam
+      // Tauri command args are camelCase on the JS side by default.
       const result = await invoke<JournalEntryWithLines[]>(
         'get_journal_entries',
-        { status_filter: statusFilter, limit: 200, offset: 0 }
+        { statusFilter, limit: 200, offset: 0 }
       )
       setEntries(result)
     } catch (err) {
@@ -220,9 +228,11 @@ const JournalEntries: React.FC = () => {
     async (id: number) => {
       setActionError(null)
       try {
+        // Record the real approver identity (Inv-7 provenance), not a
+        // placeholder string.
         await invoke('approve_journal_entry', {
           id,
-          approver: 'current-user',
+          approver: user?.email ?? user?.display_name ?? 'unknown',
         })
         fetchEntries()
         refreshCounts()
@@ -231,7 +241,7 @@ const JournalEntries: React.FC = () => {
         setActionError(msg)
       }
     },
-    [fetchEntries, refreshCounts]
+    [fetchEntries, refreshCounts, user]
   )
 
   /** Post an approved entry */
@@ -267,34 +277,24 @@ const JournalEntries: React.FC = () => {
     [fetchEntries, refreshCounts]
   )
 
-  /** Demote an approved entry back to draft for editing */
+  /**
+   * Demote an approved entry back to draft for editing.
+   * Uses the dedicated backend command: the DB state machine allows
+   * approved -> draft directly. (void_journal_entry only accepts POSTED
+   * entries and creates a posted reversal — wrong tool for an unposted
+   * approved entry.)
+   */
   const handleDemote = useCallback(
     async (entry: JournalEntryWithLines) => {
       setActionError(null)
       try {
-        await invoke('void_journal_entry', { id: entry.id })
-        const input = {
-          entry_date: new Date(entry.entryDate).toISOString().split('T')[0],
-          description: entry.description ?? '',
-          reference_number: entry.referenceNumber ?? null,
-          raw_transaction_id: null,
-          lines: entry.lines.map(l => ({
-            gl_account_id: l.glAccountId,
-            token_id: l.tokenId ?? null,
-            debit_minor: l.debitMinor,
-            credit_minor: l.creditMinor,
-            quantity: l.quantity ?? null,
-            asset_id: l.assetId ?? 'USD',
-            description: l.description ?? null,
-          })),
-        }
-        const newDraft = await invoke<JournalEntryWithLines>(
-          'create_journal_entry',
-          { input }
+        const demoted = await invoke<JournalEntryWithLines>(
+          'demote_journal_entry',
+          { id: entry.id }
         )
         fetchEntries()
         refreshCounts()
-        handleEditEntry(newDraft)
+        handleEditEntry(demoted)
       } catch (err) {
         const msg = typeof err === 'string' ? err : 'Failed to demote entry'
         setActionError(msg)

--- a/src/app/journal-entries/JournalEntries.tsx
+++ b/src/app/journal-entries/JournalEntries.tsx
@@ -8,23 +8,22 @@ import {
   CheckCircle2,
   Clock,
   XCircle,
+  ShieldCheck,
   ChevronDown,
   ChevronRight,
 } from 'lucide-react'
 import { useNavBadges } from '../../contexts/NavBadgeContext'
 import type { JournalEntryWithLines, GLAccount } from '../../types/database'
 import JournalEntryDrawer from './JournalEntryDrawer'
+import JournalEntryDetail from './JournalEntryDetail'
+import {
+  displayStatus as displayStatusUtil,
+  formatDate,
+  formatDateTime,
+  minorToDollars,
+} from './journalEntryUtils'
 
-type StatusFilter = 'all' | 'draft' | 'posted' | 'void'
-
-/** Derives a display status from the lifecycle status column */
-function getEntryStatus(
-  entry: JournalEntryWithLines
-): 'draft' | 'posted' | 'void' {
-  if (entry.status === 'voided') return 'void'
-  if (entry.status === 'posted') return 'posted'
-  return 'draft'
-}
+type StatusFilter = 'all' | 'draft' | 'approved' | 'posted' | 'voided'
 
 const statusConfig = {
   draft: {
@@ -33,22 +32,39 @@ const statusConfig = {
     className:
       'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
   },
+  approved: {
+    label: 'Approved',
+    icon: ShieldCheck,
+    className:
+      'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  },
   posted: {
     label: 'Posted',
     icon: CheckCircle2,
     className:
       'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300',
   },
-  void: {
-    label: 'Void',
+  voided: {
+    label: 'Voided',
     icon: XCircle,
     className:
       'bg-gray-100 text-gray-600 dark:bg-gray-800/50 dark:text-gray-400',
   },
+} as const
+
+const originLabels: Record<string, string> = {
+  manual: 'Manual',
+  rule: 'Rule',
+  model: 'Model',
 }
 
-/** Status badge pill */
-const StatusBadge: React.FC<{ status: 'draft' | 'posted' | 'void' }> = ({
+/**
+ * Status badge pill for journal entry lifecycle states.
+ * @param props - Component properties
+ * @param props.status - The lifecycle status to render
+ * @returns A styled status badge element
+ */
+const StatusBadge: React.FC<{ status: keyof typeof statusConfig }> = ({
   status,
 }) => {
   const cfg = statusConfig[status]
@@ -63,18 +79,23 @@ const StatusBadge: React.FC<{ status: 'draft' | 'posted' | 'void' }> = ({
   )
 }
 
-/** Formats a date string for display */
-function formatDate(d: string | Date | undefined | null): string {
-  if (!d) return '—'
-  const date = typeof d === 'string' ? new Date(d) : d
-  return date.toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })
+/**
+ * Maps the database status field to a display status key.
+ * @param entry - Journal entry to inspect
+ * @returns The display status key
+ */
+function displayStatus(
+  entry: JournalEntryWithLines
+): keyof typeof statusConfig {
+  return displayStatusUtil(entry.status)
 }
 
-/** Journal Entries list page */
+/**
+ * Journal Entries approval queue page.
+ * Lists entries by lifecycle status with filters and per-row actions
+ * wired to the Tauri backend commands.
+ * @returns The JournalEntries page component
+ */
 const JournalEntries: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const filterParam = (searchParams.get('filter') ?? 'all') as StatusFilter
@@ -88,6 +109,10 @@ const JournalEntries: React.FC = () => {
   const [editingEntry, setEditingEntry] = useState<
     JournalEntryWithLines | undefined
   >()
+  const [detailEntry, setDetailEntry] = useState<
+    JournalEntryWithLines | undefined
+  >()
+  const [voidConfirmId, setVoidConfirmId] = useState<number | null>(null)
   const { refreshCounts } = useNavBadges()
 
   const accountMap = useMemo(() => {
@@ -99,7 +124,12 @@ const JournalEntries: React.FC = () => {
   const fetchEntries = useCallback(async () => {
     setLoading(true)
     try {
-      const statusFilter = filterParam === 'all' ? null : filterParam
+      const statusFilter =
+        filterParam === 'all'
+          ? null
+          : filterParam === 'voided'
+            ? 'void'
+            : filterParam
       const result = await invoke<JournalEntryWithLines[]>(
         'get_journal_entries',
         { status_filter: statusFilter, limit: 200, offset: 0 }
@@ -126,16 +156,21 @@ const JournalEntries: React.FC = () => {
     fetchAccounts()
   }, [fetchEntries, fetchAccounts])
 
+  /** Filter entries by search query */
   const filteredEntries = useMemo(() => {
-    if (!searchQuery) return entries
+    let list = entries
+    if (filterParam !== 'all') {
+      list = list.filter(e => displayStatus(e) === filterParam)
+    }
+    if (!searchQuery) return list
     const q = searchQuery.toLowerCase()
-    return entries.filter(
+    return list.filter(
       e =>
         e.description?.toLowerCase().includes(q) ||
         e.entryNumber?.toLowerCase().includes(q) ||
         e.referenceNumber?.toLowerCase().includes(q)
     )
-  }, [entries, searchQuery])
+  }, [entries, searchQuery, filterParam])
 
   const handleTabChange = useCallback(
     (tab: StatusFilter) => {
@@ -148,12 +183,17 @@ const JournalEntries: React.FC = () => {
     setExpandedId(prev => (prev === id ? null : id))
   }, [])
 
-  const clearEditingEntry = useCallback(() => setEditingEntry(undefined), []) // skipcq: JS-W1042 — React setState requires explicit argument
+  const clearEditingEntry = useCallback(() => setEditingEntry(undefined), [])
 
   const handleNewEntry = useCallback(() => {
     clearEditingEntry()
     setDrawerOpen(true)
   }, [clearEditingEntry])
+
+  const handleEditEntry = useCallback((entry: JournalEntryWithLines) => {
+    setEditingEntry(entry)
+    setDrawerOpen(true)
+  }, [])
 
   const handleCloseDrawer = useCallback(() => {
     setDrawerOpen(false)
@@ -167,6 +207,34 @@ const JournalEntries: React.FC = () => {
     refreshCounts()
   }, [clearEditingEntry, fetchEntries, refreshCounts])
 
+  const handleViewDetail = useCallback((entry: JournalEntryWithLines) => {
+    setDetailEntry(entry)
+  }, [])
+
+  const handleCloseDetail = useCallback(() => {
+    setDetailEntry(undefined)
+  }, [])
+
+  /** Approve a draft entry */
+  const handleApprove = useCallback(
+    async (id: number) => {
+      setActionError(null)
+      try {
+        await invoke('approve_journal_entry', {
+          id,
+          approver: 'current-user',
+        })
+        fetchEntries()
+        refreshCounts()
+      } catch (err) {
+        const msg = typeof err === 'string' ? err : 'Failed to approve entry'
+        setActionError(msg)
+      }
+    },
+    [fetchEntries, refreshCounts]
+  )
+
+  /** Post an approved entry */
   const handlePost = useCallback(
     async (id: number) => {
       setActionError(null)
@@ -176,38 +244,89 @@ const JournalEntries: React.FC = () => {
         refreshCounts()
       } catch (err) {
         const msg = typeof err === 'string' ? err : 'Failed to post entry'
-        console.error('Failed to post entry:', err)
         setActionError(msg)
       }
     },
     [fetchEntries, refreshCounts]
   )
 
+  /** Void a posted entry (with confirmation) */
   const handleVoid = useCallback(
     async (id: number) => {
+      setActionError(null)
       try {
         await invoke('void_journal_entry', { id })
+        setVoidConfirmId(null)
         fetchEntries()
         refreshCounts()
       } catch (err) {
-        console.error('Failed to void entry:', err)
+        const msg = typeof err === 'string' ? err : 'Failed to void entry'
+        setActionError(msg)
       }
     },
     [fetchEntries, refreshCounts]
   )
 
+  /** Demote an approved entry back to draft for editing */
+  const handleDemote = useCallback(
+    async (entry: JournalEntryWithLines) => {
+      setActionError(null)
+      try {
+        await invoke('void_journal_entry', { id: entry.id })
+        const input = {
+          entry_date: new Date(entry.entryDate).toISOString().split('T')[0],
+          description: entry.description ?? '',
+          reference_number: entry.referenceNumber ?? null,
+          raw_transaction_id: null,
+          lines: entry.lines.map(l => ({
+            gl_account_id: l.glAccountId,
+            token_id: l.tokenId ?? null,
+            debit_minor: l.debitMinor,
+            credit_minor: l.creditMinor,
+            quantity: l.quantity ?? null,
+            asset_id: l.assetId ?? 'USD',
+            description: l.description ?? null,
+          })),
+        }
+        const newDraft = await invoke<JournalEntryWithLines>(
+          'create_journal_entry',
+          { input }
+        )
+        fetchEntries()
+        refreshCounts()
+        handleEditEntry(newDraft)
+      } catch (err) {
+        const msg = typeof err === 'string' ? err : 'Failed to demote entry'
+        setActionError(msg)
+      }
+    },
+    [fetchEntries, refreshCounts, handleEditEntry]
+  )
+
+  const handleDismissError = useCallback(() => setActionError(null), [])
+
+  const handleDismissVoidConfirm = useCallback(
+    () => setVoidConfirmId(null),
+    []
+  )
+
+  const resolveAccountName = useCallback(
+    (glAccountId: number) => {
+      const acct = accountMap.get(glAccountId)
+      return acct
+        ? `${acct.accountNumber} \u00b7 ${acct.accountName}`
+        : `#${glAccountId}`
+    },
+    [accountMap]
+  )
+
   const tabs: { key: StatusFilter; label: string }[] = [
     { key: 'all', label: 'All' },
     { key: 'draft', label: 'Drafts' },
+    { key: 'approved', label: 'Approved' },
     { key: 'posted', label: 'Posted' },
+    { key: 'voided', label: 'Voided' },
   ]
-
-  const resolveAccountName = (glAccountId: number) => {
-    const acct = accountMap.get(glAccountId)
-    return acct
-      ? `${acct.accountNumber} · ${acct.accountName}`
-      : `#${glAccountId}`
-  }
 
   return (
     <div className="p-4 sm:p-6 lg:p-8 max-w-7xl mx-auto">
@@ -218,7 +337,7 @@ const JournalEntries: React.FC = () => {
             Journal Entries
           </h1>
           <p className="text-sm text-[#294050] dark:text-[#9FB4BE] mt-1">
-            Double-entry bookkeeping records
+            Approval queue &middot; draft &rarr; approve &rarr; post
           </p>
         </div>
         <button
@@ -235,6 +354,7 @@ const JournalEntries: React.FC = () => {
         {tabs.map(tab => (
           <button
             key={tab.key}
+            data-tab={tab.key}
             onClick={() => handleTabChange(tab.key)}
             className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
               filterParam === tab.key
@@ -252,11 +372,36 @@ const JournalEntries: React.FC = () => {
         <div className="mb-4 flex items-center justify-between p-3 rounded-lg bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 text-sm">
           <span>{actionError}</span>
           <button
-            onClick={() => setActionError(null)}
+            onClick={handleDismissError}
             className="ml-4 text-red-500 hover:text-red-700 dark:hover:text-red-200 font-medium"
           >
             Dismiss
           </button>
+        </div>
+      )}
+
+      {/* Void confirmation dialog */}
+      {voidConfirmId !== null && (
+        <div className="mb-4 flex items-center justify-between p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-300 text-sm">
+          <span>
+            Voiding this entry will generate a reversing entry that nets it to
+            zero in the ledger. The original and reversing entries both remain
+            visible. Continue?
+          </span>
+          <div className="flex gap-2 ml-4">
+            <button
+              onClick={handleDismissVoidConfirm}
+              className="px-3 py-1 text-xs font-medium rounded border border-amber-400 text-amber-700 dark:text-amber-300 hover:bg-amber-100 dark:hover:bg-amber-900/40 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => handleVoid(voidConfirmId)}
+              className="px-3 py-1 text-xs font-medium rounded bg-red-600 text-white hover:bg-red-700 transition-colors"
+            >
+              Void Entry
+            </button>
+          </div>
         </div>
       )}
 
@@ -303,7 +448,7 @@ const JournalEntries: React.FC = () => {
                   Description
                 </th>
                 <th className="px-4 py-3 text-left text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider">
-                  Reference
+                  Origin
                 </th>
                 <th className="px-4 py-3 text-right text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider">
                   Debits
@@ -321,7 +466,7 @@ const JournalEntries: React.FC = () => {
             </thead>
             <tbody className="divide-y divide-[rgba(95,227,192,0.1)]">
               {filteredEntries.map(entry => {
-                const status = getEntryStatus(entry)
+                const status = displayStatus(entry)
                 const totalDebits = entry.lines.reduce(
                   (sum, l) => sum + l.debitMinor,
                   0
@@ -331,11 +476,6 @@ const JournalEntries: React.FC = () => {
                   0
                 )
                 const isExpanded = expandedId === entry.id
-                const refDisplay = entry.referenceNumber
-                  ? entry.referenceNumber.length > 12
-                    ? `${entry.referenceNumber.slice(0, 12)}…`
-                    : entry.referenceNumber
-                  : '—'
 
                 return (
                   <React.Fragment key={entry.id}>
@@ -354,22 +494,19 @@ const JournalEntries: React.FC = () => {
                         {formatDate(entry.entryDate)}
                       </td>
                       <td className="px-4 py-3 text-sm font-mono text-[#294050] dark:text-[#9FB4BE]">
-                        {entry.entryNumber ?? '—'}
+                        {entry.entryNumber ?? '\u2014'}
                       </td>
                       <td className="px-4 py-3 text-sm text-[#11202B] dark:text-[#EAF3F2] max-w-xs truncate">
-                        {entry.description ?? '—'}
+                        {entry.description ?? '\u2014'}
                       </td>
-                      <td
-                        className="px-4 py-3 text-sm font-mono text-[#294050] dark:text-[#9FB4BE]"
-                        title={entry.referenceNumber ?? undefined}
-                      >
-                        {refDisplay}
+                      <td className="px-4 py-3 text-xs text-[#294050] dark:text-[#9FB4BE]">
+                        {originLabels[entry.origin] ?? entry.origin}
                       </td>
                       <td className="px-4 py-3 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
-                        {(totalDebits / 100).toFixed(2)}
+                        {minorToDollars(totalDebits)}
                       </td>
                       <td className="px-4 py-3 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
-                        {(totalCredits / 100).toFixed(2)}
+                        {minorToDollars(totalCredits)}
                       </td>
                       <td className="px-4 py-3 text-center">
                         <StatusBadge status={status} />
@@ -379,22 +516,48 @@ const JournalEntries: React.FC = () => {
                           className="flex items-center justify-end gap-2"
                           onClick={e => e.stopPropagation()}
                         >
+                          {/* Draft actions: Approve */}
                           {status === 'draft' && (
                             <button
-                              onClick={() => handlePost(entry.id)}
-                              className="px-2 py-1 text-xs font-medium rounded bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300 hover:bg-emerald-200 dark:hover:bg-emerald-900/50 transition-colors"
+                              onClick={() => handleApprove(entry.id)}
+                              className="px-2 py-1 text-xs font-medium rounded bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-900/50 transition-colors"
                             >
-                              Post
+                              Approve
                             </button>
                           )}
+                          {/* Approved actions: Post, Demote */}
+                          {status === 'approved' && (
+                            <>
+                              <button
+                                onClick={() => handlePost(entry.id)}
+                                className="px-2 py-1 text-xs font-medium rounded bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300 hover:bg-emerald-200 dark:hover:bg-emerald-900/50 transition-colors"
+                              >
+                                Post
+                              </button>
+                              <button
+                                onClick={() => handleDemote(entry)}
+                                className="px-2 py-1 text-xs font-medium rounded bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 hover:bg-amber-200 dark:hover:bg-amber-900/50 transition-colors"
+                              >
+                                Demote
+                              </button>
+                            </>
+                          )}
+                          {/* Posted actions: Void */}
                           {status === 'posted' && (
                             <button
-                              onClick={() => handleVoid(entry.id)}
+                              onClick={() => setVoidConfirmId(entry.id)}
                               className="px-2 py-1 text-xs font-medium rounded bg-gray-100 text-gray-600 dark:bg-gray-800/50 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700/50 transition-colors"
                             >
                               Void
                             </button>
                           )}
+                          {/* Detail view for all */}
+                          <button
+                            onClick={() => handleViewDetail(entry)}
+                            className="px-2 py-1 text-xs font-medium rounded border border-[rgba(95,227,192,0.2)] text-[#294050] dark:text-[#9FB4BE] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F] transition-colors"
+                          >
+                            Detail
+                          </button>
                         </div>
                       </td>
                     </tr>
@@ -402,10 +565,40 @@ const JournalEntries: React.FC = () => {
                     {isExpanded && entry.lines.length > 0 && (
                       <tr className="bg-[#F7FAFA] dark:bg-[#0C141B]">
                         <td colSpan={9} className="px-8 py-3">
+                          {/* Provenance info */}
+                          <div className="flex flex-wrap gap-4 mb-3 text-xs text-[#294050] dark:text-[#9FB4BE]">
+                            <span>
+                              Created by: {entry.createdBy ?? 'system'}
+                            </span>
+                            {entry.approvedBy && (
+                              <span>
+                                Approved by: {entry.approvedBy} (
+                                {formatDateTime(entry.approvedAt)})
+                              </span>
+                            )}
+                            {entry.postedAt && (
+                              <span>
+                                Posted: {formatDateTime(entry.postedAt)}
+                              </span>
+                            )}
+                            {entry.referenceNumber && (
+                              <span
+                                className="font-mono"
+                                title={entry.referenceNumber}
+                              >
+                                Ref:{' '}
+                                {entry.referenceNumber.length > 20
+                                  ? `${entry.referenceNumber.slice(0, 20)}\u2026`
+                                  : entry.referenceNumber}
+                              </span>
+                            )}
+                          </div>
                           <table className="w-full text-sm">
                             <thead>
                               <tr className="text-xs uppercase text-[#294050] dark:text-[#9FB4BE]">
-                                <th className="text-left py-1 pr-4">Account</th>
+                                <th className="text-left py-1 pr-4">
+                                  Account
+                                </th>
                                 <th className="text-right py-1 px-4 w-32">
                                   Debit
                                 </th>
@@ -426,12 +619,12 @@ const JournalEntries: React.FC = () => {
                                   </td>
                                   <td className="py-1.5 px-4 text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
                                     {line.debitMinor > 0
-                                      ? (line.debitMinor / 100).toFixed(2)
+                                      ? minorToDollars(line.debitMinor)
                                       : ''}
                                   </td>
                                   <td className="py-1.5 px-4 text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
                                     {line.creditMinor > 0
-                                      ? (line.creditMinor / 100).toFixed(2)
+                                      ? minorToDollars(line.creditMinor)
                                       : ''}
                                   </td>
                                   <td className="py-1.5 pl-4 text-[#294050] dark:text-[#9FB4BE]">
@@ -452,13 +645,23 @@ const JournalEntries: React.FC = () => {
         </div>
       )}
 
-      {/* Journal Entry Creation Drawer */}
+      {/* Journal Entry Creation/Edit Drawer */}
       {drawerOpen && (
         <JournalEntryDrawer
           accounts={accounts}
           entry={editingEntry}
           onClose={handleCloseDrawer}
           onSaved={handleSaved}
+        />
+      )}
+
+      {/* Entry Detail View */}
+      {detailEntry !== undefined && (
+        <JournalEntryDetail
+          entry={detailEntry}
+          accounts={accounts}
+          entries={entries}
+          onClose={handleCloseDetail}
         />
       )}
     </div>

--- a/src/app/journal-entries/JournalEntryDetail.tsx
+++ b/src/app/journal-entries/JournalEntryDetail.tsx
@@ -159,9 +159,7 @@ const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
                 {entry.isReversed && !reversalEntry && (
                   <span>
                     This entry has been voided. Reversed by entry ID:{' '}
-                    <span className="font-mono">
-                      {entry.reversedByEntryId}
-                    </span>
+                    <span className="font-mono">{entry.reversedByEntryId}</span>
                   </span>
                 )}
                 {isReversing && reversalEntry && (
@@ -170,14 +168,14 @@ const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
                     <span className="font-mono font-medium">
                       {reversalEntry.entryNumber}
                     </span>{' '}
-                    ({formatDate(reversalEntry.entryDate)}). Both entries
-                    remain in the ledger with a net effect of zero.
+                    ({formatDate(reversalEntry.entryDate)}). Both entries remain
+                    in the ledger with a net effect of zero.
                   </span>
                 )}
                 {isReversing && !reversalEntry && (
                   <span>
-                    This is a reversing entry. {entry.description}. Both
-                    entries remain in the ledger with a net effect of zero.
+                    This is a reversing entry. {entry.description}. Both entries
+                    remain in the ledger with a net effect of zero.
                   </span>
                 )}
               </div>
@@ -320,10 +318,7 @@ const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
                 </thead>
                 <tbody className="divide-y divide-[rgba(95,227,192,0.08)]">
                   {entry.lines.map(line => (
-                    <tr
-                      key={line.id}
-                      className="bg-white dark:bg-[#11202B]"
-                    >
+                    <tr key={line.id} className="bg-white dark:bg-[#11202B]">
                       <td className="px-4 py-2 text-[#11202B] dark:text-[#EAF3F2]">
                         {resolveAccountName(line.glAccountId)}
                       </td>

--- a/src/app/journal-entries/JournalEntryDetail.tsx
+++ b/src/app/journal-entries/JournalEntryDetail.tsx
@@ -1,0 +1,387 @@
+import React, { useMemo } from 'react'
+import {
+  X,
+  Clock,
+  CheckCircle2,
+  ShieldCheck,
+  XCircle,
+  ArrowRightLeft,
+} from 'lucide-react'
+import type { GLAccount, JournalEntryWithLines } from '../../types/database'
+import {
+  displayStatus as displayStatusUtil,
+  formatDate,
+  formatDateTime,
+  minorToDollars,
+} from './journalEntryUtils'
+
+interface JournalEntryDetailProps {
+  entry: JournalEntryWithLines
+  accounts: GLAccount[]
+  entries: JournalEntryWithLines[]
+  onClose: () => void
+}
+
+const statusConfig = {
+  draft: {
+    label: 'Draft',
+    icon: Clock,
+    className:
+      'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+  },
+  approved: {
+    label: 'Approved',
+    icon: ShieldCheck,
+    className:
+      'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  },
+  posted: {
+    label: 'Posted',
+    icon: CheckCircle2,
+    className:
+      'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300',
+  },
+  voided: {
+    label: 'Voided',
+    icon: XCircle,
+    className:
+      'bg-gray-100 text-gray-600 dark:bg-gray-800/50 dark:text-gray-400',
+  },
+} as const
+
+const originLabels: Record<string, string> = {
+  manual: 'Manual',
+  rule: 'Rule',
+  model: 'Model',
+}
+
+/**
+ * Full detail view for a journal entry.
+ * Shows lines, lifecycle timestamps, provenance (origin, created_by),
+ * and reversal linkage: a voided entry links to its reversing entry
+ * and vice versa.
+ * @param props - Component properties
+ * @returns The JournalEntryDetail overlay component
+ */
+const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
+  entry,
+  accounts,
+  entries,
+  onClose,
+}) => {
+  const accountMap = useMemo(() => {
+    const m = new Map<number, GLAccount>()
+    accounts.forEach(a => m.set(a.id, a))
+    return m
+  }, [accounts])
+
+  const resolveAccountName = (glAccountId: number) => {
+    const acct = accountMap.get(glAccountId)
+    return acct
+      ? `${acct.accountNumber} \u00b7 ${acct.accountName}`
+      : `#${glAccountId}`
+  }
+
+  const status = displayStatusUtil(entry.status)
+  const cfg = statusConfig[status]
+  const StatusIcon = cfg.icon
+
+  const totalDebits = entry.lines.reduce((s, l) => s + l.debitMinor, 0)
+  const totalCredits = entry.lines.reduce((s, l) => s + l.creditMinor, 0)
+
+  /** Find the linked reversal entry if one exists */
+  const reversalEntry = useMemo(() => {
+    if (entry.reversedByEntryId) {
+      return entries.find(e => e.id === entry.reversedByEntryId)
+    }
+    if (
+      entry.description &&
+      entry.description.startsWith('Reversal of entry #')
+    ) {
+      const originalNumber = entry.description.replace(
+        'Reversal of entry #',
+        ''
+      )
+      return entries.find(e => e.entryNumber === originalNumber)
+    }
+    return undefined
+  }, [entry, entries])
+
+  const isReversing =
+    entry.description !== undefined &&
+    entry.description !== null &&
+    entry.description.startsWith('Reversal of entry #')
+
+  return (
+    // skipcq: JS-0415 — detail overlay requires nested containers
+    <div className="fixed inset-0 z-50 flex justify-end">
+      {/* Backdrop */}
+      <div className="fixed inset-0 bg-black/40" onClick={onClose} />
+      {/* Detail panel */}
+      <div className="relative w-full max-w-3xl bg-[#F7FAFA] dark:bg-[#11202B] shadow-xl flex flex-col overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-[rgba(95,227,192,0.15)]">
+          <div className="flex items-center gap-3">
+            <h2 className="text-lg font-bold text-[#11202B] dark:text-[#EAF3F2]">
+              {entry.entryNumber ?? 'Journal Entry'}
+            </h2>
+            <span
+              className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${cfg.className}`}
+            >
+              <StatusIcon className="w-3 h-3" />
+              {cfg.label}
+            </span>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 rounded-lg text-[#294050] hover:text-[#11202B] dark:hover:text-[#EAF3F2] transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6">
+          {/* Reversal linkage banner */}
+          {(entry.isReversed || isReversing) && (
+            <div className="flex items-center gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-800/30 border border-gray-200 dark:border-gray-700">
+              <ArrowRightLeft className="w-5 h-5 text-gray-500 dark:text-gray-400 flex-shrink-0" />
+              <div className="text-sm text-gray-700 dark:text-gray-300">
+                {entry.isReversed && reversalEntry && (
+                  <span>
+                    This entry has been voided. Reversing entry:{' '}
+                    <span className="font-mono font-medium">
+                      {reversalEntry.entryNumber}
+                    </span>{' '}
+                    ({formatDate(reversalEntry.entryDate)})
+                  </span>
+                )}
+                {entry.isReversed && !reversalEntry && (
+                  <span>
+                    This entry has been voided. Reversed by entry ID:{' '}
+                    <span className="font-mono">
+                      {entry.reversedByEntryId}
+                    </span>
+                  </span>
+                )}
+                {isReversing && reversalEntry && (
+                  <span>
+                    This is a reversing entry for{' '}
+                    <span className="font-mono font-medium">
+                      {reversalEntry.entryNumber}
+                    </span>{' '}
+                    ({formatDate(reversalEntry.entryDate)}). Both entries
+                    remain in the ledger with a net effect of zero.
+                  </span>
+                )}
+                {isReversing && !reversalEntry && (
+                  <span>
+                    This is a reversing entry. {entry.description}. Both
+                    entries remain in the ledger with a net effect of zero.
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Entry metadata grid */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-xs font-medium text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider mb-1">
+                Entry Date
+              </label>
+              <span className="text-sm text-[#11202B] dark:text-[#EAF3F2]">
+                {formatDate(entry.entryDate)}
+              </span>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider mb-1">
+                Entry Number
+              </label>
+              <span className="text-sm font-mono text-[#11202B] dark:text-[#EAF3F2]">
+                {entry.entryNumber ?? '\u2014'}
+              </span>
+            </div>
+            <div className="col-span-2">
+              <label className="block text-xs font-medium text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider mb-1">
+                Description
+              </label>
+              <span className="text-sm text-[#11202B] dark:text-[#EAF3F2]">
+                {entry.description ?? '\u2014'}
+              </span>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider mb-1">
+                Reference
+              </label>
+              <span className="text-sm font-mono text-[#11202B] dark:text-[#EAF3F2] break-all">
+                {entry.referenceNumber ?? '\u2014'}
+              </span>
+            </div>
+            <div>
+              <label className="block text-xs font-medium text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider mb-1">
+                Origin
+              </label>
+              <span className="text-sm text-[#11202B] dark:text-[#EAF3F2]">
+                {originLabels[entry.origin] ?? entry.origin}
+              </span>
+            </div>
+          </div>
+
+          {/* Lifecycle timestamps */}
+          <div>
+            <h3 className="text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider mb-3">
+              Lifecycle
+            </h3>
+            <div className="space-y-2">
+              <div className="flex items-center gap-3 text-sm">
+                <Clock className="w-4 h-4 text-[#647D8B]" />
+                <span className="text-[#294050] dark:text-[#9FB4BE] w-24">
+                  Created
+                </span>
+                <span className="text-[#11202B] dark:text-[#EAF3F2]">
+                  {formatDateTime(entry.createdAt)}
+                </span>
+                {entry.createdBy && (
+                  <span className="text-xs text-[#647D8B]">
+                    by {entry.createdBy}
+                  </span>
+                )}
+              </div>
+              {entry.approvedAt && (
+                <div className="flex items-center gap-3 text-sm">
+                  <ShieldCheck className="w-4 h-4 text-blue-500" />
+                  <span className="text-[#294050] dark:text-[#9FB4BE] w-24">
+                    Approved
+                  </span>
+                  <span className="text-[#11202B] dark:text-[#EAF3F2]">
+                    {formatDateTime(entry.approvedAt)}
+                  </span>
+                  {entry.approvedBy && (
+                    <span className="text-xs text-[#647D8B]">
+                      by {entry.approvedBy}
+                    </span>
+                  )}
+                </div>
+              )}
+              {entry.postedAt && (
+                <div className="flex items-center gap-3 text-sm">
+                  <CheckCircle2 className="w-4 h-4 text-emerald-500" />
+                  <span className="text-[#294050] dark:text-[#9FB4BE] w-24">
+                    Posted
+                  </span>
+                  <span className="text-[#11202B] dark:text-[#EAF3F2]">
+                    {formatDateTime(entry.postedAt)}
+                  </span>
+                </div>
+              )}
+              {entry.status === 'voided' && (
+                <div className="flex items-center gap-3 text-sm">
+                  <XCircle className="w-4 h-4 text-gray-500" />
+                  <span className="text-[#294050] dark:text-[#9FB4BE] w-24">
+                    Voided
+                  </span>
+                  <span className="text-[#11202B] dark:text-[#EAF3F2]">
+                    {formatDateTime(entry.updatedAt)}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Entry lines table */}
+          <div>
+            <h3 className="text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider mb-3">
+              Lines
+            </h3>
+            <div className="border border-[rgba(95,227,192,0.15)] rounded-lg overflow-hidden">
+              <table className="min-w-full text-sm">
+                <thead>
+                  <tr className="bg-[#EAF3F2] dark:bg-[#16242F]">
+                    <th className="px-4 py-2 text-left text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase">
+                      Account
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase">
+                      Asset
+                    </th>
+                    <th className="px-4 py-2 text-right text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase">
+                      Qty
+                    </th>
+                    <th className="px-4 py-2 text-right text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase w-28">
+                      Debit
+                    </th>
+                    <th className="px-4 py-2 text-right text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase w-28">
+                      Credit
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase">
+                      Memo
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-[rgba(95,227,192,0.08)]">
+                  {entry.lines.map(line => (
+                    <tr
+                      key={line.id}
+                      className="bg-white dark:bg-[#11202B]"
+                    >
+                      <td className="px-4 py-2 text-[#11202B] dark:text-[#EAF3F2]">
+                        {resolveAccountName(line.glAccountId)}
+                      </td>
+                      <td className="px-4 py-2 font-mono text-xs text-[#294050] dark:text-[#9FB4BE]">
+                        {line.assetId ?? '\u2014'}
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono text-[#294050] dark:text-[#9FB4BE]">
+                        {line.quantity ?? ''}
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+                        {line.debitMinor > 0
+                          ? minorToDollars(line.debitMinor)
+                          : ''}
+                      </td>
+                      <td className="px-4 py-2 text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+                        {line.creditMinor > 0
+                          ? minorToDollars(line.creditMinor)
+                          : ''}
+                      </td>
+                      <td className="px-4 py-2 text-[#294050] dark:text-[#9FB4BE]">
+                        {line.description ?? ''}
+                      </td>
+                    </tr>
+                  ))}
+                  {/* Totals row */}
+                  <tr className="bg-[#EAF3F2]/50 dark:bg-[#16242F]/50 font-medium">
+                    <td
+                      colSpan={3}
+                      className="px-4 py-2 text-right text-xs uppercase text-[#294050] dark:text-[#9FB4BE]"
+                    >
+                      Totals
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+                      {minorToDollars(totalDebits)}
+                    </td>
+                    <td className="px-4 py-2 text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+                      {minorToDollars(totalCredits)}
+                    </td>
+                    <td className="px-4 py-2" />
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end px-6 py-4 border-t border-[rgba(95,227,192,0.15)]">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm rounded-lg border border-[rgba(95,227,192,0.15)] text-[#294050] dark:text-[#9FB4BE] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F] transition-colors"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default JournalEntryDetail

--- a/src/app/journal-entries/JournalEntryDrawer.tsx
+++ b/src/app/journal-entries/JournalEntryDrawer.tsx
@@ -66,10 +66,8 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
       ? entry.lines.map(l => ({
           id: nextLineId(),
           glAccountId: l.glAccountId,
-          debitAmount:
-            l.debitMinor > 0 ? minorToDollars(l.debitMinor) : '',
-          creditAmount:
-            l.creditMinor > 0 ? minorToDollars(l.creditMinor) : '',
+          debitAmount: l.debitMinor > 0 ? minorToDollars(l.debitMinor) : '',
+          creditAmount: l.creditMinor > 0 ? minorToDollars(l.creditMinor) : '',
           quantity: l.quantity ?? '',
           assetId: l.assetId ?? 'USD',
           description: l.description ?? '',
@@ -416,33 +414,31 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
           {/* Per-asset quantity balance hints */}
           {assetQuantityHints.size > 0 && (
             <div className="space-y-1">
-              {Array.from(assetQuantityHints.entries()).map(
-                ([asset, bal]) => {
-                  const net = bal.debit - bal.credit
-                  const balanced = Math.abs(net) < 1e-12
-                  return (
-                    <div
-                      key={asset}
-                      className={`flex items-center justify-between px-3 py-1.5 rounded text-xs ${
-                        balanced
-                          ? 'bg-[#5FE3C0]/5 text-[#294050] dark:text-[#9FB4BE]'
-                          : 'bg-amber-50 dark:bg-amber-900/10 text-amber-700 dark:text-amber-400'
-                      }`}
-                    >
-                      <span className="font-mono">{asset}</span>
-                      <span>
-                        DR {bal.debit} / CR {bal.credit}
-                        {!balanced && (
-                          <span className="ml-2 font-medium">
-                            (net {net > 0 ? '+' : ''}
-                            {net})
-                          </span>
-                        )}
-                      </span>
-                    </div>
-                  )
-                }
-              )}
+              {Array.from(assetQuantityHints.entries()).map(([asset, bal]) => {
+                const net = bal.debit - bal.credit
+                const balanced = Math.abs(net) < 1e-12
+                return (
+                  <div
+                    key={asset}
+                    className={`flex items-center justify-between px-3 py-1.5 rounded text-xs ${
+                      balanced
+                        ? 'bg-[#5FE3C0]/5 text-[#294050] dark:text-[#9FB4BE]'
+                        : 'bg-amber-50 dark:bg-amber-900/10 text-amber-700 dark:text-amber-400'
+                    }`}
+                  >
+                    <span className="font-mono">{asset}</span>
+                    <span>
+                      DR {bal.debit} / CR {bal.credit}
+                      {!balanced && (
+                        <span className="ml-2 font-medium">
+                          (net {net > 0 ? '+' : ''}
+                          {net})
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                )
+              })}
             </div>
           )}
         </div>

--- a/src/app/journal-entries/JournalEntryDrawer.tsx
+++ b/src/app/journal-entries/JournalEntryDrawer.tsx
@@ -142,31 +142,39 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
     setError(null)
     setSaving(true)
     try {
+      // Keys are camelCase: NewJournalEntryInput / JournalEntryLineInput are
+      // #[serde(rename_all = "camelCase")] on the Rust side.
       const input = {
-        entry_date: entryDate,
+        entryDate,
         description,
-        reference_number: referenceNumber || null,
-        raw_transaction_id: null,
+        referenceNumber: referenceNumber || null,
+        rawTransactionId: null,
         lines: lines
           .filter(l => l.glAccountId !== '')
           .map(l => ({
-            gl_account_id: l.glAccountId as number,
-            token_id: null,
-            debit_minor: toMinorUnits(l.debitAmount),
-            credit_minor: toMinorUnits(l.creditAmount),
+            glAccountId: l.glAccountId as number,
+            tokenId: null,
+            debitMinor: toMinorUnits(l.debitAmount),
+            creditMinor: toMinorUnits(l.creditAmount),
             quantity: l.quantity || null,
-            asset_id: l.assetId || 'USD',
+            assetId: l.assetId || 'USD',
             description: l.description || null,
           })),
       }
-      await invoke('create_journal_entry', { input })
+      if (isEditDraft && entry) {
+        // Edit-in-place: creating a new entry here would leave a duplicate
+        // draft in the queue.
+        await invoke('update_journal_entry', { id: entry.id, input })
+      } else {
+        await invoke('create_journal_entry', { input })
+      }
       onSaved()
     } catch (err) {
       setError(typeof err === 'string' ? err : 'Failed to save entry')
     } finally {
       setSaving(false)
     }
-  }, [entryDate, description, referenceNumber, lines, onSaved])
+  }, [entryDate, description, referenceNumber, lines, isEditDraft, entry, onSaved])
 
   const isEditable = !isView || isEditDraft
 

--- a/src/app/journal-entries/JournalEntryDrawer.tsx
+++ b/src/app/journal-entries/JournalEntryDrawer.tsx
@@ -174,7 +174,15 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
     } finally {
       setSaving(false)
     }
-  }, [entryDate, description, referenceNumber, lines, isEditDraft, entry, onSaved])
+  }, [
+    entryDate,
+    description,
+    referenceNumber,
+    lines,
+    isEditDraft,
+    entry,
+    onSaved,
+  ])
 
   const isEditable = !isView || isEditDraft
 

--- a/src/app/journal-entries/JournalEntryDrawer.tsx
+++ b/src/app/journal-entries/JournalEntryDrawer.tsx
@@ -2,12 +2,15 @@ import React, { useState, useCallback, useMemo } from 'react'
 import { invoke } from '@tauri-apps/api/core'
 import { X, Plus, Trash2 } from 'lucide-react'
 import type { GLAccount, JournalEntryWithLines } from '../../types/database'
+import { toMinorUnits, minorToDollars } from './journalEntryUtils'
 
 interface LineInput {
   id: string
   glAccountId: number | ''
   debitAmount: string
   creditAmount: string
+  quantity: string
+  assetId: string
   description: string
 }
 
@@ -29,10 +32,17 @@ const emptyLine = (): LineInput => ({
   glAccountId: '',
   debitAmount: '',
   creditAmount: '',
+  quantity: '',
+  assetId: 'USD',
   description: '',
 })
 
-/** Slide-in drawer for creating/viewing a journal entry */
+/**
+ * Slide-in drawer for creating/editing draft journal entries.
+ * Editing an approved entry requires demote-to-draft first (backend enforces).
+ * @param props - Component properties
+ * @returns The JournalEntryDrawer component
+ */
 const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
   accounts,
   entry,
@@ -40,7 +50,8 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
   onClose,
   onSaved,
 }) => {
-  const isView = Boolean(entry)
+  const isView = Boolean(entry) && entry?.status !== 'draft'
+  const isEditDraft = Boolean(entry) && entry?.status === 'draft'
   const [entryDate, setEntryDate] = useState(
     entry?.entryDate
       ? new Date(entry.entryDate).toISOString().split('T')[0]
@@ -55,9 +66,12 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
       ? entry.lines.map(l => ({
           id: nextLineId(),
           glAccountId: l.glAccountId,
-          debitAmount: l.debitMinor > 0 ? (l.debitMinor / 100).toFixed(2) : '',
+          debitAmount:
+            l.debitMinor > 0 ? minorToDollars(l.debitMinor) : '',
           creditAmount:
-            l.creditMinor > 0 ? (l.creditMinor / 100).toFixed(2) : '',
+            l.creditMinor > 0 ? minorToDollars(l.creditMinor) : '',
+          quantity: l.quantity ?? '',
+          assetId: l.assetId ?? 'USD',
           description: l.description ?? '',
         }))
       : [emptyLine(), emptyLine()]
@@ -65,28 +79,46 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const totalDebits = useMemo(
-    () => lines.reduce((s, l) => s + (parseFloat(l.debitAmount) || 0), 0),
+  /** Compute balance in integer minor units (no floats touching money). */
+  const totalDebitMinor = useMemo(
+    () => lines.reduce((s, l) => s + toMinorUnits(l.debitAmount), 0),
     [lines]
   )
-  const totalCredits = useMemo(
-    () => lines.reduce((s, l) => s + (parseFloat(l.creditAmount) || 0), 0),
+  const totalCreditMinor = useMemo(
+    () => lines.reduce((s, l) => s + toMinorUnits(l.creditAmount), 0),
     [lines]
   )
-  const difference = Math.abs(totalDebits - totalCredits)
-  const isBalanced = difference < 0.01 && totalDebits > 0
+  const differenceMinor = totalDebitMinor - totalCreditMinor
+  const isBalanced = differenceMinor === 0 && totalDebitMinor > 0
+
+  /** Per-asset quantity balance hints. */
+  const assetQuantityHints = useMemo(() => {
+    const map = new Map<string, { debit: number; credit: number }>()
+    for (const l of lines) {
+      if (!l.quantity || !l.assetId || l.assetId === 'USD') continue
+      const qty = Number.parseFloat(l.quantity)
+      if (Number.isNaN(qty) || qty === 0) continue
+      const existing = map.get(l.assetId) ?? { debit: 0, credit: 0 }
+      if (toMinorUnits(l.debitAmount) > 0) {
+        existing.debit += qty
+      } else {
+        existing.credit += qty
+      }
+      map.set(l.assetId, existing)
+    }
+    return map
+  }, [lines])
 
   const handleLineChange = useCallback(
     (index: number, field: keyof LineInput, value: string | number) => {
       setLines(prev => {
         const updated = [...prev]
         updated[index] = { ...updated[index], [field]: value }
-        // If entering a debit, clear credit (and vice versa)
-        if (field === 'debitAmount' && parseFloat(value as string) > 0) {
+        if (field === 'debitAmount' && toMinorUnits(value as string) > 0) {
           updated[index].creditAmount = ''
         } else if (
           field === 'creditAmount' &&
-          parseFloat(value as string) > 0
+          toMinorUnits(value as string) > 0
         ) {
           updated[index].debitAmount = ''
         }
@@ -108,10 +140,6 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
     [lines.length]
   )
 
-  /** Converts a dollar string to integer minor units (cents). */
-  const toMinor = (val: string): number =>
-    Math.round((parseFloat(val) || 0) * 100)
-
   const handleSaveDraft = useCallback(async () => {
     setError(null)
     setSaving(true)
@@ -126,10 +154,10 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
           .map(l => ({
             gl_account_id: l.glAccountId as number,
             token_id: null,
-            debit_minor: toMinor(l.debitAmount),
-            credit_minor: toMinor(l.creditAmount),
-            quantity: null,
-            asset_id: 'USD',
+            debit_minor: toMinorUnits(l.debitAmount),
+            credit_minor: toMinorUnits(l.creditAmount),
+            quantity: l.quantity || null,
+            asset_id: l.assetId || 'USD',
             description: l.description || null,
           })),
       }
@@ -142,39 +170,7 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
     }
   }, [entryDate, description, referenceNumber, lines, onSaved])
 
-  const handlePostEntry = useCallback(async () => {
-    setError(null)
-    setSaving(true)
-    try {
-      const input = {
-        entry_date: entryDate,
-        description,
-        reference_number: referenceNumber || null,
-        raw_transaction_id: null,
-        lines: lines
-          .filter(l => l.glAccountId !== '')
-          .map(l => ({
-            gl_account_id: l.glAccountId as number,
-            token_id: null,
-            debit_minor: toMinor(l.debitAmount),
-            credit_minor: toMinor(l.creditAmount),
-            quantity: null,
-            asset_id: 'USD',
-            description: l.description || null,
-          })),
-      }
-      const created = await invoke<JournalEntryWithLines>(
-        'create_journal_entry',
-        { input }
-      )
-      await invoke('post_journal_entry', { id: created.id })
-      onSaved()
-    } catch (err) {
-      setError(typeof err === 'string' ? err : 'Failed to post entry')
-    } finally {
-      setSaving(false)
-    }
-  }, [entryDate, description, referenceNumber, lines, onSaved])
+  const isEditable = !isView || isEditDraft
 
   return (
     // skipcq: JS-0415 — drawer layout requires nested containers
@@ -186,7 +182,11 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-[rgba(95,227,192,0.15)]">
           <h2 className="text-lg font-bold text-[#11202B] dark:text-[#EAF3F2]">
-            {isView ? 'Journal Entry' : 'New Journal Entry'}
+            {isView
+              ? 'Journal Entry'
+              : isEditDraft
+                ? 'Edit Draft'
+                : 'New Journal Entry'}
           </h2>
           <button
             onClick={onClose}
@@ -196,7 +196,7 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
           </button>
         </div>
 
-        {/* Body — scrollable */}
+        {/* Body */}
         <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
           {error && (
             <div className="p-3 rounded-lg bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 text-sm">
@@ -213,7 +213,7 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
               type="date"
               value={entryDate}
               onChange={e => setEntryDate(e.target.value)}
-              disabled={isView}
+              disabled={!isEditable}
               className="w-full px-3 py-2 rounded-lg border border-[rgba(95,227,192,0.15)] bg-white dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2] text-sm disabled:opacity-60"
             />
           </div>
@@ -227,7 +227,7 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
               type="text"
               value={description}
               onChange={e => setDescription(e.target.value)}
-              disabled={isView}
+              disabled={!isEditable}
               placeholder="e.g. Staking reward on Polkadot"
               className="w-full px-3 py-2 rounded-lg border border-[rgba(95,227,192,0.15)] bg-white dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2] text-sm placeholder-[#647D8B] disabled:opacity-60"
             />
@@ -242,7 +242,7 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
               type="text"
               value={referenceNumber}
               onChange={e => setReferenceNumber(e.target.value)}
-              disabled={isView}
+              disabled={!isEditable}
               placeholder="Transaction hash or reference"
               className="w-full px-3 py-2 rounded-lg border border-[rgba(95,227,192,0.15)] bg-white dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2] text-sm font-mono placeholder-[#647D8B] disabled:opacity-60"
             />
@@ -254,7 +254,7 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
               <label className="text-sm font-medium text-[#294050] dark:text-[#9FB4BE]">
                 Line Items
               </label>
-              {!isView && (
+              {isEditable && (
                 <button
                   onClick={handleAddLine}
                   className="flex items-center gap-1 text-xs text-[#294050] hover:text-[#1E2F3C] transition-colors"
@@ -271,7 +271,7 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
                   key={line.id}
                   className="flex gap-2 items-start p-3 rounded-lg border border-[rgba(95,227,192,0.1)] bg-white dark:bg-[#0C141B]"
                 >
-                  {/* Account selector */}
+                  {/* Account + asset + memo */}
                   <div className="flex-1 min-w-0">
                     <select
                       value={line.glAccountId}
@@ -279,29 +279,53 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
                         handleLineChange(
                           idx,
                           'glAccountId',
-                          e.target.value ? parseInt(e.target.value) : ''
+                          e.target.value
+                            ? Number.parseInt(e.target.value, 10)
+                            : ''
                         )
                       }
-                      disabled={isView}
+                      disabled={!isEditable}
                       className="w-full px-2 py-1.5 rounded border border-[rgba(95,227,192,0.15)] bg-white dark:bg-[#11202B] text-[#11202B] dark:text-[#EAF3F2] text-sm disabled:opacity-60"
                     >
                       <option value="">Select account...</option>
                       {accounts.map(a => (
                         <option key={a.id} value={a.id}>
-                          {a.accountNumber} · {a.accountName}
+                          {a.accountNumber} &middot; {a.accountName}
                         </option>
                       ))}
                     </select>
-                    <input
-                      type="text"
-                      value={line.description}
-                      onChange={e =>
-                        handleLineChange(idx, 'description', e.target.value)
-                      }
-                      disabled={isView}
-                      placeholder="Memo"
-                      className="w-full mt-1 px-2 py-1 rounded border border-[rgba(95,227,192,0.1)] bg-transparent text-[#294050] dark:text-[#9FB4BE] text-xs placeholder-[#647D8B] disabled:opacity-60"
-                    />
+                    <div className="flex gap-2 mt-1">
+                      <input
+                        type="text"
+                        value={line.quantity}
+                        onChange={e =>
+                          handleLineChange(idx, 'quantity', e.target.value)
+                        }
+                        disabled={!isEditable}
+                        placeholder="Qty"
+                        className="w-20 px-2 py-1 rounded border border-[rgba(95,227,192,0.1)] bg-transparent text-[#294050] dark:text-[#9FB4BE] text-xs placeholder-[#647D8B] disabled:opacity-60"
+                      />
+                      <input
+                        type="text"
+                        value={line.assetId}
+                        onChange={e =>
+                          handleLineChange(idx, 'assetId', e.target.value)
+                        }
+                        disabled={!isEditable}
+                        placeholder="Asset"
+                        className="w-24 px-2 py-1 rounded border border-[rgba(95,227,192,0.1)] bg-transparent text-[#294050] dark:text-[#9FB4BE] text-xs placeholder-[#647D8B] disabled:opacity-60"
+                      />
+                      <input
+                        type="text"
+                        value={line.description}
+                        onChange={e =>
+                          handleLineChange(idx, 'description', e.target.value)
+                        }
+                        disabled={!isEditable}
+                        placeholder="Memo"
+                        className="flex-1 px-2 py-1 rounded border border-[rgba(95,227,192,0.1)] bg-transparent text-[#294050] dark:text-[#9FB4BE] text-xs placeholder-[#647D8B] disabled:opacity-60"
+                      />
+                    </div>
                   </div>
 
                   {/* Debit */}
@@ -310,14 +334,14 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
                       Debit
                     </label>
                     <input
-                      type="number"
-                      step="0.01"
-                      min="0"
+                      type="text"
+                      inputMode="decimal"
                       value={line.debitAmount}
                       onChange={e =>
                         handleLineChange(idx, 'debitAmount', e.target.value)
                       }
-                      disabled={isView}
+                      disabled={!isEditable}
+                      placeholder="0.00"
                       className="w-full px-2 py-1.5 rounded border border-[rgba(95,227,192,0.15)] bg-white dark:bg-[#11202B] text-[#11202B] dark:text-[#EAF3F2] text-sm text-right font-mono disabled:opacity-60"
                     />
                   </div>
@@ -328,20 +352,20 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
                       Credit
                     </label>
                     <input
-                      type="number"
-                      step="0.01"
-                      min="0"
+                      type="text"
+                      inputMode="decimal"
                       value={line.creditAmount}
                       onChange={e =>
                         handleLineChange(idx, 'creditAmount', e.target.value)
                       }
-                      disabled={isView}
+                      disabled={!isEditable}
+                      placeholder="0.00"
                       className="w-full px-2 py-1.5 rounded border border-[rgba(95,227,192,0.15)] bg-white dark:bg-[#11202B] text-[#11202B] dark:text-[#EAF3F2] text-sm text-right font-mono disabled:opacity-60"
                     />
                   </div>
 
                   {/* Remove */}
-                  {!isView && lines.length > 2 && (
+                  {isEditable && lines.length > 2 && (
                     <button
                       onClick={() => handleRemoveLine(idx)}
                       className="mt-4 p-1 text-[#647D8B] hover:text-red-500 transition-colors"
@@ -354,7 +378,7 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
             </div>
           </div>
 
-          {/* Balance indicator */}
+          {/* Balance indicator — integer math, no floats */}
           <div
             className={`flex items-center justify-between p-3 rounded-lg border ${
               isBalanced
@@ -366,13 +390,13 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
               <span className="text-[#294050] dark:text-[#9FB4BE]">
                 Debits:{' '}
                 <span className="font-mono font-medium text-[#11202B] dark:text-[#EAF3F2]">
-                  {totalDebits.toFixed(2)}
+                  {minorToDollars(totalDebitMinor)}
                 </span>
               </span>
               <span className="text-[#294050] dark:text-[#9FB4BE]">
                 Credits:{' '}
                 <span className="font-mono font-medium text-[#11202B] dark:text-[#EAF3F2]">
-                  {totalCredits.toFixed(2)}
+                  {minorToDollars(totalCreditMinor)}
                 </span>
               </span>
             </div>
@@ -383,13 +407,48 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
                   : 'text-amber-600 dark:text-amber-400'
               }`}
             >
-              {isBalanced ? 'Balanced' : `Off by ${difference.toFixed(2)}`}
+              {isBalanced
+                ? 'Balanced'
+                : `Off by ${minorToDollars(Math.abs(differenceMinor))}`}
             </span>
           </div>
+
+          {/* Per-asset quantity balance hints */}
+          {assetQuantityHints.size > 0 && (
+            <div className="space-y-1">
+              {Array.from(assetQuantityHints.entries()).map(
+                ([asset, bal]) => {
+                  const net = bal.debit - bal.credit
+                  const balanced = Math.abs(net) < 1e-12
+                  return (
+                    <div
+                      key={asset}
+                      className={`flex items-center justify-between px-3 py-1.5 rounded text-xs ${
+                        balanced
+                          ? 'bg-[#5FE3C0]/5 text-[#294050] dark:text-[#9FB4BE]'
+                          : 'bg-amber-50 dark:bg-amber-900/10 text-amber-700 dark:text-amber-400'
+                      }`}
+                    >
+                      <span className="font-mono">{asset}</span>
+                      <span>
+                        DR {bal.debit} / CR {bal.credit}
+                        {!balanced && (
+                          <span className="ml-2 font-medium">
+                            (net {net > 0 ? '+' : ''}
+                            {net})
+                          </span>
+                        )}
+                      </span>
+                    </div>
+                  )
+                }
+              )}
+            </div>
+          )}
         </div>
 
         {/* Footer buttons */}
-        {!isView && (
+        {isEditable && (
           <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-[rgba(95,227,192,0.15)]">
             <button
               onClick={onClose}
@@ -402,16 +461,9 @@ const JournalEntryDrawer: React.FC<JournalEntryDrawerProps> = ({
               disabled={
                 saving || lines.filter(l => l.glAccountId !== '').length < 2
               }
-              className="px-4 py-2 text-sm rounded-lg border border-[#294050] text-[#294050] hover:bg-[#294050]/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Save Draft
-            </button>
-            <button
-              onClick={handlePostEntry}
-              disabled={saving || !isBalanced}
               className="px-4 py-2 text-sm rounded-lg bg-[#294050] text-white hover:bg-[#1E2F3C] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              Post Entry
+              {isEditDraft ? 'Update Draft' : 'Save Draft'}
             </button>
           </div>
         )}

--- a/src/app/journal-entries/__tests__/journalEntryUtils.test.ts
+++ b/src/app/journal-entries/__tests__/journalEntryUtils.test.ts
@@ -53,6 +53,20 @@ describe('toMinorUnits', () => {
     const b = toMinorUnits('0.01')
     expect(a + b).toBe(2000) // exactly $20.00
   })
+
+  it('should preserve the sign of negative amounts', () => {
+    expect(toMinorUnits('-1.50')).toBe(-150)
+    expect(toMinorUnits('-100')).toBe(-10000)
+    // Regression: parseInt('-0') is -0 (not < 0), which used to flip
+    // sub-dollar negatives to positive.
+    expect(toMinorUnits('-0.50')).toBe(-50)
+    expect(toMinorUnits('-0.01')).toBe(-1)
+  })
+
+  it('should handle a leading decimal point', () => {
+    expect(toMinorUnits('.5')).toBe(50)
+    expect(toMinorUnits('.05')).toBe(5)
+  })
 })
 
 describe('minorToDollars', () => {

--- a/src/app/journal-entries/__tests__/journalEntryUtils.test.ts
+++ b/src/app/journal-entries/__tests__/journalEntryUtils.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest'
+import {
+  toMinorUnits,
+  minorToDollars,
+  computeBalance,
+  displayStatus,
+  formatDate,
+} from '../journalEntryUtils'
+
+describe('toMinorUnits', () => {
+  it('should convert whole dollars to cents', () => {
+    expect(toMinorUnits('100')).toBe(10000)
+    expect(toMinorUnits('1')).toBe(100)
+    expect(toMinorUnits('0')).toBe(0)
+  })
+
+  it('should convert dollars and cents', () => {
+    expect(toMinorUnits('123.45')).toBe(12345)
+    expect(toMinorUnits('0.99')).toBe(99)
+    expect(toMinorUnits('0.01')).toBe(1)
+  })
+
+  it('should handle single-digit cents', () => {
+    expect(toMinorUnits('10.5')).toBe(1050)
+    expect(toMinorUnits('1.1')).toBe(110)
+  })
+
+  it('should truncate extra decimal places (no rounding)', () => {
+    expect(toMinorUnits('10.999')).toBe(1099)
+    expect(toMinorUnits('1.555')).toBe(155)
+  })
+
+  it('should return 0 for empty strings', () => {
+    expect(toMinorUnits('')).toBe(0)
+    expect(toMinorUnits('  ')).toBe(0)
+  })
+
+  it('should return 0 for non-numeric strings', () => {
+    expect(toMinorUnits('abc')).toBe(0)
+    expect(toMinorUnits('.')).toBe(0)
+  })
+
+  it('should avoid floating-point errors on classic problem values', () => {
+    // 0.1 + 0.2 !== 0.3 in floating point, but our integer math is exact
+    const a = toMinorUnits('0.10')
+    const b = toMinorUnits('0.20')
+    expect(a + b).toBe(30) // exactly 30 cents
+    expect(a + b).toBe(toMinorUnits('0.30'))
+  })
+
+  it('should handle the float rounding trap 19.99 + 0.01', () => {
+    const a = toMinorUnits('19.99')
+    const b = toMinorUnits('0.01')
+    expect(a + b).toBe(2000) // exactly $20.00
+  })
+})
+
+describe('minorToDollars', () => {
+  it('should format whole dollar amounts', () => {
+    expect(minorToDollars(10000)).toBe('100.00')
+    expect(minorToDollars(100)).toBe('1.00')
+    expect(minorToDollars(0)).toBe('0.00')
+  })
+
+  it('should format dollars and cents', () => {
+    expect(minorToDollars(12345)).toBe('123.45')
+    expect(minorToDollars(99)).toBe('0.99')
+    expect(minorToDollars(1)).toBe('0.01')
+  })
+
+  it('should format negative amounts', () => {
+    expect(minorToDollars(-12345)).toBe('-123.45')
+    expect(minorToDollars(-1)).toBe('-0.01')
+  })
+
+  it('should pad single-digit cents', () => {
+    expect(minorToDollars(5)).toBe('0.05')
+    expect(minorToDollars(1005)).toBe('10.05')
+  })
+})
+
+describe('toMinorUnits and minorToDollars roundtrip', () => {
+  const values = ['0.00', '0.01', '0.99', '1.00', '123.45', '9999.99']
+  for (const val of values) {
+    it(`should roundtrip ${val}`, () => {
+      expect(minorToDollars(toMinorUnits(val))).toBe(val)
+    })
+  }
+})
+
+describe('computeBalance', () => {
+  it('should detect a balanced entry', () => {
+    const result = computeBalance([
+      { debitAmount: '100.00', creditAmount: '' },
+      { debitAmount: '', creditAmount: '100.00' },
+    ])
+    expect(result.totalDebitMinor).toBe(10000)
+    expect(result.totalCreditMinor).toBe(10000)
+    expect(result.differenceMinor).toBe(0)
+    expect(result.isBalanced).toBe(true)
+  })
+
+  it('should detect an unbalanced entry', () => {
+    const result = computeBalance([
+      { debitAmount: '100.00', creditAmount: '' },
+      { debitAmount: '', creditAmount: '50.00' },
+    ])
+    expect(result.differenceMinor).toBe(5000)
+    expect(result.isBalanced).toBe(false)
+  })
+
+  it('should not be balanced when all zeros', () => {
+    const result = computeBalance([
+      { debitAmount: '', creditAmount: '' },
+      { debitAmount: '', creditAmount: '' },
+    ])
+    expect(result.isBalanced).toBe(false)
+  })
+
+  it('should handle multi-line entries (swap example)', () => {
+    // Swap 10 Token A ($100 basis, $150 FV) for 4 Token B
+    // Line 1: DR Digital assets - B $150
+    // Line 2: CR Digital assets - A $100
+    // Line 3: CR Realized gain    $50
+    const result = computeBalance([
+      { debitAmount: '150.00', creditAmount: '' },
+      { debitAmount: '', creditAmount: '100.00' },
+      { debitAmount: '', creditAmount: '50.00' },
+    ])
+    expect(result.totalDebitMinor).toBe(15000)
+    expect(result.totalCreditMinor).toBe(15000)
+    expect(result.differenceMinor).toBe(0)
+    expect(result.isBalanced).toBe(true)
+  })
+
+  it('should use integer math avoiding float error on 0.1 + 0.2', () => {
+    const result = computeBalance([
+      { debitAmount: '0.10', creditAmount: '' },
+      { debitAmount: '0.20', creditAmount: '' },
+      { debitAmount: '', creditAmount: '0.30' },
+    ])
+    expect(result.differenceMinor).toBe(0)
+    expect(result.isBalanced).toBe(true)
+  })
+})
+
+describe('displayStatus', () => {
+  it('should map draft status', () => {
+    expect(displayStatus('draft')).toBe('draft')
+  })
+
+  it('should map approved status', () => {
+    expect(displayStatus('approved')).toBe('approved')
+  })
+
+  it('should map posted status', () => {
+    expect(displayStatus('posted')).toBe('posted')
+  })
+
+  it('should map voided status', () => {
+    expect(displayStatus('voided')).toBe('voided')
+  })
+
+  it('should default unknown status to draft', () => {
+    expect(displayStatus('unknown')).toBe('draft')
+    expect(displayStatus('')).toBe('draft')
+  })
+})
+
+describe('formatDate', () => {
+  it('should return em-dash for null/undefined', () => {
+    expect(formatDate(null)).toBe('\u2014')
+    expect(formatDate(undefined)).toBe('\u2014')
+  })
+
+  it('should format a date string', () => {
+    const result = formatDate('2026-07-15T12:00:00Z')
+    expect(result).toContain('2026')
+  })
+
+  it('should format a Date object', () => {
+    const result = formatDate(new Date(2026, 0, 15))
+    expect(result).toContain('2026')
+  })
+})

--- a/src/app/journal-entries/journalEntryUtils.ts
+++ b/src/app/journal-entries/journalEntryUtils.ts
@@ -7,13 +7,19 @@
 export function toMinorUnits(val: string): number {
   const trimmed = val.trim()
   if (trimmed === '') return 0
-  const parts = trimmed.split('.')
+  // Parse the sign from the string, not from parseInt: parseInt('-0', 10)
+  // yields -0, which is NOT < 0, so "-0.50" silently flipped sign to +50.
+  const negative = trimmed.startsWith('-')
+  const unsigned = trimmed.replace(/^[+-]/, '')
+  const parts = unsigned.split('.')
+  const fraction = parts[1] ?? ''
   const whole = Number.parseInt(parts[0] || '0', 10)
-  if (Number.isNaN(whole)) return 0
-  const centStr = (parts[1] ?? '').slice(0, 2).padEnd(2, '0')
+  if (Number.isNaN(whole) && fraction === '') return 0
+  const centStr = fraction.slice(0, 2).padEnd(2, '0')
   const cents = Number.parseInt(centStr, 10)
-  if (Number.isNaN(cents)) return 0
-  return whole * 100 + (whole < 0 ? -cents : cents)
+  const magnitude =
+    (Number.isNaN(whole) ? 0 : whole) * 100 + (Number.isNaN(cents) ? 0 : cents)
+  return negative ? -magnitude : magnitude
 }
 
 /**

--- a/src/app/journal-entries/journalEntryUtils.ts
+++ b/src/app/journal-entries/journalEntryUtils.ts
@@ -1,0 +1,108 @@
+/**
+ * Converts a dollar-string to integer minor units (cents) using integer math.
+ * Avoids floating-point precision issues by parsing the string directly.
+ * @param val - Dollar string (e.g. "123.45")
+ * @returns Integer cents (e.g. 12345)
+ */
+export function toMinorUnits(val: string): number {
+  const trimmed = val.trim()
+  if (trimmed === '') return 0
+  const parts = trimmed.split('.')
+  const whole = Number.parseInt(parts[0] || '0', 10)
+  if (Number.isNaN(whole)) return 0
+  const centStr = (parts[1] ?? '').slice(0, 2).padEnd(2, '0')
+  const cents = Number.parseInt(centStr, 10)
+  if (Number.isNaN(cents)) return 0
+  return whole * 100 + (whole < 0 ? -cents : cents)
+}
+
+/**
+ * Formats minor units (integer cents) as a USD dollar string.
+ * Uses integer math only — no floats touch money.
+ * @param minor - Amount in cents
+ * @returns Formatted dollar string (e.g., "123.45")
+ */
+export function minorToDollars(minor: number): string {
+  const negative = minor < 0
+  const abs = Math.abs(minor)
+  const dollars = Math.trunc(abs / 100)
+  const cents = abs % 100
+  const str = `${dollars}.${String(cents).padStart(2, '0')}`
+  return negative ? `-${str}` : str
+}
+
+/**
+ * Computes the balance of line items in integer minor units.
+ * @param lines - Array of objects with debitAmount and creditAmount dollar-strings
+ * @returns Object with totalDebitMinor, totalCreditMinor, differenceMinor, and isBalanced
+ */
+export function computeBalance(
+  lines: { debitAmount: string; creditAmount: string }[]
+): {
+  totalDebitMinor: number
+  totalCreditMinor: number
+  differenceMinor: number
+  isBalanced: boolean
+} {
+  const totalDebitMinor = lines.reduce(
+    (s, l) => s + toMinorUnits(l.debitAmount),
+    0
+  )
+  const totalCreditMinor = lines.reduce(
+    (s, l) => s + toMinorUnits(l.creditAmount),
+    0
+  )
+  const differenceMinor = totalDebitMinor - totalCreditMinor
+  return {
+    totalDebitMinor,
+    totalCreditMinor,
+    differenceMinor,
+    isBalanced: differenceMinor === 0 && totalDebitMinor > 0,
+  }
+}
+
+/**
+ * Maps a database status string to a display status key.
+ * @param status - Raw status from the database
+ * @returns Display status key
+ */
+export function displayStatus(
+  status: string
+): 'draft' | 'approved' | 'posted' | 'voided' {
+  if (status === 'voided') return 'voided'
+  if (status === 'posted') return 'posted'
+  if (status === 'approved') return 'approved'
+  return 'draft'
+}
+
+/**
+ * Formats a date string or Date for display.
+ * @param d - Date value to format
+ * @returns Formatted date string or em-dash for null/undefined
+ */
+export function formatDate(d: string | Date | undefined | null): string {
+  if (!d) return '\u2014'
+  const date = typeof d === 'string' ? new Date(d) : d
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+/**
+ * Formats a date string or Date with time for display.
+ * @param d - Date value to format
+ * @returns Formatted datetime string or em-dash for null/undefined
+ */
+export function formatDateTime(d: string | Date | undefined | null): string {
+  if (!d) return '\u2014'
+  const date = typeof d === 'string' ? new Date(d) : d
+  return date.toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}


### PR DESCRIPTION
## Summary

Phase 3 of the Stage 1 accounting engine. Puts the human approval workflow on top of the Phase 2 backend (approve, post, void, per-asset balances).

- **Approval queue view**: five-tab filter (All/Draft/Approved/Posted/Voided), per-row lifecycle actions wired to existing Tauri commands (`approve_journal_entry`, `post_journal_entry`, `void_journal_entry`), void confirmation dialog explaining reversing-entry semantics, demote (approved→draft) for editing. Origin and provenance columns. Backend errors surfaced verbatim.
- **Manual journal entry form**: create/edit drafts with account picker, optional quantity + asset_id per line, live balance indicator using **integer minor-unit math** (`toMinorUnits` string parser — no floats touch money, exact zero comparison). Per-asset quantity balance hints for multi-asset entries.
- **Entry detail view**: full lines with account/asset/qty/debit/credit/memo, lifecycle timeline (created→approved→posted→voided with timestamps and actors), reversal linkage (voided entries link to reversing entry and vice versa).
- **Shared utilities**: `journalEntryUtils.ts` — `toMinorUnits()`, `minorToDollars()`, `computeBalance()`, `displayStatus()`, `formatDate/DateTime()`.
- **31 Vitest tests**: integer-math conversions, balance computation (including float-trap avoidance for 0.1+0.2 and 19.99+0.01), roundtrip identity, status mapping, date formatting.
- **Docs**: `stage1-progress.md` Phase 3 checkbox + session log.

## Invariants preserved

- No floats touch money (integer minor units everywhere in UI math)
- Backend is the enforcement layer (no client-side state machine second-guessing)
- Reports remain views
- Append-only corrections via reversing entries (both entries stay in GL)

## Test plan

- [x] `npx vitest run` — 31 new tests pass, 222 existing tests pass
- [x] `npx eslint src/app/journal-entries/` — clean
- [ ] Manual: create draft → approve → post → void → verify reversing entry pair in detail view
- [ ] Manual: demote approved entry → verify opens in drawer as editable draft
- [ ] Manual: try posting a draft directly → verify backend error surfaced


🤖 Generated with [Claude Code](https://claude.com/claude-code)