### PR TITLE
feat(accounting): Phase 6 financial statements v1 (GIV-688)

### DIFF
--- a/docs/accounting-model.md
+++ b/docs/accounting-model.md
@@ -225,13 +225,13 @@ with mechanically verified ties.
 
 ### Account classification for statements
 
-| Account Type | Statement       | Section       | Sign convention                |
-| ------------ | --------------- | ------------- | ------------------------------ |
-| Asset        | Balance Sheet   | Assets        | Debit − Credit (natural debit) |
-| Liability    | Balance Sheet   | Liabilities   | Credit − Debit (natural credit)|
-| Equity       | Balance Sheet   | Equity        | Credit − Debit (natural credit)|
-| Income       | Income Statement| Revenue       | Credit − Debit (natural credit)|
-| Expense      | Income Statement| Expenses      | Debit − Credit (natural debit) |
+| Account Type | Statement        | Section     | Sign convention                 |
+| ------------ | ---------------- | ----------- | ------------------------------- |
+| Asset        | Balance Sheet    | Assets      | Debit − Credit (natural debit)  |
+| Liability    | Balance Sheet    | Liabilities | Credit − Debit (natural credit) |
+| Equity       | Balance Sheet    | Equity      | Credit − Debit (natural credit) |
+| Income       | Income Statement | Revenue     | Credit − Debit (natural credit) |
+| Expense      | Income Statement | Expenses    | Debit − Credit (natural debit)  |
 
 ### How net income ties to equity
 

--- a/docs/accounting-model.md
+++ b/docs/accounting-model.md
@@ -215,13 +215,17 @@ with mechanically verified ties.
 
 ### Statement types
 
-1. **Balance Sheet** — Assets, Liabilities, Equity for a selected period.
-   Equity includes the current-period net income computed from Income and
-   Expense accounts.
-2. **Income Statement** — Revenue (Income accounts) and Expenses for a
-   selected period.
-3. **Trial Balance** — All accounts with non-zero activity in the period,
-   showing debit and credit balances.
+1. **Balance Sheet** — Assets, Liabilities, Equity **as of the period end
+   date** (cumulative from inception: a balance sheet reports positions,
+   not period movements, so opening balances are always included). Equity
+   decomposes into contributed equity accounts, **retained earnings** (net
+   income accumulated before the period start), and current-period net
+   income.
+2. **Income Statement** — Revenue (Income accounts) and Expenses for the
+   selected period (start through end).
+3. **Trial Balance** — All accounts with non-zero cumulative balances
+   **as of the period end date** (conventional "trial balance as at
+   date", consistent with the M4 views and the Phase 2 balances).
 
 ### Account classification for statements
 
@@ -235,42 +239,57 @@ with mechanically verified ties.
 
 ### How net income ties to equity
 
-The balance sheet includes a **net income plug**: current-period net income
-(Revenue − Expenses) is added to the Equity section. The tie assertion is:
+There is no journal-entry closing process in Stage 1: Income and Expense
+accounts are never closed into an equity account. Instead the balance
+sheet derives the equity roll-forward from the ledger on every run:
 
-    Total Assets = Total Liabilities + (Equity + Net Income)
+    Retained Earnings = Net Income accumulated from inception
+                        through the day before the period start
+    Total Equity      = Equity accounts + Retained Earnings
+                        + Current-Period Net Income
+    Total Assets      = Total Liabilities + Total Equity
 
-If this equation does not hold, the statement generation **fails loudly**
+If the last equation does not hold, statement generation **fails loudly**
 — the `verify_ties` function returns an error and the UI never renders a
 statement that does not tie.
 
 ### Tie verification (`verify_ties`)
 
-Before returning any statement to the UI, the engine runs four checks:
+Before any statement is returned to the UI or exported, the engine builds
+all three statements for the period and runs four checks (current AND
+comparative prior period both pass through the same gate):
 
-1. **Balance sheet ties**: Assets = Liabilities + Equity (incl. net income)
+1. **Balance sheet ties**: Assets = Liabilities + Equity (incl. retained
+   earnings and current-period net income)
 2. **Net income consistency**: Income Statement net income = Balance Sheet
-   net income plug
+   current-period net income
 3. **Trial balance is in balance**: Total debits = Total credits
-4. **Cross-check**: Trial balance net income (Income credits − Expense
-   debits) = Income Statement net income
+4. **Cross-check**: Trial balance cumulative net income (Income −
+   Expense as of the end date) = Balance Sheet retained earnings +
+   current-period net income
 
 A failure on any check is a hard error — the statement is never rendered
 silently with incorrect figures.
 
 ### Period filtering
 
-Statements accept a start date and end date. Only posted entries with
-`entry_date` within the range are included. Voided entries net out via
+Only **posted** entries feed statements, filtered by `entry_date`:
+cumulative aggregation (inception..=end) for balance sheet and trial
+balance, period aggregation (start..=end) for the income statement and
+the net-income split. The posted/date predicates are applied in the SQL
+WHERE clause over INNER JOINs — never on a chained LEFT JOIN's ON clause,
+which would silently leak draft and out-of-period lines into the sums
+(regression covered by DB integration tests). Voided entries net out via
 their reversing entries (both are posted and included in aggregation).
 
 ### Comparative periods
 
 Each statement includes a **comparative prior period** of the same
-duration, immediately preceding the current period. For example, if the
-current period is 2025-01-01 to 2025-12-31, the prior period is
-2024-01-01 to 2024-12-31. The UI shows both periods side by side with
-percentage change.
+day-count duration, ending the day before the current period starts (for
+example, the prior period of 2025-01-01..2025-12-31 is
+2024-01-02..2024-12-31 — equal duration, not calendar-aligned). The
+comparative balance sheet and trial balance are "as of" the prior period
+end date. The UI shows both periods side by side with percentage change.
 
 ### CSV export
 

--- a/docs/accounting-model.md
+++ b/docs/accounting-model.md
@@ -205,7 +205,79 @@ Close and reopen follow the Phase 2/3 conditional-UPDATE pattern:
 `UPDATE ... WHERE status='open'` (or `='closed'`). Double-close and
 double-reopen are 0-row no-ops — no error, no side effects.
 
-## 9. Transfers between own wallets _(reserved — Phase 7)_
+## 9. Financial statements (Phase 6)
+
+Financial statements are **derived views** over posted entries (Invariant 4):
+no stored report tables, no snapshots. The Rust engine queries posted
+journal entries within a date range, aggregates using i64 minor units
+(no floats touch money — Invariant 2), and returns structured reports
+with mechanically verified ties.
+
+### Statement types
+
+1. **Balance Sheet** — Assets, Liabilities, Equity for a selected period.
+   Equity includes the current-period net income computed from Income and
+   Expense accounts.
+2. **Income Statement** — Revenue (Income accounts) and Expenses for a
+   selected period.
+3. **Trial Balance** — All accounts with non-zero activity in the period,
+   showing debit and credit balances.
+
+### Account classification for statements
+
+| Account Type | Statement       | Section       | Sign convention                |
+| ------------ | --------------- | ------------- | ------------------------------ |
+| Asset        | Balance Sheet   | Assets        | Debit − Credit (natural debit) |
+| Liability    | Balance Sheet   | Liabilities   | Credit − Debit (natural credit)|
+| Equity       | Balance Sheet   | Equity        | Credit − Debit (natural credit)|
+| Income       | Income Statement| Revenue       | Credit − Debit (natural credit)|
+| Expense      | Income Statement| Expenses      | Debit − Credit (natural debit) |
+
+### How net income ties to equity
+
+The balance sheet includes a **net income plug**: current-period net income
+(Revenue − Expenses) is added to the Equity section. The tie assertion is:
+
+    Total Assets = Total Liabilities + (Equity + Net Income)
+
+If this equation does not hold, the statement generation **fails loudly**
+— the `verify_ties` function returns an error and the UI never renders a
+statement that does not tie.
+
+### Tie verification (`verify_ties`)
+
+Before returning any statement to the UI, the engine runs four checks:
+
+1. **Balance sheet ties**: Assets = Liabilities + Equity (incl. net income)
+2. **Net income consistency**: Income Statement net income = Balance Sheet
+   net income plug
+3. **Trial balance is in balance**: Total debits = Total credits
+4. **Cross-check**: Trial balance net income (Income credits − Expense
+   debits) = Income Statement net income
+
+A failure on any check is a hard error — the statement is never rendered
+silently with incorrect figures.
+
+### Period filtering
+
+Statements accept a start date and end date. Only posted entries with
+`entry_date` within the range are included. Voided entries net out via
+their reversing entries (both are posted and included in aggregation).
+
+### Comparative periods
+
+Each statement includes a **comparative prior period** of the same
+duration, immediately preceding the current period. For example, if the
+current period is 2025-01-01 to 2025-12-31, the prior period is
+2024-01-01 to 2024-12-31. The UI shows both periods side by side with
+percentage change.
+
+### CSV export
+
+All three statements can be exported to CSV. The export runs the same
+`verify_ties` check — a statement that does not tie cannot be exported.
+
+## 10. Transfers between own wallets _(reserved — Phase 7)_
 
 Treatment of lot movement without realization will be documented when the
 cost-basis engine lands.

--- a/docs/stage1-progress.md
+++ b/docs/stage1-progress.md
@@ -4,9 +4,10 @@ Session constitution: `SCOPE.md` (repo root). Stage 1 mandate: GIV-668.
 Gate 1: CPA-reviewed statements from real imported transactions, manually
 classified through the approval queue.
 
-**Current phase: 5 (Accounting periods) — Phases 1-4 landed;
-Phase 5 implemented by Engineer (GIV-684): accounting_periods table,
-closed-period posting trigger, period lifecycle commands, Periods UI.**
+**Current phase: 6 (Financial statements v1) — Phases 1-5 landed;
+Phase 6 implemented by Engineer (GIV-688): income statement, balance
+sheet, trial balance with period filtering + comparative prior period,
+verify_ties assertion, CSV export, statement UI pages.**
 
 ## Phase Checklist
 
@@ -32,7 +33,11 @@ closed-period posting trigger, period lifecycle commands, Periods UI.**
       DB trigger blocks posting into closed periods, list_periods/
       close_period/reopen_period commands, Periods UI with confirm
       modals, reopen audit log, 9 Rust tests — Engineer)
-- [ ] **Phase 6 — Financial statements v1**
+- [x] **Phase 6 — Financial statements v1**
+      (GIV-688: balance sheet, income statement, trial balance with period
+      filtering + comparative prior period, verify_ties assertion enforced
+      before all statement returns, CSV export, statement UI pages with
+      period selector and comparative columns — Engineer)
 - [ ] **Phase 7 — Cost basis engine (FIFO first)**
 - [ ] **Phase 8 — Fair-value measurement (ASU 2023-08)**
 - [ ] **Phase 9 — Invariant test suite (proptest)**
@@ -549,3 +554,50 @@ WHERE status='approved'` (the M5 state machine explicitly allows
     literal trailing `undefined` args in tests.
   - Tests: +3 Rust (posted entry_date immutable; draft entry_date
     editable; conditional-insert overlap atomicity) → 230 lib green.
+- **Session 11 (2026-07-16, Engineer — GIV-688):** Implemented Phase 6
+  (financial statements v1):
+  - **New Rust module** (`src-tauri/src/api/statements.rs`): financial
+    statement engine with period-aware queries over posted entries using
+    i64 minor units (no floats touch money — Inv-2). Reports are derived
+    views, never stored (Inv-4). Voided entries net out via their
+    reversals — verified by test. Three statement types: balance sheet,
+    income statement, trial balance.
+  - **Period-aware aggregation:** SQL queries filter posted entries by
+    `entry_date` within the requested date range. Supports both
+    accounting-period selection and arbitrary date ranges.
+  - **Comparative prior period:** each statement automatically computes
+    a comparative prior period of equal duration (e.g., current year
+    2025 → prior year 2024). Both periods returned to the UI.
+  - **`verify_ties` function (non-negotiable):** runs four tie checks
+    before any statement data is returned to the UI: (1) balance sheet
+    ties (A = L + E incl. NI), (2) net income matches between BS and IS,
+    (3) trial balance is in balance, (4) trial balance NI cross-checks
+    income statement NI. A statement that does not tie is a hard error —
+    it never renders silently.
+  - **CSV export:** three Tauri commands
+    (`export_balance_sheet_csv`, `export_income_statement_csv`,
+    `export_trial_balance_csv`) write statements to CSV via the existing
+    `csv` crate. Export runs `verify_ties` before writing. PDF deferred
+    (no lightweight tooling available without heavy deps).
+  - **UI pages:** `BalanceSheet.tsx`, `IncomeStatement.tsx`,
+    `PeriodTrialBalance.tsx` — period selector (start/end date inputs),
+    comparative columns with change percentage, CSV export button via
+    Tauri file-save dialog. Error messages surfaced verbatim from the
+    Rust backend. JSX depth kept ≤ 4 via extracted sub-components
+    (PeriodSelector, SectionTable, IncomeSection, TrialBalanceRowComponent).
+  - **Routes:** `/reports/balance-sheet`, `/reports/income-statement`,
+    `/reports/trial-balance` added to App.tsx. Reports.tsx route map
+    updated for all three.
+  - **Tests:** 11 Rust tests in statements.rs (balance sheet ties,
+    income statement net income, trial balance balances, verify_ties pass,
+    verify fails on corrupted BS/IS/TB, voided-entry neutrality,
+    comparative period dates, format_minor, empty period balanced,
+    zero-balance exclusion). 6 Vitest tests for statementUtils.ts
+    (formatMinorAsDollars, formatMinorPlain, formatStatementDate,
+    computeChangePercent, formatChangePercent, defaultPeriodDates).
+  - **Docs:** `docs/accounting-model.md` §9 (Financial statements)
+    documenting account classification, net income tie, verification,
+    period filtering, comparative periods, CSV export. This tracker
+    updated (Phase 6 checkbox + this session log).
+  - **No schema migration.** No SQL views created. All aggregation in
+    Rust from posted journal_entry_lines.

--- a/docs/stage1-progress.md
+++ b/docs/stage1-progress.md
@@ -601,3 +601,42 @@ WHERE status='approved'` (the M5 state machine explicitly allows
     updated (Phase 6 checkbox + this session log).
   - **No schema migration.** No SQL views created. All aggregation in
     Rust from posted journal_entry_lines.
+- **Session 11 addendum (2026-07-16, CTO review hardening — GIV-688):**
+  two correctness gaps found and fixed on the PR before merge:
+  1. **SQL filter leak (critical):** the aggregation query put the
+     `is_posted = 1` + date predicates on a chained LEFT JOIN's ON
+     clause. That only NULLs the `journal_entries` columns — the line
+     rows still survive and get summed, so DRAFT entries and
+     out-of-period entries leaked into every statement (repro: a draft
+     for 999.00 and an out-of-period posted 555.00 both appeared in a
+     Feb-only statement). The 12 unit tests were pure-fixture and never
+     executed the SQL, so CI stayed green over a broken query. Fixed
+     with INNER JOINs + WHERE-clause predicates
+     (`query_account_activity`), and two new **DB integration tests**
+     (in-memory SQLite + full migrations) that seed posted-in-period,
+     posted-before-period, and draft entries and assert exclusion.
+     Rule for future phases: any new SQL aggregation needs at least one
+     DB-backed test — fixture tests cannot catch join-semantics bugs.
+  2. **Balance sheet was period-movement, not as-of:** A/L/E were
+     aggregated over `[start, end]` only, so a June balance sheet
+     dropped every opening balance (all pre-June cash vanished) and
+     there was no retained-earnings concept. Statements now aggregate
+     twice: cumulative (inception..=end) for balance sheet + trial
+     balance, period (start..=end) for the income statement. New
+     `retained_earnings_minor` on the balance sheet = cumulative NI −
+     current-period NI; tie is A = L + (equity accounts + RE + NI).
+     Trial balance is now conventional "as at end date" (matches M4
+     views/Phase 2). `verify_ties` check 4 updated: TB cumulative NI
+     must equal BS retained earnings + current-period NI.
+  - Also: all three Tauri commands and CSV exports now route through a
+    single `build_verified_statements` gate, and the **comparative
+    prior period is verified too** before rendering (previously prior
+    statements bypassed `verify_ties`). BalanceSheet UI + CSV gained a
+    Retained Earnings line; trial balance page header is "As of {end}".
+    16 Rust statement tests green (14 fixture + 2 DB integration).
+  - **Known limit (tracker-documented):** the comparative prior period
+    is equal _day-count_ duration ending the day before the current
+    start (2025 full year → 2024-01-02..2024-12-31), not
+    calendar-aligned. Acceptable for v1; calendar-aligned comparatives
+    (prior month/quarter/year via `accounting_periods`) are future
+    polish.

--- a/src-tauri/src/api/mod.rs
+++ b/src-tauri/src/api/mod.rs
@@ -16,6 +16,9 @@ pub mod persistence;
 pub mod price_feeds;
 /// The `prices` module provides functionality for retrieving and managing price data.
 pub mod prices;
+/// Financial statement generation: balance sheet, income statement, trial balance,
+/// tie verification, and CSV export (GIV-688, Phase 6).
+pub mod statements;
 /// Provides functionality for wallet-based authentication, including
 /// signing in users through their wallets and verifying credentials.
 pub mod wallet_auth;

--- a/src-tauri/src/api/statements.rs
+++ b/src-tauri/src/api/statements.rs
@@ -1,0 +1,987 @@
+use csv::Writer;
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+use tauri::State;
+
+use super::persistence::DatabaseState;
+
+// ============================================================================
+// Types — Financial Statement Line Items
+// ============================================================================
+
+/// A single account row aggregated for a financial statement period.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[serde(rename_all = "camelCase")]
+pub struct StatementLineItem {
+    /// Account number (e.g. "1200").
+    pub account_number: String,
+    /// Human-readable account name.
+    pub account_name: String,
+    /// One of: Asset, Liability, Equity, Income, Expense.
+    pub account_type: String,
+    /// Net balance in minor units (USD cents), sign-corrected for reporting.
+    pub balance_minor: i64,
+}
+
+/// A trial balance row for a specific period.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[serde(rename_all = "camelCase")]
+pub struct PeriodTrialBalanceRow {
+    /// Account number.
+    pub account_number: String,
+    /// Account name.
+    pub account_name: String,
+    /// Account type.
+    pub account_type: String,
+    /// Debit balance in minor units (0 if net credit side).
+    pub debit_balance: i64,
+    /// Credit balance in minor units (0 if net debit side).
+    pub credit_balance: i64,
+}
+
+// ============================================================================
+// Types — Financial Statement Reports
+// ============================================================================
+
+/// A single section (e.g. "Assets") in a financial statement.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatementSection {
+    /// Section label (e.g. "Assets", "Income").
+    pub label: String,
+    /// Line items in this section.
+    pub items: Vec<StatementLineItem>,
+    /// Section subtotal in minor units.
+    pub subtotal_minor: i64,
+}
+
+/// Balance sheet report for a given date range.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BalanceSheetReport {
+    /// Start date of the reporting period (ISO 8601 date string).
+    pub start_date: String,
+    /// End date of the reporting period (ISO 8601 date string).
+    pub end_date: String,
+    /// Assets section.
+    pub assets: StatementSection,
+    /// Liabilities section.
+    pub liabilities: StatementSection,
+    /// Equity section (excluding current-period net income).
+    pub equity: StatementSection,
+    /// Current-period net income in minor units (plugged into equity).
+    pub net_income_minor: i64,
+    /// Total assets in minor units.
+    pub total_assets_minor: i64,
+    /// Total liabilities in minor units.
+    pub total_liabilities_minor: i64,
+    /// Total equity in minor units (including net income).
+    pub total_equity_minor: i64,
+    /// Whether the balance sheet ties (assets == liabilities + equity).
+    pub is_balanced: bool,
+}
+
+/// Income statement report for a given date range.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IncomeStatementReport {
+    /// Start date of the reporting period.
+    pub start_date: String,
+    /// End date of the reporting period.
+    pub end_date: String,
+    /// Revenue / income section.
+    pub revenue: StatementSection,
+    /// Expenses section.
+    pub expenses: StatementSection,
+    /// Total revenue in minor units.
+    pub total_revenue_minor: i64,
+    /// Total expenses in minor units.
+    pub total_expenses_minor: i64,
+    /// Net income in minor units (revenue - expenses).
+    pub net_income_minor: i64,
+}
+
+/// Trial balance report for a given date range.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrialBalanceReport {
+    /// Start date of the reporting period.
+    pub start_date: String,
+    /// End date of the reporting period.
+    pub end_date: String,
+    /// Account rows.
+    pub rows: Vec<PeriodTrialBalanceRow>,
+    /// Total debits in minor units.
+    pub total_debits_minor: i64,
+    /// Total credits in minor units.
+    pub total_credits_minor: i64,
+    /// Whether the trial balance is in balance.
+    pub is_balanced: bool,
+}
+
+/// Comparative financial statement with current and prior period.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComparativeBalanceSheet {
+    /// Current period balance sheet.
+    pub current: BalanceSheetReport,
+    /// Prior period balance sheet (comparative).
+    pub prior: BalanceSheetReport,
+}
+
+/// Comparative income statement with current and prior period.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComparativeIncomeStatement {
+    /// Current period income statement.
+    pub current: IncomeStatementReport,
+    /// Prior period income statement (comparative).
+    pub prior: IncomeStatementReport,
+}
+
+/// Comparative trial balance with current and prior period.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ComparativeTrialBalance {
+    /// Current period trial balance.
+    pub current: TrialBalanceReport,
+    /// Prior period trial balance (comparative).
+    pub prior: TrialBalanceReport,
+}
+
+// ============================================================================
+// Internal query helpers
+// ============================================================================
+
+/// Raw row from the period-filtered aggregation query.
+#[derive(Debug, Clone, FromRow)]
+struct PeriodAccountRow {
+    account_number: String,
+    account_name: String,
+    account_type: String,
+    total_debit_minor: i64,
+    total_credit_minor: i64,
+}
+
+/// Queries posted journal entries within a date range, aggregating debit_minor
+/// and credit_minor per GL account. Only posted entries (is_posted = 1) are
+/// included — voided entries net out via their reversing entries.
+async fn query_period_accounts(
+    pool: &sqlx::SqlitePool,
+    start_date: &str,
+    end_date: &str,
+) -> Result<Vec<PeriodAccountRow>, String> {
+    sqlx::query_as::<_, PeriodAccountRow>(
+        r#"
+        SELECT
+            ga.account_number,
+            ga.account_name,
+            ga.account_type,
+            COALESCE(SUM(jel.debit_minor), 0) AS total_debit_minor,
+            COALESCE(SUM(jel.credit_minor), 0) AS total_credit_minor
+        FROM gl_accounts ga
+        LEFT JOIN journal_entry_lines jel ON ga.id = jel.gl_account_id
+        LEFT JOIN journal_entries je ON jel.journal_entry_id = je.id
+            AND je.is_posted = 1
+            AND DATE(je.entry_date) >= ?
+            AND DATE(je.entry_date) <= ?
+        WHERE ga.is_active = 1
+        GROUP BY ga.id, ga.account_number, ga.account_name, ga.account_type
+        HAVING COALESCE(SUM(jel.debit_minor), 0) != 0
+            OR COALESCE(SUM(jel.credit_minor), 0) != 0
+        ORDER BY ga.account_number
+        "#,
+    )
+    .bind(start_date)
+    .bind(end_date)
+    .fetch_all(pool)
+    .await
+    .map_err(|e| e.to_string())
+}
+
+/// Computes the sign-corrected balance for reporting.
+/// Assets and Expenses have a natural debit balance (debit - credit).
+/// Liabilities, Equity, and Income have a natural credit balance (credit - debit).
+fn signed_balance(account_type: &str, debit: i64, credit: i64) -> i64 {
+    match account_type {
+        "Asset" | "Expense" => debit - credit,
+        _ => credit - debit,
+    }
+}
+
+/// Builds a section (Assets, Liabilities, Equity, Income, or Expense) from rows.
+fn build_section(label: &str, rows: &[PeriodAccountRow], types: &[&str]) -> StatementSection {
+    let items: Vec<StatementLineItem> = rows
+        .iter()
+        .filter(|r| types.contains(&r.account_type.as_str()))
+        .map(|r| StatementLineItem {
+            account_number: r.account_number.clone(),
+            account_name: r.account_name.clone(),
+            account_type: r.account_type.clone(),
+            balance_minor: signed_balance(&r.account_type, r.total_debit_minor, r.total_credit_minor),
+        })
+        .filter(|item| item.balance_minor != 0)
+        .collect();
+
+    let subtotal_minor: i64 = items.iter().map(|i| i.balance_minor).sum();
+
+    StatementSection {
+        label: label.to_string(),
+        items,
+        subtotal_minor,
+    }
+}
+
+// ============================================================================
+// Statement Builders (pure logic, testable)
+// ============================================================================
+
+/// Builds a balance sheet from period account rows.
+///
+/// Balance sheet tie: total_assets == total_liabilities + total_equity
+/// where total_equity includes current-period net income.
+fn build_balance_sheet(
+    rows: &[PeriodAccountRow],
+    start_date: &str,
+    end_date: &str,
+) -> BalanceSheetReport {
+    let assets = build_section("Assets", rows, &["Asset"]);
+    let liabilities = build_section("Liabilities", rows, &["Liability"]);
+    let equity = build_section("Equity", rows, &["Equity"]);
+
+    // Net income = Income - Expenses for the period
+    let revenue_section = build_section("Income", rows, &["Income"]);
+    let expense_section = build_section("Expenses", rows, &["Expense"]);
+    let net_income_minor = revenue_section.subtotal_minor - expense_section.subtotal_minor;
+
+    let total_assets_minor = assets.subtotal_minor;
+    let total_liabilities_minor = liabilities.subtotal_minor;
+    let total_equity_minor = equity.subtotal_minor + net_income_minor;
+
+    let is_balanced = total_assets_minor == total_liabilities_minor + total_equity_minor;
+
+    BalanceSheetReport {
+        start_date: start_date.to_string(),
+        end_date: end_date.to_string(),
+        assets,
+        liabilities,
+        equity,
+        net_income_minor,
+        total_assets_minor,
+        total_liabilities_minor,
+        total_equity_minor,
+        is_balanced,
+    }
+}
+
+/// Builds an income statement from period account rows.
+fn build_income_statement(
+    rows: &[PeriodAccountRow],
+    start_date: &str,
+    end_date: &str,
+) -> IncomeStatementReport {
+    let revenue = build_section("Revenue", rows, &["Income"]);
+    let expenses = build_section("Expenses", rows, &["Expense"]);
+
+    let total_revenue_minor = revenue.subtotal_minor;
+    let total_expenses_minor = expenses.subtotal_minor;
+    let net_income_minor = total_revenue_minor - total_expenses_minor;
+
+    IncomeStatementReport {
+        start_date: start_date.to_string(),
+        end_date: end_date.to_string(),
+        revenue,
+        expenses,
+        total_revenue_minor,
+        total_expenses_minor,
+        net_income_minor,
+    }
+}
+
+/// Builds a trial balance from period account rows.
+fn build_trial_balance(
+    rows: &[PeriodAccountRow],
+    start_date: &str,
+    end_date: &str,
+) -> TrialBalanceReport {
+    let tb_rows: Vec<PeriodTrialBalanceRow> = rows
+        .iter()
+        .map(|r| {
+            let net = r.total_debit_minor - r.total_credit_minor;
+            PeriodTrialBalanceRow {
+                account_number: r.account_number.clone(),
+                account_name: r.account_name.clone(),
+                account_type: r.account_type.clone(),
+                debit_balance: if net > 0 { net } else { 0 },
+                credit_balance: if net < 0 { -net } else { 0 },
+            }
+        })
+        .collect();
+
+    let total_debits_minor: i64 = tb_rows.iter().map(|r| r.debit_balance).sum();
+    let total_credits_minor: i64 = tb_rows.iter().map(|r| r.credit_balance).sum();
+    let is_balanced = total_debits_minor == total_credits_minor;
+
+    TrialBalanceReport {
+        start_date: start_date.to_string(),
+        end_date: end_date.to_string(),
+        rows: tb_rows,
+        total_debits_minor,
+        total_credits_minor,
+        is_balanced,
+    }
+}
+
+// ============================================================================
+// Verify — Non-Negotiable Tie Assertions
+// ============================================================================
+
+/// Verifies that financial statements tie correctly. Returns Ok(()) if all
+/// assertions pass, or Err with a description of what failed.
+///
+/// Assertions:
+/// 1. Balance sheet balances: assets == liabilities + equity (incl. net income)
+/// 2. Net income on the income statement == the corresponding equity movement
+/// 3. Trial balance is in balance: total debits == total credits
+pub fn verify_ties(
+    balance_sheet: &BalanceSheetReport,
+    income_statement: &IncomeStatementReport,
+    trial_balance: &TrialBalanceReport,
+) -> Result<(), String> {
+    // 1. Balance sheet must balance
+    if !balance_sheet.is_balanced {
+        return Err(format!(
+            "Balance sheet does not tie: assets ({}) != liabilities ({}) + equity ({})",
+            balance_sheet.total_assets_minor,
+            balance_sheet.total_liabilities_minor,
+            balance_sheet.total_equity_minor,
+        ));
+    }
+
+    // 2. Net income must match between income statement and balance sheet
+    if income_statement.net_income_minor != balance_sheet.net_income_minor {
+        return Err(format!(
+            "Net income mismatch: income statement ({}) != balance sheet net income plug ({})",
+            income_statement.net_income_minor,
+            balance_sheet.net_income_minor,
+        ));
+    }
+
+    // 3. Trial balance must be in balance
+    if !trial_balance.is_balanced {
+        return Err(format!(
+            "Trial balance does not tie: debits ({}) != credits ({})",
+            trial_balance.total_debits_minor,
+            trial_balance.total_credits_minor,
+        ));
+    }
+
+    // 4. Cross-check: income statement net income should equal the difference
+    // between revenue-type and expense-type totals from the trial balance
+    let tb_income: i64 = trial_balance
+        .rows
+        .iter()
+        .filter(|r| r.account_type == "Income")
+        .map(|r| r.credit_balance - r.debit_balance)
+        .sum();
+    let tb_expense: i64 = trial_balance
+        .rows
+        .iter()
+        .filter(|r| r.account_type == "Expense")
+        .map(|r| r.debit_balance - r.credit_balance)
+        .sum();
+    let tb_net_income = tb_income - tb_expense;
+
+    if tb_net_income != income_statement.net_income_minor {
+        return Err(format!(
+            "Trial balance net income ({}) != income statement net income ({})",
+            tb_net_income,
+            income_statement.net_income_minor,
+        ));
+    }
+
+    Ok(())
+}
+
+// ============================================================================
+// Helper: compute comparative prior period dates
+// ============================================================================
+
+/// Given a period (start, end), computes the prior period of the same duration.
+fn compute_prior_period(start_date: &str, end_date: &str) -> Result<(String, String), String> {
+    let start = chrono::NaiveDate::parse_from_str(start_date, "%Y-%m-%d")
+        .map_err(|e| format!("Invalid start_date '{}': {}", start_date, e))?;
+    let end = chrono::NaiveDate::parse_from_str(end_date, "%Y-%m-%d")
+        .map_err(|e| format!("Invalid end_date '{}': {}", end_date, e))?;
+
+    let duration = end.signed_duration_since(start);
+    let days = duration.num_days();
+    if days < 0 {
+        return Err("end_date must be >= start_date".to_string());
+    }
+
+    let prior_end = start - chrono::Duration::days(1);
+    let prior_start = prior_end - chrono::Duration::days(days);
+
+    Ok((
+        prior_start.format("%Y-%m-%d").to_string(),
+        prior_end.format("%Y-%m-%d").to_string(),
+    ))
+}
+
+// ============================================================================
+// Tauri Commands — Financial Statements
+// ============================================================================
+
+/// Input parameters for financial statement generation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatementParams {
+    /// Start date of the reporting period (ISO 8601 date, e.g. "2025-01-01").
+    pub start_date: String,
+    /// End date of the reporting period (ISO 8601 date, e.g. "2025-12-31").
+    pub end_date: String,
+}
+
+/// Generates a balance sheet with comparative prior period.
+/// Runs verify_ties before returning — a statement that does not tie is an error.
+///
+/// # Arguments
+/// * `state` - Database state managed by Tauri.
+/// * `params` - Period start and end dates.
+///
+/// # Returns
+/// Comparative balance sheet with current and prior period.
+///
+/// # Errors
+/// Returns a string error if the query fails or statements do not tie.
+#[tauri::command]
+pub async fn get_balance_sheet(
+    state: State<'_, DatabaseState>,
+    params: StatementParams,
+) -> Result<ComparativeBalanceSheet, String> {
+    // Current period
+    let current_rows = query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
+    let current_bs = build_balance_sheet(&current_rows, &params.start_date, &params.end_date);
+    let current_is = build_income_statement(&current_rows, &params.start_date, &params.end_date);
+    let current_tb = build_trial_balance(&current_rows, &params.start_date, &params.end_date);
+
+    verify_ties(&current_bs, &current_is, &current_tb)?;
+
+    // Prior period (same duration, immediately preceding)
+    let (prior_start, prior_end) = compute_prior_period(&params.start_date, &params.end_date)?;
+    let prior_rows = query_period_accounts(&state.pool, &prior_start, &prior_end).await?;
+    let prior_bs = build_balance_sheet(&prior_rows, &prior_start, &prior_end);
+
+    Ok(ComparativeBalanceSheet {
+        current: current_bs,
+        prior: prior_bs,
+    })
+}
+
+/// Generates an income statement with comparative prior period.
+/// Runs verify_ties before returning.
+///
+/// # Arguments
+/// * `state` - Database state managed by Tauri.
+/// * `params` - Period start and end dates.
+///
+/// # Returns
+/// Comparative income statement with current and prior period.
+///
+/// # Errors
+/// Returns a string error if the query fails or statements do not tie.
+#[tauri::command]
+pub async fn get_income_statement(
+    state: State<'_, DatabaseState>,
+    params: StatementParams,
+) -> Result<ComparativeIncomeStatement, String> {
+    let current_rows = query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
+    let current_bs = build_balance_sheet(&current_rows, &params.start_date, &params.end_date);
+    let current_is = build_income_statement(&current_rows, &params.start_date, &params.end_date);
+    let current_tb = build_trial_balance(&current_rows, &params.start_date, &params.end_date);
+
+    verify_ties(&current_bs, &current_is, &current_tb)?;
+
+    let (prior_start, prior_end) = compute_prior_period(&params.start_date, &params.end_date)?;
+    let prior_rows = query_period_accounts(&state.pool, &prior_start, &prior_end).await?;
+    let prior_is = build_income_statement(&prior_rows, &prior_start, &prior_end);
+
+    Ok(ComparativeIncomeStatement {
+        current: current_is,
+        prior: prior_is,
+    })
+}
+
+/// Generates a trial balance with comparative prior period.
+/// Runs verify_ties before returning.
+///
+/// # Arguments
+/// * `state` - Database state managed by Tauri.
+/// * `params` - Period start and end dates.
+///
+/// # Returns
+/// Comparative trial balance with current and prior period.
+///
+/// # Errors
+/// Returns a string error if the query fails or statements do not tie.
+#[tauri::command]
+pub async fn get_period_trial_balance(
+    state: State<'_, DatabaseState>,
+    params: StatementParams,
+) -> Result<ComparativeTrialBalance, String> {
+    let current_rows = query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
+    let current_bs = build_balance_sheet(&current_rows, &params.start_date, &params.end_date);
+    let current_is = build_income_statement(&current_rows, &params.start_date, &params.end_date);
+    let current_tb = build_trial_balance(&current_rows, &params.start_date, &params.end_date);
+
+    verify_ties(&current_bs, &current_is, &current_tb)?;
+
+    let (prior_start, prior_end) = compute_prior_period(&params.start_date, &params.end_date)?;
+    let prior_rows = query_period_accounts(&state.pool, &prior_start, &prior_end).await?;
+    let prior_tb = build_trial_balance(&prior_rows, &prior_start, &prior_end);
+
+    Ok(ComparativeTrialBalance {
+        current: current_tb,
+        prior: prior_tb,
+    })
+}
+
+// ============================================================================
+// CSV Export Commands
+// ============================================================================
+
+/// Exports a balance sheet to CSV at the specified file path.
+///
+/// # Arguments
+/// * `state` - Database state managed by Tauri.
+/// * `params` - Period start and end dates.
+/// * `path` - File system path for the CSV output.
+///
+/// # Errors
+/// Returns a string error if the query fails, statements do not tie, or file I/O fails.
+#[tauri::command]
+pub async fn export_balance_sheet_csv(
+    state: State<'_, DatabaseState>,
+    params: StatementParams,
+    path: String,
+) -> Result<(), String> {
+    let rows = query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
+    let bs = build_balance_sheet(&rows, &params.start_date, &params.end_date);
+    let is = build_income_statement(&rows, &params.start_date, &params.end_date);
+    let tb = build_trial_balance(&rows, &params.start_date, &params.end_date);
+    verify_ties(&bs, &is, &tb)?;
+
+    let mut writer = Writer::from_path(&path).map_err(|e| e.to_string())?;
+
+    writer
+        .write_record(["Section", "Account #", "Account Name", "Balance"])
+        .map_err(|e| e.to_string())?;
+
+    for item in &bs.assets.items {
+        writer
+            .write_record([
+                "Assets",
+                &item.account_number,
+                &item.account_name,
+                &format_minor(item.balance_minor),
+            ])
+            .map_err(|e| e.to_string())?;
+    }
+    writer
+        .write_record(["", "", "Total Assets", &format_minor(bs.total_assets_minor)])
+        .map_err(|e| e.to_string())?;
+
+    for item in &bs.liabilities.items {
+        writer
+            .write_record([
+                "Liabilities",
+                &item.account_number,
+                &item.account_name,
+                &format_minor(item.balance_minor),
+            ])
+            .map_err(|e| e.to_string())?;
+    }
+    writer
+        .write_record([
+            "",
+            "",
+            "Total Liabilities",
+            &format_minor(bs.total_liabilities_minor),
+        ])
+        .map_err(|e| e.to_string())?;
+
+    for item in &bs.equity.items {
+        writer
+            .write_record([
+                "Equity",
+                &item.account_number,
+                &item.account_name,
+                &format_minor(item.balance_minor),
+            ])
+            .map_err(|e| e.to_string())?;
+    }
+    writer
+        .write_record(["Equity", "", "Net Income", &format_minor(bs.net_income_minor)])
+        .map_err(|e| e.to_string())?;
+    writer
+        .write_record(["", "", "Total Equity", &format_minor(bs.total_equity_minor)])
+        .map_err(|e| e.to_string())?;
+
+    writer.flush().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Exports an income statement to CSV at the specified file path.
+///
+/// # Arguments
+/// * `state` - Database state managed by Tauri.
+/// * `params` - Period start and end dates.
+/// * `path` - File system path for the CSV output.
+///
+/// # Errors
+/// Returns a string error if the query fails, statements do not tie, or file I/O fails.
+#[tauri::command]
+pub async fn export_income_statement_csv(
+    state: State<'_, DatabaseState>,
+    params: StatementParams,
+    path: String,
+) -> Result<(), String> {
+    let rows = query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
+    let bs = build_balance_sheet(&rows, &params.start_date, &params.end_date);
+    let is = build_income_statement(&rows, &params.start_date, &params.end_date);
+    let tb = build_trial_balance(&rows, &params.start_date, &params.end_date);
+    verify_ties(&bs, &is, &tb)?;
+
+    let mut writer = Writer::from_path(&path).map_err(|e| e.to_string())?;
+
+    writer
+        .write_record(["Section", "Account #", "Account Name", "Amount"])
+        .map_err(|e| e.to_string())?;
+
+    for item in &is.revenue.items {
+        writer
+            .write_record([
+                "Revenue",
+                &item.account_number,
+                &item.account_name,
+                &format_minor(item.balance_minor),
+            ])
+            .map_err(|e| e.to_string())?;
+    }
+    writer
+        .write_record(["", "", "Total Revenue", &format_minor(is.total_revenue_minor)])
+        .map_err(|e| e.to_string())?;
+
+    for item in &is.expenses.items {
+        writer
+            .write_record([
+                "Expenses",
+                &item.account_number,
+                &item.account_name,
+                &format_minor(item.balance_minor),
+            ])
+            .map_err(|e| e.to_string())?;
+    }
+    writer
+        .write_record(["", "", "Total Expenses", &format_minor(is.total_expenses_minor)])
+        .map_err(|e| e.to_string())?;
+
+    writer
+        .write_record(["", "", "Net Income", &format_minor(is.net_income_minor)])
+        .map_err(|e| e.to_string())?;
+
+    writer.flush().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Exports a trial balance to CSV at the specified file path.
+///
+/// # Arguments
+/// * `state` - Database state managed by Tauri.
+/// * `params` - Period start and end dates.
+/// * `path` - File system path for the CSV output.
+///
+/// # Errors
+/// Returns a string error if the query fails, statements do not tie, or file I/O fails.
+#[tauri::command]
+pub async fn export_trial_balance_csv(
+    state: State<'_, DatabaseState>,
+    params: StatementParams,
+    path: String,
+) -> Result<(), String> {
+    let rows = query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
+    let bs = build_balance_sheet(&rows, &params.start_date, &params.end_date);
+    let is = build_income_statement(&rows, &params.start_date, &params.end_date);
+    let tb = build_trial_balance(&rows, &params.start_date, &params.end_date);
+    verify_ties(&bs, &is, &tb)?;
+
+    let mut writer = Writer::from_path(&path).map_err(|e| e.to_string())?;
+
+    writer
+        .write_record(["Account #", "Account Name", "Type", "Debit", "Credit"])
+        .map_err(|e| e.to_string())?;
+
+    for row in &tb.rows {
+        writer
+            .write_record([
+                &row.account_number,
+                &row.account_name,
+                &row.account_type,
+                &format_minor(row.debit_balance),
+                &format_minor(row.credit_balance),
+            ])
+            .map_err(|e| e.to_string())?;
+    }
+
+    writer
+        .write_record([
+            "",
+            "",
+            "Totals",
+            &format_minor(tb.total_debits_minor),
+            &format_minor(tb.total_credits_minor),
+        ])
+        .map_err(|e| e.to_string())?;
+
+    writer.flush().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+/// Formats minor units (cents) as a dollar string (e.g. 12345 -> "123.45").
+fn format_minor(minor: i64) -> String {
+    let sign = if minor < 0 { "-" } else { "" };
+    let abs = minor.unsigned_abs();
+    let dollars = abs / 100;
+    let cents = abs % 100;
+    format!("{sign}{dollars}.{cents:02}")
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: creates a PeriodAccountRow for testing.
+    fn row(
+        account_number: &str,
+        account_name: &str,
+        account_type: &str,
+        debit: i64,
+        credit: i64,
+    ) -> PeriodAccountRow {
+        PeriodAccountRow {
+            account_number: account_number.to_string(),
+            account_name: account_name.to_string(),
+            account_type: account_type.to_string(),
+            total_debit_minor: debit,
+            total_credit_minor: credit,
+        }
+    }
+
+    /// A balanced set of fixture rows for testing:
+    /// Cash (Asset): dr 50000, cr 0 -> balance 50000
+    /// Accounts Payable (Liability): dr 0, cr 10000 -> balance 10000
+    /// Owner Equity (Equity): dr 0, cr 30000 -> balance 30000
+    /// Donation Revenue (Income): dr 0, cr 20000 -> balance 20000
+    /// Office Supplies (Expense): dr 10000, cr 0 -> balance 10000
+    ///
+    /// Check: TB debits = 60000, credits = 60000 (balanced)
+    /// Net income = 20000 - 10000 = 10000
+    /// Assets = 50000, Liabilities = 10000, Equity = 30000 + 10000 NI = 40000
+    /// A = L + E: 50000 = 10000 + 40000 ✓
+    fn balanced_fixture() -> Vec<PeriodAccountRow> {
+        vec![
+            row("1000", "Cash", "Asset", 50000, 0),
+            row("2000", "Accounts Payable", "Liability", 0, 10000),
+            row("3000", "Owner Equity", "Equity", 0, 30000),
+            row("4000", "Donation Revenue", "Income", 0, 20000),
+            row("5000", "Office Supplies", "Expense", 10000, 0),
+        ]
+    }
+
+    #[test]
+    fn test_balance_sheet_ties() {
+        let rows = balanced_fixture();
+        let bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+
+        assert_eq!(bs.total_assets_minor, 50000);
+        assert_eq!(bs.total_liabilities_minor, 10000);
+        assert_eq!(bs.net_income_minor, 10000);
+        assert_eq!(bs.total_equity_minor, 40000); // 30000 equity + 10000 NI
+        assert!(bs.is_balanced);
+        assert_eq!(
+            bs.total_assets_minor,
+            bs.total_liabilities_minor + bs.total_equity_minor
+        );
+    }
+
+    #[test]
+    fn test_income_statement_net_income() {
+        let rows = balanced_fixture();
+        let is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
+
+        assert_eq!(is.total_revenue_minor, 20000);
+        assert_eq!(is.total_expenses_minor, 10000);
+        assert_eq!(is.net_income_minor, 10000);
+    }
+
+    #[test]
+    fn test_trial_balance_balances() {
+        let rows = balanced_fixture();
+        let tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
+
+        assert_eq!(tb.total_debits_minor, 60000);
+        assert_eq!(tb.total_credits_minor, 60000);
+        assert!(tb.is_balanced);
+    }
+
+    #[test]
+    fn test_verify_ties_pass() {
+        let rows = balanced_fixture();
+        let bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+        let is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
+        let tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
+
+        assert!(verify_ties(&bs, &is, &tb).is_ok());
+    }
+
+    #[test]
+    fn test_verify_ties_fails_on_corrupted_balance_sheet() {
+        let rows = balanced_fixture();
+        let mut bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+        let is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
+        let tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
+
+        // Corrupt the balance sheet
+        bs.total_assets_minor += 100;
+        bs.is_balanced = false;
+
+        let result = verify_ties(&bs, &is, &tb);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Balance sheet does not tie"));
+    }
+
+    #[test]
+    fn test_verify_ties_fails_on_net_income_mismatch() {
+        let rows = balanced_fixture();
+        let bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+        let mut is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
+        let tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
+
+        // Corrupt income statement
+        is.net_income_minor += 500;
+
+        let result = verify_ties(&bs, &is, &tb);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Net income mismatch"));
+    }
+
+    #[test]
+    fn test_verify_ties_fails_on_unbalanced_trial_balance() {
+        let rows = balanced_fixture();
+        let bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+        let is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
+        let mut tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
+
+        // Corrupt trial balance
+        tb.total_debits_minor += 1;
+        tb.is_balanced = false;
+
+        let result = verify_ties(&bs, &is, &tb);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Trial balance does not tie"));
+    }
+
+    #[test]
+    fn test_voided_entry_neutrality() {
+        // A voided entry creates a reversing entry. Both are posted.
+        // The original: dr Cash 10000, cr Revenue 10000
+        // The reversal: dr Revenue 10000, cr Cash 10000
+        // Net effect: zero on all accounts.
+        let rows = vec![
+            // Original entry debits + reversal credits to Cash
+            row("1000", "Cash", "Asset", 10000, 10000),
+            // Original entry credits + reversal debits to Revenue
+            row("4000", "Donation Revenue", "Income", 10000, 10000),
+        ];
+
+        let bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+        let is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
+        let tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
+
+        // All zeros — voided entry nets out
+        assert_eq!(bs.total_assets_minor, 0);
+        assert_eq!(bs.total_liabilities_minor, 0);
+        assert_eq!(bs.total_equity_minor, 0);
+        assert_eq!(is.net_income_minor, 0);
+        assert!(bs.is_balanced);
+
+        // Trial balance with zero rows is trivially balanced
+        assert!(tb.is_balanced);
+    }
+
+    #[test]
+    fn test_comparative_period_dates() {
+        // Full year 2025 (Jan 1 – Dec 31): 365 inclusive days.
+        // Prior end = Dec 31 2024. Prior period is same gap (364 days between
+        // start and end), so prior start = Jan 2 2024.
+        let (prior_start, prior_end) =
+            compute_prior_period("2025-01-01", "2025-12-31").unwrap();
+        assert_eq!(prior_end, "2024-12-31");
+        assert_eq!(prior_start, "2024-01-02");
+
+        // Monthly: January 2025 (31 inclusive days, gap = 30).
+        // Prior end = Dec 31 2024. Prior start = Dec 1 2024.
+        let (prior_start, prior_end) =
+            compute_prior_period("2025-01-01", "2025-01-31").unwrap();
+        assert_eq!(prior_end, "2024-12-31");
+        assert_eq!(prior_start, "2024-12-01");
+
+        // Single day period
+        let (prior_start, prior_end) =
+            compute_prior_period("2025-06-15", "2025-06-15").unwrap();
+        assert_eq!(prior_end, "2025-06-14");
+        assert_eq!(prior_start, "2025-06-14");
+    }
+
+    #[test]
+    fn test_format_minor() {
+        assert_eq!(format_minor(12345), "123.45");
+        assert_eq!(format_minor(100), "1.00");
+        assert_eq!(format_minor(5), "0.05");
+        assert_eq!(format_minor(0), "0.00");
+        assert_eq!(format_minor(-500), "-5.00");
+    }
+
+    #[test]
+    fn test_empty_period_produces_balanced_statements() {
+        let rows: Vec<PeriodAccountRow> = vec![];
+        let bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+        let is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
+        let tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
+
+        assert!(bs.is_balanced);
+        assert!(tb.is_balanced);
+        assert_eq!(is.net_income_minor, 0);
+        assert!(verify_ties(&bs, &is, &tb).is_ok());
+    }
+
+    #[test]
+    fn test_section_items_exclude_zero_balances() {
+        let rows = vec![
+            row("1000", "Cash", "Asset", 5000, 0),
+            row("1100", "Receivables", "Asset", 1000, 1000), // nets to zero
+        ];
+        let section = build_section("Assets", &rows, &["Asset"]);
+
+        assert_eq!(section.items.len(), 1);
+        assert_eq!(section.items[0].account_number, "1000");
+        assert_eq!(section.subtotal_minor, 5000);
+    }
+}

--- a/src-tauri/src/api/statements.rs
+++ b/src-tauri/src/api/statements.rs
@@ -218,7 +218,11 @@ fn build_section(label: &str, rows: &[PeriodAccountRow], types: &[&str]) -> Stat
             account_number: r.account_number.clone(),
             account_name: r.account_name.clone(),
             account_type: r.account_type.clone(),
-            balance_minor: signed_balance(&r.account_type, r.total_debit_minor, r.total_credit_minor),
+            balance_minor: signed_balance(
+                &r.account_type,
+                r.total_debit_minor,
+                r.total_credit_minor,
+            ),
         })
         .filter(|item| item.balance_minor != 0)
         .collect();
@@ -362,8 +366,7 @@ pub fn verify_ties(
     if income_statement.net_income_minor != balance_sheet.net_income_minor {
         return Err(format!(
             "Net income mismatch: income statement ({}) != balance sheet net income plug ({})",
-            income_statement.net_income_minor,
-            balance_sheet.net_income_minor,
+            income_statement.net_income_minor, balance_sheet.net_income_minor,
         ));
     }
 
@@ -371,8 +374,7 @@ pub fn verify_ties(
     if !trial_balance.is_balanced {
         return Err(format!(
             "Trial balance does not tie: debits ({}) != credits ({})",
-            trial_balance.total_debits_minor,
-            trial_balance.total_credits_minor,
+            trial_balance.total_debits_minor, trial_balance.total_credits_minor,
         ));
     }
 
@@ -395,8 +397,7 @@ pub fn verify_ties(
     if tb_net_income != income_statement.net_income_minor {
         return Err(format!(
             "Trial balance net income ({}) != income statement net income ({})",
-            tb_net_income,
-            income_statement.net_income_minor,
+            tb_net_income, income_statement.net_income_minor,
         ));
     }
 
@@ -461,7 +462,8 @@ pub async fn get_balance_sheet(
     params: StatementParams,
 ) -> Result<ComparativeBalanceSheet, String> {
     // Current period
-    let current_rows = query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
+    let current_rows =
+        query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
     let current_bs = build_balance_sheet(&current_rows, &params.start_date, &params.end_date);
     let current_is = build_income_statement(&current_rows, &params.start_date, &params.end_date);
     let current_tb = build_trial_balance(&current_rows, &params.start_date, &params.end_date);
@@ -496,7 +498,8 @@ pub async fn get_income_statement(
     state: State<'_, DatabaseState>,
     params: StatementParams,
 ) -> Result<ComparativeIncomeStatement, String> {
-    let current_rows = query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
+    let current_rows =
+        query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
     let current_bs = build_balance_sheet(&current_rows, &params.start_date, &params.end_date);
     let current_is = build_income_statement(&current_rows, &params.start_date, &params.end_date);
     let current_tb = build_trial_balance(&current_rows, &params.start_date, &params.end_date);
@@ -530,7 +533,8 @@ pub async fn get_period_trial_balance(
     state: State<'_, DatabaseState>,
     params: StatementParams,
 ) -> Result<ComparativeTrialBalance, String> {
-    let current_rows = query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
+    let current_rows =
+        query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
     let current_bs = build_balance_sheet(&current_rows, &params.start_date, &params.end_date);
     let current_is = build_income_statement(&current_rows, &params.start_date, &params.end_date);
     let current_tb = build_trial_balance(&current_rows, &params.start_date, &params.end_date);
@@ -622,7 +626,12 @@ pub async fn export_balance_sheet_csv(
             .map_err(|e| e.to_string())?;
     }
     writer
-        .write_record(["Equity", "", "Net Income", &format_minor(bs.net_income_minor)])
+        .write_record([
+            "Equity",
+            "",
+            "Net Income",
+            &format_minor(bs.net_income_minor),
+        ])
         .map_err(|e| e.to_string())?;
     writer
         .write_record(["", "", "Total Equity", &format_minor(bs.total_equity_minor)])
@@ -670,7 +679,12 @@ pub async fn export_income_statement_csv(
             .map_err(|e| e.to_string())?;
     }
     writer
-        .write_record(["", "", "Total Revenue", &format_minor(is.total_revenue_minor)])
+        .write_record([
+            "",
+            "",
+            "Total Revenue",
+            &format_minor(is.total_revenue_minor),
+        ])
         .map_err(|e| e.to_string())?;
 
     for item in &is.expenses.items {
@@ -684,7 +698,12 @@ pub async fn export_income_statement_csv(
             .map_err(|e| e.to_string())?;
     }
     writer
-        .write_record(["", "", "Total Expenses", &format_minor(is.total_expenses_minor)])
+        .write_record([
+            "",
+            "",
+            "Total Expenses",
+            &format_minor(is.total_expenses_minor),
+        ])
         .map_err(|e| e.to_string())?;
 
     writer
@@ -862,9 +881,7 @@ mod tests {
 
         let result = verify_ties(&bs, &is, &tb);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .contains("Balance sheet does not tie"));
+        assert!(result.unwrap_err().contains("Balance sheet does not tie"));
     }
 
     #[test]
@@ -931,21 +948,18 @@ mod tests {
         // Full year 2025 (Jan 1 – Dec 31): 365 inclusive days.
         // Prior end = Dec 31 2024. Prior period is same gap (364 days between
         // start and end), so prior start = Jan 2 2024.
-        let (prior_start, prior_end) =
-            compute_prior_period("2025-01-01", "2025-12-31").unwrap();
+        let (prior_start, prior_end) = compute_prior_period("2025-01-01", "2025-12-31").unwrap();
         assert_eq!(prior_end, "2024-12-31");
         assert_eq!(prior_start, "2024-01-02");
 
         // Monthly: January 2025 (31 inclusive days, gap = 30).
         // Prior end = Dec 31 2024. Prior start = Dec 1 2024.
-        let (prior_start, prior_end) =
-            compute_prior_period("2025-01-01", "2025-01-31").unwrap();
+        let (prior_start, prior_end) = compute_prior_period("2025-01-01", "2025-01-31").unwrap();
         assert_eq!(prior_end, "2024-12-31");
         assert_eq!(prior_start, "2024-12-01");
 
         // Single day period
-        let (prior_start, prior_end) =
-            compute_prior_period("2025-06-15", "2025-06-15").unwrap();
+        let (prior_start, prior_end) = compute_prior_period("2025-06-15", "2025-06-15").unwrap();
         assert_eq!(prior_end, "2025-06-14");
         assert_eq!(prior_start, "2025-06-14");
     }

--- a/src-tauri/src/api/statements.rs
+++ b/src-tauri/src/api/statements.rs
@@ -55,7 +55,8 @@ pub struct StatementSection {
     pub subtotal_minor: i64,
 }
 
-/// Balance sheet report for a given date range.
+/// Balance sheet report as of `end_date` (cumulative from inception).
+/// `start_date` scopes the current-period net income split only.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BalanceSheetReport {
@@ -63,13 +64,17 @@ pub struct BalanceSheetReport {
     pub start_date: String,
     /// End date of the reporting period (ISO 8601 date string).
     pub end_date: String,
-    /// Assets section.
+    /// Assets section (cumulative balances as of end_date).
     pub assets: StatementSection,
-    /// Liabilities section.
+    /// Liabilities section (cumulative balances as of end_date).
     pub liabilities: StatementSection,
-    /// Equity section (excluding current-period net income).
+    /// Equity section (contributed equity accounts, excluding retained
+    /// earnings and current-period net income).
     pub equity: StatementSection,
-    /// Current-period net income in minor units (plugged into equity).
+    /// Retained earnings in minor units: accumulated net income from
+    /// inception through the day before start_date.
+    pub retained_earnings_minor: i64,
+    /// Current-period net income in minor units (start_date..=end_date).
     pub net_income_minor: i64,
     /// Total assets in minor units.
     pub total_assets_minor: i64,
@@ -163,12 +168,24 @@ struct PeriodAccountRow {
     total_credit_minor: i64,
 }
 
-/// Queries posted journal entries within a date range, aggregating debit_minor
-/// and credit_minor per GL account. Only posted entries (is_posted = 1) are
-/// included — voided entries net out via their reversing entries.
-async fn query_period_accounts(
+/// Aggregates posted journal-entry activity per GL account.
+///
+/// Filtering uses INNER JOINs with predicates in the WHERE clause. Putting the
+/// posted/date predicates on a chained LEFT JOIN's ON clause only NULLs the
+/// joined columns — the line rows still survive and get summed, which leaked
+/// draft and out-of-period lines into statements (caught in CTO review).
+///
+/// * `start_date = None` — cumulative activity from inception through
+///   `end_date` (balance-sheet / as-of semantics).
+/// * `start_date = Some(d)` — activity within `[d, end_date]`
+///   (income-statement / period semantics).
+///
+/// Only posted entries (is_posted = 1) are included — voided entries net out
+/// via their reversing entries. Inactive accounts with posted history are
+/// intentionally INCLUDED: excluding them would break the ties.
+async fn query_account_activity(
     pool: &sqlx::SqlitePool,
-    start_date: &str,
+    start_date: Option<&str>,
     end_date: &str,
 ) -> Result<Vec<PeriodAccountRow>, String> {
     sqlx::query_as::<_, PeriodAccountRow>(
@@ -179,21 +196,21 @@ async fn query_period_accounts(
             ga.account_type,
             COALESCE(SUM(jel.debit_minor), 0) AS total_debit_minor,
             COALESCE(SUM(jel.credit_minor), 0) AS total_credit_minor
-        FROM gl_accounts ga
-        LEFT JOIN journal_entry_lines jel ON ga.id = jel.gl_account_id
-        LEFT JOIN journal_entries je ON jel.journal_entry_id = je.id
-            AND je.is_posted = 1
-            AND DATE(je.entry_date) >= ?
-            AND DATE(je.entry_date) <= ?
-        WHERE ga.is_active = 1
+        FROM journal_entry_lines jel
+        INNER JOIN journal_entries je ON je.id = jel.journal_entry_id
+        INNER JOIN gl_accounts ga ON ga.id = jel.gl_account_id
+        WHERE je.is_posted = 1
+            AND DATE(je.entry_date) <= DATE(?)
+            AND (? IS NULL OR DATE(je.entry_date) >= DATE(?))
         GROUP BY ga.id, ga.account_number, ga.account_name, ga.account_type
         HAVING COALESCE(SUM(jel.debit_minor), 0) != 0
             OR COALESCE(SUM(jel.credit_minor), 0) != 0
         ORDER BY ga.account_number
         "#,
     )
-    .bind(start_date)
     .bind(end_date)
+    .bind(start_date)
+    .bind(start_date)
     .fetch_all(pool)
     .await
     .map_err(|e| e.to_string())
@@ -240,27 +257,42 @@ fn build_section(label: &str, rows: &[PeriodAccountRow], types: &[&str]) -> Stat
 // Statement Builders (pure logic, testable)
 // ============================================================================
 
-/// Builds a balance sheet from period account rows.
+/// Builds a balance sheet as of `end_date`.
 ///
-/// Balance sheet tie: total_assets == total_liabilities + total_equity
-/// where total_equity includes current-period net income.
+/// A balance sheet reports cumulative positions, not period movements:
+/// `cumulative_rows` must cover inception..=end_date and `period_rows` must
+/// cover start_date..=end_date (both posted-only). Building A/L/E from period
+/// activity alone would drop every opening balance (caught in CTO review).
+///
+/// Equity decomposes as: contributed equity accounts (cumulative) + retained
+/// earnings (net income accumulated before start_date) + current-period net
+/// income. Tie: total_assets == total_liabilities + total_equity.
 fn build_balance_sheet(
-    rows: &[PeriodAccountRow],
+    cumulative_rows: &[PeriodAccountRow],
+    period_rows: &[PeriodAccountRow],
     start_date: &str,
     end_date: &str,
 ) -> BalanceSheetReport {
-    let assets = build_section("Assets", rows, &["Asset"]);
-    let liabilities = build_section("Liabilities", rows, &["Liability"]);
-    let equity = build_section("Equity", rows, &["Equity"]);
+    let assets = build_section("Assets", cumulative_rows, &["Asset"]);
+    let liabilities = build_section("Liabilities", cumulative_rows, &["Liability"]);
+    let equity = build_section("Equity", cumulative_rows, &["Equity"]);
 
-    // Net income = Income - Expenses for the period
-    let revenue_section = build_section("Income", rows, &["Income"]);
-    let expense_section = build_section("Expenses", rows, &["Expense"]);
-    let net_income_minor = revenue_section.subtotal_minor - expense_section.subtotal_minor;
+    // Current-period net income = Income - Expenses over the period rows.
+    let period_revenue = build_section("Income", period_rows, &["Income"]);
+    let period_expense = build_section("Expenses", period_rows, &["Expense"]);
+    let net_income_minor = period_revenue.subtotal_minor - period_expense.subtotal_minor;
+
+    // Retained earnings = accumulated net income from inception through the
+    // day before start_date (cumulative NI minus the current-period portion).
+    let cumulative_revenue = build_section("Income", cumulative_rows, &["Income"]);
+    let cumulative_expense = build_section("Expenses", cumulative_rows, &["Expense"]);
+    let cumulative_net_income =
+        cumulative_revenue.subtotal_minor - cumulative_expense.subtotal_minor;
+    let retained_earnings_minor = cumulative_net_income - net_income_minor;
 
     let total_assets_minor = assets.subtotal_minor;
     let total_liabilities_minor = liabilities.subtotal_minor;
-    let total_equity_minor = equity.subtotal_minor + net_income_minor;
+    let total_equity_minor = equity.subtotal_minor + retained_earnings_minor + net_income_minor;
 
     let is_balanced = total_assets_minor == total_liabilities_minor + total_equity_minor;
 
@@ -270,6 +302,7 @@ fn build_balance_sheet(
         assets,
         liabilities,
         equity,
+        retained_earnings_minor,
         net_income_minor,
         total_assets_minor,
         total_liabilities_minor,
@@ -302,7 +335,9 @@ fn build_income_statement(
     }
 }
 
-/// Builds a trial balance from period account rows.
+/// Builds a trial balance as of `end_date` from cumulative account rows
+/// (inception..=end_date, posted-only) — conventional "trial balance as at
+/// date" semantics, consistent with the Phase 2 balances and the M4 views.
 fn build_trial_balance(
     rows: &[PeriodAccountRow],
     start_date: &str,
@@ -344,9 +379,12 @@ fn build_trial_balance(
 /// assertions pass, or Err with a description of what failed.
 ///
 /// Assertions:
-/// 1. Balance sheet balances: assets == liabilities + equity (incl. net income)
+/// 1. Balance sheet balances: assets == liabilities + equity
+///    (incl. retained earnings and current-period net income)
 /// 2. Net income on the income statement == the corresponding equity movement
 /// 3. Trial balance is in balance: total debits == total credits
+/// 4. Trial balance cumulative net income (Income − Expense as of end_date)
+///    == balance sheet retained earnings + current-period net income
 pub fn verify_ties(
     balance_sheet: &BalanceSheetReport,
     income_statement: &IncomeStatementReport,
@@ -378,8 +416,9 @@ pub fn verify_ties(
         ));
     }
 
-    // 4. Cross-check: income statement net income should equal the difference
-    // between revenue-type and expense-type totals from the trial balance
+    // 4. Cross-check: the trial balance is cumulative as of end_date, so its
+    // Income − Expense total must equal retained earnings + current-period
+    // net income on the balance sheet.
     let tb_income: i64 = trial_balance
         .rows
         .iter()
@@ -393,11 +432,13 @@ pub fn verify_ties(
         .map(|r| r.debit_balance - r.credit_balance)
         .sum();
     let tb_net_income = tb_income - tb_expense;
+    let bs_accumulated_income =
+        balance_sheet.retained_earnings_minor + balance_sheet.net_income_minor;
 
-    if tb_net_income != income_statement.net_income_minor {
+    if tb_net_income != bs_accumulated_income {
         return Err(format!(
-            "Trial balance net income ({}) != income statement net income ({})",
-            tb_net_income, income_statement.net_income_minor,
+            "Trial balance cumulative net income ({}) != balance sheet retained earnings + net income ({})",
+            tb_net_income, bs_accumulated_income,
         ));
     }
 
@@ -431,6 +472,42 @@ fn compute_prior_period(start_date: &str, end_date: &str) -> Result<(String, Str
 }
 
 // ============================================================================
+// Shared builder — query, build, and verify all three statements
+// ============================================================================
+
+/// All three statements for one period, built together and verified as a set.
+struct VerifiedStatements {
+    balance_sheet: BalanceSheetReport,
+    income_statement: IncomeStatementReport,
+    trial_balance: TrialBalanceReport,
+}
+
+/// Queries cumulative (inception..=end) and period (start..=end) activity,
+/// builds all three statements, and runs `verify_ties`. Every statement
+/// handed to the UI or an export goes through this single gate — a statement
+/// that does not tie is a hard error, never a silent render.
+async fn build_verified_statements(
+    pool: &sqlx::SqlitePool,
+    start_date: &str,
+    end_date: &str,
+) -> Result<VerifiedStatements, String> {
+    let cumulative_rows = query_account_activity(pool, None, end_date).await?;
+    let period_rows = query_account_activity(pool, Some(start_date), end_date).await?;
+
+    let balance_sheet = build_balance_sheet(&cumulative_rows, &period_rows, start_date, end_date);
+    let income_statement = build_income_statement(&period_rows, start_date, end_date);
+    let trial_balance = build_trial_balance(&cumulative_rows, start_date, end_date);
+
+    verify_ties(&balance_sheet, &income_statement, &trial_balance)?;
+
+    Ok(VerifiedStatements {
+        balance_sheet,
+        income_statement,
+        trial_balance,
+    })
+}
+
+// ============================================================================
 // Tauri Commands — Financial Statements
 // ============================================================================
 
@@ -461,23 +538,15 @@ pub async fn get_balance_sheet(
     state: State<'_, DatabaseState>,
     params: StatementParams,
 ) -> Result<ComparativeBalanceSheet, String> {
-    // Current period
-    let current_rows =
-        query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
-    let current_bs = build_balance_sheet(&current_rows, &params.start_date, &params.end_date);
-    let current_is = build_income_statement(&current_rows, &params.start_date, &params.end_date);
-    let current_tb = build_trial_balance(&current_rows, &params.start_date, &params.end_date);
-
-    verify_ties(&current_bs, &current_is, &current_tb)?;
-
-    // Prior period (same duration, immediately preceding)
     let (prior_start, prior_end) = compute_prior_period(&params.start_date, &params.end_date)?;
-    let prior_rows = query_period_accounts(&state.pool, &prior_start, &prior_end).await?;
-    let prior_bs = build_balance_sheet(&prior_rows, &prior_start, &prior_end);
+
+    let current =
+        build_verified_statements(&state.pool, &params.start_date, &params.end_date).await?;
+    let prior = build_verified_statements(&state.pool, &prior_start, &prior_end).await?;
 
     Ok(ComparativeBalanceSheet {
-        current: current_bs,
-        prior: prior_bs,
+        current: current.balance_sheet,
+        prior: prior.balance_sheet,
     })
 }
 
@@ -498,21 +567,15 @@ pub async fn get_income_statement(
     state: State<'_, DatabaseState>,
     params: StatementParams,
 ) -> Result<ComparativeIncomeStatement, String> {
-    let current_rows =
-        query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
-    let current_bs = build_balance_sheet(&current_rows, &params.start_date, &params.end_date);
-    let current_is = build_income_statement(&current_rows, &params.start_date, &params.end_date);
-    let current_tb = build_trial_balance(&current_rows, &params.start_date, &params.end_date);
-
-    verify_ties(&current_bs, &current_is, &current_tb)?;
-
     let (prior_start, prior_end) = compute_prior_period(&params.start_date, &params.end_date)?;
-    let prior_rows = query_period_accounts(&state.pool, &prior_start, &prior_end).await?;
-    let prior_is = build_income_statement(&prior_rows, &prior_start, &prior_end);
+
+    let current =
+        build_verified_statements(&state.pool, &params.start_date, &params.end_date).await?;
+    let prior = build_verified_statements(&state.pool, &prior_start, &prior_end).await?;
 
     Ok(ComparativeIncomeStatement {
-        current: current_is,
-        prior: prior_is,
+        current: current.income_statement,
+        prior: prior.income_statement,
     })
 }
 
@@ -533,21 +596,15 @@ pub async fn get_period_trial_balance(
     state: State<'_, DatabaseState>,
     params: StatementParams,
 ) -> Result<ComparativeTrialBalance, String> {
-    let current_rows =
-        query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
-    let current_bs = build_balance_sheet(&current_rows, &params.start_date, &params.end_date);
-    let current_is = build_income_statement(&current_rows, &params.start_date, &params.end_date);
-    let current_tb = build_trial_balance(&current_rows, &params.start_date, &params.end_date);
-
-    verify_ties(&current_bs, &current_is, &current_tb)?;
-
     let (prior_start, prior_end) = compute_prior_period(&params.start_date, &params.end_date)?;
-    let prior_rows = query_period_accounts(&state.pool, &prior_start, &prior_end).await?;
-    let prior_tb = build_trial_balance(&prior_rows, &prior_start, &prior_end);
+
+    let current =
+        build_verified_statements(&state.pool, &params.start_date, &params.end_date).await?;
+    let prior = build_verified_statements(&state.pool, &prior_start, &prior_end).await?;
 
     Ok(ComparativeTrialBalance {
-        current: current_tb,
-        prior: prior_tb,
+        current: current.trial_balance,
+        prior: prior.trial_balance,
     })
 }
 
@@ -570,11 +627,9 @@ pub async fn export_balance_sheet_csv(
     params: StatementParams,
     path: String,
 ) -> Result<(), String> {
-    let rows = query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
-    let bs = build_balance_sheet(&rows, &params.start_date, &params.end_date);
-    let is = build_income_statement(&rows, &params.start_date, &params.end_date);
-    let tb = build_trial_balance(&rows, &params.start_date, &params.end_date);
-    verify_ties(&bs, &is, &tb)?;
+    let statements =
+        build_verified_statements(&state.pool, &params.start_date, &params.end_date).await?;
+    let bs = statements.balance_sheet;
 
     let mut writer = Writer::from_path(&path).map_err(|e| e.to_string())?;
 
@@ -629,7 +684,15 @@ pub async fn export_balance_sheet_csv(
         .write_record([
             "Equity",
             "",
-            "Net Income",
+            "Retained Earnings",
+            &format_minor(bs.retained_earnings_minor),
+        ])
+        .map_err(|e| e.to_string())?;
+    writer
+        .write_record([
+            "Equity",
+            "",
+            "Net Income (current period)",
             &format_minor(bs.net_income_minor),
         ])
         .map_err(|e| e.to_string())?;
@@ -656,11 +719,9 @@ pub async fn export_income_statement_csv(
     params: StatementParams,
     path: String,
 ) -> Result<(), String> {
-    let rows = query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
-    let bs = build_balance_sheet(&rows, &params.start_date, &params.end_date);
-    let is = build_income_statement(&rows, &params.start_date, &params.end_date);
-    let tb = build_trial_balance(&rows, &params.start_date, &params.end_date);
-    verify_ties(&bs, &is, &tb)?;
+    let statements =
+        build_verified_statements(&state.pool, &params.start_date, &params.end_date).await?;
+    let is = statements.income_statement;
 
     let mut writer = Writer::from_path(&path).map_err(|e| e.to_string())?;
 
@@ -729,11 +790,9 @@ pub async fn export_trial_balance_csv(
     params: StatementParams,
     path: String,
 ) -> Result<(), String> {
-    let rows = query_period_accounts(&state.pool, &params.start_date, &params.end_date).await?;
-    let bs = build_balance_sheet(&rows, &params.start_date, &params.end_date);
-    let is = build_income_statement(&rows, &params.start_date, &params.end_date);
-    let tb = build_trial_balance(&rows, &params.start_date, &params.end_date);
-    verify_ties(&bs, &is, &tb)?;
+    let statements =
+        build_verified_statements(&state.pool, &params.start_date, &params.end_date).await?;
+    let tb = statements.trial_balance;
 
     let mut writer = Writer::from_path(&path).map_err(|e| e.to_string())?;
 
@@ -825,10 +884,11 @@ mod tests {
     #[test]
     fn test_balance_sheet_ties() {
         let rows = balanced_fixture();
-        let bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+        let bs = build_balance_sheet(&rows, &rows, "2025-01-01", "2025-12-31");
 
         assert_eq!(bs.total_assets_minor, 50000);
         assert_eq!(bs.total_liabilities_minor, 10000);
+        assert_eq!(bs.retained_earnings_minor, 0); // no pre-period history
         assert_eq!(bs.net_income_minor, 10000);
         assert_eq!(bs.total_equity_minor, 40000); // 30000 equity + 10000 NI
         assert!(bs.is_balanced);
@@ -861,7 +921,7 @@ mod tests {
     #[test]
     fn test_verify_ties_pass() {
         let rows = balanced_fixture();
-        let bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+        let bs = build_balance_sheet(&rows, &rows, "2025-01-01", "2025-12-31");
         let is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
         let tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
 
@@ -871,7 +931,7 @@ mod tests {
     #[test]
     fn test_verify_ties_fails_on_corrupted_balance_sheet() {
         let rows = balanced_fixture();
-        let mut bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+        let mut bs = build_balance_sheet(&rows, &rows, "2025-01-01", "2025-12-31");
         let is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
         let tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
 
@@ -887,7 +947,7 @@ mod tests {
     #[test]
     fn test_verify_ties_fails_on_net_income_mismatch() {
         let rows = balanced_fixture();
-        let bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+        let bs = build_balance_sheet(&rows, &rows, "2025-01-01", "2025-12-31");
         let mut is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
         let tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
 
@@ -902,7 +962,7 @@ mod tests {
     #[test]
     fn test_verify_ties_fails_on_unbalanced_trial_balance() {
         let rows = balanced_fixture();
-        let bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+        let bs = build_balance_sheet(&rows, &rows, "2025-01-01", "2025-12-31");
         let is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
         let mut tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
 
@@ -928,7 +988,7 @@ mod tests {
             row("4000", "Donation Revenue", "Income", 10000, 10000),
         ];
 
-        let bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+        let bs = build_balance_sheet(&rows, &rows, "2025-01-01", "2025-12-31");
         let is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
         let tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
 
@@ -976,7 +1036,7 @@ mod tests {
     #[test]
     fn test_empty_period_produces_balanced_statements() {
         let rows: Vec<PeriodAccountRow> = vec![];
-        let bs = build_balance_sheet(&rows, "2025-01-01", "2025-12-31");
+        let bs = build_balance_sheet(&rows, &rows, "2025-01-01", "2025-12-31");
         let is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
         let tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
 
@@ -997,5 +1057,219 @@ mod tests {
         assert_eq!(section.items.len(), 1);
         assert_eq!(section.items[0].account_number, "1000");
         assert_eq!(section.subtotal_minor, 5000);
+    }
+
+    #[test]
+    fn test_retained_earnings_split_from_prior_income() {
+        // Entity history: 10000 contributed equity, 20000 total income
+        // (15000 earned before the period, 5000 within the period).
+        let cumulative = vec![
+            row("1000", "Cash", "Asset", 30000, 0),
+            row("3000", "Owner Equity", "Equity", 0, 10000),
+            row("4000", "Donation Revenue", "Income", 0, 20000),
+        ];
+        let period = vec![
+            row("1000", "Cash", "Asset", 5000, 0),
+            row("4000", "Donation Revenue", "Income", 0, 5000),
+        ];
+
+        let bs = build_balance_sheet(&cumulative, &period, "2025-06-01", "2025-06-30");
+        let is = build_income_statement(&period, "2025-06-01", "2025-06-30");
+        let tb = build_trial_balance(&cumulative, "2025-06-01", "2025-06-30");
+
+        // Opening balances survive: assets are cumulative, not period movement.
+        assert_eq!(bs.total_assets_minor, 30000);
+        assert_eq!(bs.net_income_minor, 5000);
+        assert_eq!(bs.retained_earnings_minor, 15000);
+        assert_eq!(bs.total_equity_minor, 30000); // 10000 + 15000 RE + 5000 NI
+        assert!(bs.is_balanced);
+        assert_eq!(is.net_income_minor, 5000);
+        assert!(verify_ties(&bs, &is, &tb).is_ok());
+    }
+
+    #[test]
+    fn test_verify_ties_fails_on_corrupted_retained_earnings() {
+        let rows = balanced_fixture();
+        let mut bs = build_balance_sheet(&rows, &rows, "2025-01-01", "2025-12-31");
+        let is = build_income_statement(&rows, "2025-01-01", "2025-12-31");
+        let tb = build_trial_balance(&rows, "2025-01-01", "2025-12-31");
+
+        // Corrupt retained earnings while keeping the A = L + E arithmetic
+        // consistent, so only the trial-balance cross-check can catch it.
+        bs.retained_earnings_minor += 700;
+        bs.total_equity_minor += 700;
+        bs.total_assets_minor += 700;
+
+        let result = verify_ties(&bs, &is, &tb);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("Trial balance cumulative net income"));
+    }
+
+    // ========================================================================
+    // DB integration tests — the SQL layer itself (draft / date filtering)
+    // ========================================================================
+
+    /// Creates an in-memory SQLite pool with all migrations applied.
+    async fn setup_test_db() -> sqlx::SqlitePool {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .connect("sqlite::memory:")
+            .await
+            .expect("Failed to create in-memory SQLite pool");
+
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+
+        pool
+    }
+
+    /// Looks up a seed GL account id by account number.
+    async fn account_id(pool: &sqlx::SqlitePool, number: &str) -> i64 {
+        let (id,): (i64,) = sqlx::query_as("SELECT id FROM gl_accounts WHERE account_number = ?")
+            .bind(number)
+            .fetch_one(pool)
+            .await
+            .expect("Seed account should exist");
+        id
+    }
+
+    /// Creates a draft entry on a given date with one balanced debit/credit
+    /// line pair, and returns its id.
+    async fn create_draft_with_lines(
+        pool: &sqlx::SqlitePool,
+        entry_number: &str,
+        entry_date: &str,
+        debit_acct: i64,
+        credit_acct: i64,
+        amount_minor: i64,
+    ) -> i64 {
+        let result = sqlx::query(
+            "INSERT INTO journal_entries (entry_date, entry_number, description, is_posted, status, origin, created_by) VALUES (?, ?, 'Statement test entry', 0, 'draft', 'manual', 'test')",
+        )
+        .bind(entry_date)
+        .bind(entry_number)
+        .execute(pool)
+        .await
+        .expect("Failed to create draft entry");
+        let entry_id = result.last_insert_rowid();
+
+        let legacy_amount = amount_minor as f64 / 100.0;
+        sqlx::query(
+            "INSERT INTO journal_entry_lines (journal_entry_id, gl_account_id, debit_amount, credit_amount, debit_minor, credit_minor, asset_id, line_number) VALUES (?, ?, ?, 0, ?, 0, 'USD', 1)",
+        )
+        .bind(entry_id)
+        .bind(debit_acct)
+        .bind(legacy_amount)
+        .bind(amount_minor)
+        .execute(pool)
+        .await
+        .expect("Failed to add debit line");
+        sqlx::query(
+            "INSERT INTO journal_entry_lines (journal_entry_id, gl_account_id, debit_amount, credit_amount, debit_minor, credit_minor, asset_id, line_number) VALUES (?, ?, 0, ?, 0, ?, 'USD', 2)",
+        )
+        .bind(entry_id)
+        .bind(credit_acct)
+        .bind(legacy_amount)
+        .bind(amount_minor)
+        .execute(pool)
+        .await
+        .expect("Failed to add credit line");
+
+        entry_id
+    }
+
+    /// Walks an entry through draft -> approved -> posted via direct SQL.
+    async fn approve_and_post(pool: &sqlx::SqlitePool, entry_id: i64) {
+        sqlx::query(
+            "UPDATE journal_entries SET status = 'approved', approved_by = 'test', approved_at = CURRENT_TIMESTAMP WHERE id = ?",
+        )
+        .bind(entry_id)
+        .execute(pool)
+        .await
+        .expect("Failed to approve entry");
+        sqlx::query(
+            "UPDATE journal_entries SET status = 'posted', is_posted = 1, posted_at = CURRENT_TIMESTAMP WHERE id = ?",
+        )
+        .bind(entry_id)
+        .execute(pool)
+        .await
+        .expect("Failed to post entry");
+    }
+
+    /// Seeds: posted in-period (100.00), posted before period (555.00), and a
+    /// DRAFT in-period (999.00) that must never reach any statement.
+    async fn seed_statement_fixture(pool: &sqlx::SqlitePool) {
+        let cash = account_id(pool, "1000").await;
+        let income = account_id(pool, "4000").await;
+
+        let in_period =
+            create_draft_with_lines(pool, "ST-001", "2026-02-10", cash, income, 10000).await;
+        approve_and_post(pool, in_period).await;
+
+        let before_period =
+            create_draft_with_lines(pool, "ST-002", "2026-01-05", cash, income, 55500).await;
+        approve_and_post(pool, before_period).await;
+
+        // Draft stays a draft — is_posted = 0.
+        create_draft_with_lines(pool, "ST-003", "2026-02-15", cash, income, 99900).await;
+    }
+
+    #[tokio::test]
+    async fn db_query_excludes_drafts_and_out_of_period_entries() {
+        let pool = setup_test_db().await;
+        seed_statement_fixture(&pool).await;
+
+        // Period query: only the posted in-period entry.
+        let period_rows = query_account_activity(&pool, Some("2026-02-01"), "2026-02-28")
+            .await
+            .expect("period query should succeed");
+        let cash_row = period_rows
+            .iter()
+            .find(|r| r.account_number == "1000")
+            .expect("Cash should have period activity");
+        assert_eq!(
+            cash_row.total_debit_minor, 10000,
+            "Draft (99900) and January (55500) lines must be excluded"
+        );
+
+        // Cumulative query: both posted entries, still no draft.
+        let cumulative_rows = query_account_activity(&pool, None, "2026-02-28")
+            .await
+            .expect("cumulative query should succeed");
+        let cash_row = cumulative_rows
+            .iter()
+            .find(|r| r.account_number == "1000")
+            .expect("Cash should have cumulative activity");
+        assert_eq!(
+            cash_row.total_debit_minor,
+            10000 + 55500,
+            "Cumulative must include prior posted entries and exclude drafts"
+        );
+    }
+
+    #[tokio::test]
+    async fn db_balance_sheet_includes_opening_balances_and_ties() {
+        let pool = setup_test_db().await;
+        seed_statement_fixture(&pool).await;
+
+        let statements = build_verified_statements(&pool, "2026-02-01", "2026-02-28")
+            .await
+            .expect("statements should build and tie");
+
+        let bs = &statements.balance_sheet;
+        assert_eq!(bs.total_assets_minor, 65500, "Assets are as-of end date");
+        assert_eq!(bs.net_income_minor, 10000, "NI is period-scoped");
+        assert_eq!(
+            bs.retained_earnings_minor, 55500,
+            "Pre-period income lands in retained earnings"
+        );
+        assert!(bs.is_balanced);
+
+        assert_eq!(statements.income_statement.net_income_minor, 10000);
+        assert!(statements.trial_balance.is_balanced);
+        assert_eq!(statements.trial_balance.total_debits_minor, 65500);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -451,7 +451,14 @@ pub fn run() {
             api::accounting::list_periods,
             api::accounting::create_period,
             api::accounting::close_period,
-            api::accounting::reopen_period
+            api::accounting::reopen_period,
+            // Financial statement commands (GIV-688, Phase 6)
+            api::statements::get_balance_sheet,
+            api::statements::get_income_statement,
+            api::statements::get_period_trial_balance,
+            api::statements::export_balance_sheet_csv,
+            api::statements::export_income_statement_csv,
+            api::statements::export_trial_balance_csv
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -193,7 +193,10 @@ const MainRoutes: React.FC = () => (
       <Route path="/ledger/reconciliation" element={<Reconciliation />} />
       <Route path="/accounting-periods" element={<AccountingPeriods />} />
       <Route path="/reports/balance-sheet" element={<BalanceSheetReport />} />
-      <Route path="/reports/income-statement" element={<IncomeStatementReport />} />
+      <Route
+        path="/reports/income-statement"
+        element={<IncomeStatementReport />}
+      />
       <Route path="/reports/trial-balance" element={<PeriodTrialBalance />} />
     </Routes>
   </Navigation>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,6 +54,15 @@ const ClassificationQueue = React.lazy(
 const AccountingPeriods = React.lazy(
   () => import('./app/accounting-periods/AccountingPeriods')
 )
+const BalanceSheetReport = React.lazy(
+  () => import('./app/reports/BalanceSheet')
+)
+const IncomeStatementReport = React.lazy(
+  () => import('./app/reports/IncomeStatement')
+)
+const PeriodTrialBalance = React.lazy(
+  () => import('./app/reports/PeriodTrialBalance')
+)
 
 // Loading fallback component
 const LoadingFallback: React.FC = () => (
@@ -183,7 +192,9 @@ const MainRoutes: React.FC = () => (
       <Route path="/trial-balance" element={<TrialBalance />} />
       <Route path="/ledger/reconciliation" element={<Reconciliation />} />
       <Route path="/accounting-periods" element={<AccountingPeriods />} />
-      <Route path="/reports/balance-sheet" element={<Reports />} />
+      <Route path="/reports/balance-sheet" element={<BalanceSheetReport />} />
+      <Route path="/reports/income-statement" element={<IncomeStatementReport />} />
+      <Route path="/reports/trial-balance" element={<PeriodTrialBalance />} />
     </Routes>
   </Navigation>
 )

--- a/src/app/reports/BalanceSheet.tsx
+++ b/src/app/reports/BalanceSheet.tsx
@@ -1,0 +1,382 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { save } from '@tauri-apps/plugin-dialog'
+import { Scale, Download, AlertTriangle } from 'lucide-react'
+import {
+  formatMinorAsDollars,
+  formatStatementDate,
+  computeChangePercent,
+  formatChangePercent,
+  defaultPeriodDates,
+} from './statementUtils'
+
+// ============================================================================
+// Types matching Rust serde output
+// ============================================================================
+
+interface StatementLineItem {
+  accountNumber: string
+  accountName: string
+  accountType: string
+  balanceMinor: number
+}
+
+interface StatementSection {
+  label: string
+  items: StatementLineItem[]
+  subtotalMinor: number
+}
+
+interface BalanceSheetData {
+  startDate: string
+  endDate: string
+  assets: StatementSection
+  liabilities: StatementSection
+  equity: StatementSection
+  netIncomeMinor: number
+  totalAssetsMinor: number
+  totalLiabilitiesMinor: number
+  totalEquityMinor: number
+  isBalanced: boolean
+}
+
+interface ComparativeBalanceSheet {
+  current: BalanceSheetData
+  prior: BalanceSheetData
+}
+
+// ============================================================================
+// Sub-components (extracted to keep JSX depth ≤ 4)
+// ============================================================================
+
+interface PeriodSelectorProps {
+  startDate: string
+  endDate: string
+  onStartChange: (value: string) => void
+  onEndChange: (value: string) => void
+  onGenerate: () => void
+  loading: boolean
+}
+
+/** Period date selector for financial statements. */
+const PeriodSelector: React.FC<PeriodSelectorProps> = ({
+  startDate,
+  endDate,
+  onStartChange,
+  onEndChange,
+  onGenerate,
+  loading,
+}) => (
+  <div className="flex flex-wrap items-end gap-4 mb-6 p-4 bg-white dark:bg-[#11202B] border border-[rgba(95,227,192,0.15)] rounded-lg">
+    <div>
+      <label className="block text-xs font-medium text-[#294050] dark:text-[#9FB4BE] mb-1">
+        Start Date
+      </label>
+      <input
+        type="date"
+        value={startDate}
+        onChange={(e) => onStartChange(e.target.value)}
+        className="px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.25)] rounded bg-[#F7FAFA] dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2]"
+      />
+    </div>
+    <div>
+      <label className="block text-xs font-medium text-[#294050] dark:text-[#9FB4BE] mb-1">
+        End Date
+      </label>
+      <input
+        type="date"
+        value={endDate}
+        onChange={(e) => onEndChange(e.target.value)}
+        className="px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.25)] rounded bg-[#F7FAFA] dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2]"
+      />
+    </div>
+    <button
+      onClick={onGenerate}
+      disabled={loading}
+      className="px-4 py-1.5 text-sm font-medium bg-[#294050] text-white rounded hover:bg-[#1E2F3C] disabled:opacity-50"
+    >
+      {loading ? 'Generating...' : 'Generate'}
+    </button>
+  </div>
+)
+
+interface SectionTableProps {
+  section: StatementSection
+  priorSection: StatementSection | null
+  totalLabel: string
+  totalMinor: number
+  priorTotalMinor: number | null
+}
+
+/** Renders a balance sheet section (Assets, Liabilities, or Equity). */
+const SectionTable: React.FC<SectionTableProps> = ({
+  section,
+  priorSection,
+  totalLabel,
+  totalMinor,
+  priorTotalMinor,
+}) => {
+  const priorMap = useMemo(() => {
+    if (!priorSection) return new Map<string, number>()
+    return new Map(priorSection.items.map((i) => [i.accountNumber, i.balanceMinor]))
+  }, [priorSection])
+
+  return (
+    <div className="mb-6">
+      <h3 className="text-sm font-semibold uppercase tracking-wider text-[#294050] dark:text-[#9FB4BE] mb-2 px-1">
+        {section.label}
+      </h3>
+      <table className="min-w-full">
+        <thead>
+          <tr className="border-b border-[rgba(95,227,192,0.2)]">
+            <th className="px-4 py-2 text-left text-xs font-medium text-[#647D8B] uppercase">
+              Account
+            </th>
+            <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
+              Current
+            </th>
+            {priorSection !== null && (
+              <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
+                Prior
+              </th>
+            )}
+            {priorSection !== null && (
+              <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
+                Change
+              </th>
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {section.items.map((item) => {
+            const prior = priorMap.get(item.accountNumber) ?? 0
+            const changePct = priorSection !== null ? computeChangePercent(item.balanceMinor, prior) : null
+            return (
+              <tr
+                key={item.accountNumber}
+                className="border-b border-[rgba(95,227,192,0.08)] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F]"
+              >
+                <td className="px-4 py-2 text-sm text-[#11202B] dark:text-[#EAF3F2]">
+                  <span className="font-mono text-[#5FE3C0] mr-2">{item.accountNumber}</span>
+                  {item.accountName}
+                </td>
+                <td className="px-4 py-2 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+                  {formatMinorAsDollars(item.balanceMinor)}
+                </td>
+                {priorSection !== null && (
+                  <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
+                    {formatMinorAsDollars(prior)}
+                  </td>
+                )}
+                {priorSection !== null && (
+                  <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
+                    {formatChangePercent(changePct)}
+                  </td>
+                )}
+              </tr>
+            )
+          })}
+        </tbody>
+        <tfoot>
+          <tr className="border-t-2 border-[#5FE3C0] font-bold">
+            <td className="px-4 py-2 text-sm text-[#11202B] dark:text-[#EAF3F2]">
+              {totalLabel}
+            </td>
+            <td className="px-4 py-2 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+              {formatMinorAsDollars(totalMinor)}
+            </td>
+            {priorTotalMinor !== null && (
+              <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
+                {formatMinorAsDollars(priorTotalMinor)}
+              </td>
+            )}
+            {priorTotalMinor !== null && (
+              <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
+                {formatChangePercent(computeChangePercent(totalMinor, priorTotalMinor))}
+              </td>
+            )}
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  )
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+/** Balance Sheet page with comparative prior period. */
+const BalanceSheet: React.FC = () => {
+  const defaults = useMemo(() => defaultPeriodDates(), [])
+  const [startDate, setStartDate] = useState(defaults.startDate)
+  const [endDate, setEndDate] = useState(defaults.endDate)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [data, setData] = useState<ComparativeBalanceSheet | null>(null)
+
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await invoke<ComparativeBalanceSheet>('get_balance_sheet', {
+        params: { startDate, endDate },
+      })
+      setData(result)
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [startDate, endDate])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const handleExportCsv = useCallback(async () => {
+    const filePath = await save({
+      filters: [{ name: 'CSV', extensions: ['csv'] }],
+      defaultPath: `balance-sheet-${startDate}-to-${endDate}.csv`,
+    })
+    if (!filePath) return
+    try {
+      await invoke('export_balance_sheet_csv', {
+        params: { startDate, endDate },
+        path: filePath,
+      })
+    } catch (err) {
+      setError(String(err))
+    }
+  }, [startDate, endDate])
+
+  const hasPrior = data !== null
+    && (data.prior.assets.items.length > 0
+      || data.prior.liabilities.items.length > 0
+      || data.prior.equity.items.length > 0)
+
+  return (
+    <div className="p-4 sm:p-6 lg:p-8 max-w-6xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-[#11202B] dark:text-[#EAF3F2]">
+            Balance Sheet
+          </h1>
+          {data !== null && (
+            <p className="text-sm text-[#294050] dark:text-[#9FB4BE] mt-1">
+              As of {formatStatementDate(data.current.endDate)}
+            </p>
+          )}
+        </div>
+        <button
+          onClick={handleExportCsv}
+          disabled={data === null}
+          className="flex items-center gap-2 px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.3)] rounded text-[#294050] dark:text-[#9FB4BE] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F] disabled:opacity-40"
+        >
+          <Download className="w-4 h-4" />
+          Export CSV
+        </button>
+      </div>
+
+      <PeriodSelector
+        startDate={startDate}
+        endDate={endDate}
+        onStartChange={setStartDate}
+        onEndChange={setEndDate}
+        onGenerate={fetchData}
+        loading={loading}
+      />
+
+      {error !== null && (
+        <div className="flex items-start gap-3 p-4 mb-6 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+          <AlertTriangle className="w-5 h-5 text-red-600 dark:text-red-400 mt-0.5 shrink-0" />
+          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      )}
+
+      {loading && (
+        <div className="flex items-center justify-center py-16">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#294050]" />
+        </div>
+      )}
+
+      {!loading && data === null && error === null && (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <Scale className="w-12 h-12 text-[#647D8B] mb-4" />
+          <h3 className="text-lg font-medium text-[#11202B] dark:text-[#EAF3F2]">
+            No data available
+          </h3>
+          <p className="text-sm text-[#294050] dark:text-[#9FB4BE] mt-1">
+            Select a period and generate the balance sheet.
+          </p>
+        </div>
+      )}
+
+      {!loading && data !== null && (
+        <div className="bg-white dark:bg-[#11202B] border border-[rgba(95,227,192,0.15)] rounded-lg p-6">
+          {!data.current.isBalanced && (
+            <div className="flex items-center gap-2 p-3 mb-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded">
+              <AlertTriangle className="w-4 h-4 text-red-600 dark:text-red-400" />
+              <span className="text-sm font-medium text-red-700 dark:text-red-300">
+                Balance sheet does not tie — investigate before relying on these figures.
+              </span>
+            </div>
+          )}
+
+          <SectionTable
+            section={data.current.assets}
+            priorSection={hasPrior ? data.prior.assets : null}
+            totalLabel="Total Assets"
+            totalMinor={data.current.totalAssetsMinor}
+            priorTotalMinor={hasPrior ? data.prior.totalAssetsMinor : null}
+          />
+
+          <SectionTable
+            section={data.current.liabilities}
+            priorSection={hasPrior ? data.prior.liabilities : null}
+            totalLabel="Total Liabilities"
+            totalMinor={data.current.totalLiabilitiesMinor}
+            priorTotalMinor={hasPrior ? data.prior.totalLiabilitiesMinor : null}
+          />
+
+          <SectionTable
+            section={data.current.equity}
+            priorSection={hasPrior ? data.prior.equity : null}
+            totalLabel="Total Equity (excl. NI)"
+            totalMinor={data.current.equity.subtotalMinor}
+            priorTotalMinor={hasPrior ? data.prior.equity.subtotalMinor : null}
+          />
+
+          <div className="border-t-2 border-[#5FE3C0] mt-2 pt-3">
+            <div className="flex justify-between px-4 py-1">
+              <span className="text-sm font-medium text-[#294050] dark:text-[#9FB4BE]">
+                Net Income (current period)
+              </span>
+              <span className="text-sm font-mono font-medium text-[#11202B] dark:text-[#EAF3F2]">
+                {formatMinorAsDollars(data.current.netIncomeMinor)}
+              </span>
+            </div>
+            <div className="flex justify-between px-4 py-1">
+              <span className="text-sm font-bold text-[#11202B] dark:text-[#EAF3F2]">
+                Total Equity (incl. NI)
+              </span>
+              <span className="text-sm font-mono font-bold text-[#11202B] dark:text-[#EAF3F2]">
+                {formatMinorAsDollars(data.current.totalEquityMinor)}
+              </span>
+            </div>
+          </div>
+
+          <div className="mt-4 pt-3 border-t border-[rgba(95,227,192,0.15)]">
+            <div className={`text-center text-sm font-medium ${data.current.isBalanced ? 'text-[#5FE3C0]' : 'text-red-600 dark:text-red-400'}`}>
+              {data.current.isBalanced
+                ? 'Assets = Liabilities + Equity — Balance sheet ties.'
+                : `Out of balance by ${formatMinorAsDollars(Math.abs(data.current.totalAssetsMinor - data.current.totalLiabilitiesMinor - data.current.totalEquityMinor))}`}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default BalanceSheet

--- a/src/app/reports/BalanceSheet.tsx
+++ b/src/app/reports/BalanceSheet.tsx
@@ -33,6 +33,7 @@ interface BalanceSheetData {
   assets: StatementSection
   liabilities: StatementSection
   equity: StatementSection
+  retainedEarningsMinor: number
   netIncomeMinor: number
   totalAssetsMinor: number
   totalLiabilitiesMinor: number
@@ -356,12 +357,20 @@ const BalanceSheet: React.FC = () => {
           <SectionTable
             section={data.current.equity}
             priorSection={hasPrior ? data.prior.equity : null}
-            totalLabel="Total Equity (excl. NI)"
+            totalLabel="Total Equity Accounts (excl. RE and NI)"
             totalMinor={data.current.equity.subtotalMinor}
             priorTotalMinor={hasPrior ? data.prior.equity.subtotalMinor : null}
           />
 
           <div className="border-t-2 border-[#5FE3C0] mt-2 pt-3">
+            <div className="flex justify-between px-4 py-1">
+              <span className="text-sm font-medium text-[#294050] dark:text-[#9FB4BE]">
+                Retained Earnings (prior periods)
+              </span>
+              <span className="text-sm font-mono font-medium text-[#11202B] dark:text-[#EAF3F2]">
+                {formatMinorAsDollars(data.current.retainedEarningsMinor)}
+              </span>
+            </div>
             <div className="flex justify-between px-4 py-1">
               <span className="text-sm font-medium text-[#294050] dark:text-[#9FB4BE]">
                 Net Income (current period)

--- a/src/app/reports/BalanceSheet.tsx
+++ b/src/app/reports/BalanceSheet.tsx
@@ -9,6 +9,10 @@ import {
   formatChangePercent,
   defaultPeriodDates,
 } from './statementUtils'
+import {
+  StatementSectionHead,
+  StatementSectionFoot,
+} from './StatementTableParts'
 
 // ============================================================================
 // Types matching Rust serde output
@@ -130,26 +134,7 @@ const SectionTable: React.FC<SectionTableProps> = ({
         {section.label}
       </h3>
       <table className="min-w-full">
-        <thead>
-          <tr className="border-b border-[rgba(95,227,192,0.2)]">
-            <th className="px-4 py-2 text-left text-xs font-medium text-[#647D8B] uppercase">
-              Account
-            </th>
-            <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
-              Current
-            </th>
-            {priorSection !== null && (
-              <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
-                Prior
-              </th>
-            )}
-            {priorSection !== null && (
-              <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
-                Change
-              </th>
-            )}
-          </tr>
-        </thead>
+        <StatementSectionHead showPrior={priorSection !== null} />
         <tbody>
           {section.items.map(item => {
             const prior = priorMap.get(item.accountNumber) ?? 0
@@ -185,28 +170,11 @@ const SectionTable: React.FC<SectionTableProps> = ({
             )
           })}
         </tbody>
-        <tfoot>
-          <tr className="border-t-2 border-[#5FE3C0] font-bold">
-            <td className="px-4 py-2 text-sm text-[#11202B] dark:text-[#EAF3F2]">
-              {totalLabel}
-            </td>
-            <td className="px-4 py-2 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
-              {formatMinorAsDollars(totalMinor)}
-            </td>
-            {priorTotalMinor !== null && (
-              <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
-                {formatMinorAsDollars(priorTotalMinor)}
-              </td>
-            )}
-            {priorTotalMinor !== null && (
-              <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
-                {formatChangePercent(
-                  computeChangePercent(totalMinor, priorTotalMinor)
-                )}
-              </td>
-            )}
-          </tr>
-        </tfoot>
+        <StatementSectionFoot
+          label={totalLabel}
+          totalMinor={totalMinor}
+          priorTotalMinor={priorTotalMinor}
+        />
       </table>
     </div>
   )

--- a/src/app/reports/BalanceSheet.tsx
+++ b/src/app/reports/BalanceSheet.tsx
@@ -75,7 +75,7 @@ const PeriodSelector: React.FC<PeriodSelectorProps> = ({
       <input
         type="date"
         value={startDate}
-        onChange={(e) => onStartChange(e.target.value)}
+        onChange={e => onStartChange(e.target.value)}
         className="px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.25)] rounded bg-[#F7FAFA] dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2]"
       />
     </div>
@@ -86,7 +86,7 @@ const PeriodSelector: React.FC<PeriodSelectorProps> = ({
       <input
         type="date"
         value={endDate}
-        onChange={(e) => onEndChange(e.target.value)}
+        onChange={e => onEndChange(e.target.value)}
         className="px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.25)] rounded bg-[#F7FAFA] dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2]"
       />
     </div>
@@ -118,7 +118,9 @@ const SectionTable: React.FC<SectionTableProps> = ({
 }) => {
   const priorMap = useMemo(() => {
     if (!priorSection) return new Map<string, number>()
-    return new Map(priorSection.items.map((i) => [i.accountNumber, i.balanceMinor]))
+    return new Map(
+      priorSection.items.map(i => [i.accountNumber, i.balanceMinor])
+    )
   }, [priorSection])
 
   return (
@@ -148,16 +150,21 @@ const SectionTable: React.FC<SectionTableProps> = ({
           </tr>
         </thead>
         <tbody>
-          {section.items.map((item) => {
+          {section.items.map(item => {
             const prior = priorMap.get(item.accountNumber) ?? 0
-            const changePct = priorSection !== null ? computeChangePercent(item.balanceMinor, prior) : null
+            const changePct =
+              priorSection !== null
+                ? computeChangePercent(item.balanceMinor, prior)
+                : null
             return (
               <tr
                 key={item.accountNumber}
                 className="border-b border-[rgba(95,227,192,0.08)] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F]"
               >
                 <td className="px-4 py-2 text-sm text-[#11202B] dark:text-[#EAF3F2]">
-                  <span className="font-mono text-[#5FE3C0] mr-2">{item.accountNumber}</span>
+                  <span className="font-mono text-[#5FE3C0] mr-2">
+                    {item.accountNumber}
+                  </span>
                   {item.accountName}
                 </td>
                 <td className="px-4 py-2 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
@@ -192,7 +199,9 @@ const SectionTable: React.FC<SectionTableProps> = ({
             )}
             {priorTotalMinor !== null && (
               <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
-                {formatChangePercent(computeChangePercent(totalMinor, priorTotalMinor))}
+                {formatChangePercent(
+                  computeChangePercent(totalMinor, priorTotalMinor)
+                )}
               </td>
             )}
           </tr>
@@ -219,9 +228,12 @@ const BalanceSheet: React.FC = () => {
     setLoading(true)
     setError(null)
     try {
-      const result = await invoke<ComparativeBalanceSheet>('get_balance_sheet', {
-        params: { startDate, endDate },
-      })
+      const result = await invoke<ComparativeBalanceSheet>(
+        'get_balance_sheet',
+        {
+          params: { startDate, endDate },
+        }
+      )
       setData(result)
     } catch (err) {
       setError(String(err))
@@ -250,10 +262,11 @@ const BalanceSheet: React.FC = () => {
     }
   }, [startDate, endDate])
 
-  const hasPrior = data !== null
-    && (data.prior.assets.items.length > 0
-      || data.prior.liabilities.items.length > 0
-      || data.prior.equity.items.length > 0)
+  const hasPrior =
+    data !== null &&
+    (data.prior.assets.items.length > 0 ||
+      data.prior.liabilities.items.length > 0 ||
+      data.prior.equity.items.length > 0)
 
   return (
     <div className="p-4 sm:p-6 lg:p-8 max-w-6xl mx-auto">
@@ -318,7 +331,8 @@ const BalanceSheet: React.FC = () => {
             <div className="flex items-center gap-2 p-3 mb-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded">
               <AlertTriangle className="w-4 h-4 text-red-600 dark:text-red-400" />
               <span className="text-sm font-medium text-red-700 dark:text-red-300">
-                Balance sheet does not tie — investigate before relying on these figures.
+                Balance sheet does not tie — investigate before relying on these
+                figures.
               </span>
             </div>
           )}
@@ -367,7 +381,9 @@ const BalanceSheet: React.FC = () => {
           </div>
 
           <div className="mt-4 pt-3 border-t border-[rgba(95,227,192,0.15)]">
-            <div className={`text-center text-sm font-medium ${data.current.isBalanced ? 'text-[#5FE3C0]' : 'text-red-600 dark:text-red-400'}`}>
+            <div
+              className={`text-center text-sm font-medium ${data.current.isBalanced ? 'text-[#5FE3C0]' : 'text-red-600 dark:text-red-400'}`}
+            >
               {data.current.isBalanced
                 ? 'Assets = Liabilities + Equity — Balance sheet ties.'
                 : `Out of balance by ${formatMinorAsDollars(Math.abs(data.current.totalAssetsMinor - data.current.totalLiabilitiesMinor - data.current.totalEquityMinor))}`}

--- a/src/app/reports/IncomeStatement.tsx
+++ b/src/app/reports/IncomeStatement.tsx
@@ -1,0 +1,339 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { save } from '@tauri-apps/plugin-dialog'
+import { TrendingUp, Download, AlertTriangle } from 'lucide-react'
+import {
+  formatMinorAsDollars,
+  formatStatementDate,
+  computeChangePercent,
+  formatChangePercent,
+  defaultPeriodDates,
+} from './statementUtils'
+
+// ============================================================================
+// Types matching Rust serde output
+// ============================================================================
+
+interface StatementLineItem {
+  accountNumber: string
+  accountName: string
+  accountType: string
+  balanceMinor: number
+}
+
+interface StatementSection {
+  label: string
+  items: StatementLineItem[]
+  subtotalMinor: number
+}
+
+interface IncomeStatementData {
+  startDate: string
+  endDate: string
+  revenue: StatementSection
+  expenses: StatementSection
+  totalRevenueMinor: number
+  totalExpensesMinor: number
+  netIncomeMinor: number
+}
+
+interface ComparativeIncomeStatement {
+  current: IncomeStatementData
+  prior: IncomeStatementData
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+interface PeriodSelectorProps {
+  startDate: string
+  endDate: string
+  onStartChange: (value: string) => void
+  onEndChange: (value: string) => void
+  onGenerate: () => void
+  loading: boolean
+}
+
+/** Period date selector for financial statements. */
+const PeriodSelector: React.FC<PeriodSelectorProps> = ({
+  startDate,
+  endDate,
+  onStartChange,
+  onEndChange,
+  onGenerate,
+  loading,
+}) => (
+  <div className="flex flex-wrap items-end gap-4 mb-6 p-4 bg-white dark:bg-[#11202B] border border-[rgba(95,227,192,0.15)] rounded-lg">
+    <div>
+      <label className="block text-xs font-medium text-[#294050] dark:text-[#9FB4BE] mb-1">
+        Start Date
+      </label>
+      <input
+        type="date"
+        value={startDate}
+        onChange={(e) => onStartChange(e.target.value)}
+        className="px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.25)] rounded bg-[#F7FAFA] dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2]"
+      />
+    </div>
+    <div>
+      <label className="block text-xs font-medium text-[#294050] dark:text-[#9FB4BE] mb-1">
+        End Date
+      </label>
+      <input
+        type="date"
+        value={endDate}
+        onChange={(e) => onEndChange(e.target.value)}
+        className="px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.25)] rounded bg-[#F7FAFA] dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2]"
+      />
+    </div>
+    <button
+      onClick={onGenerate}
+      disabled={loading}
+      className="px-4 py-1.5 text-sm font-medium bg-[#294050] text-white rounded hover:bg-[#1E2F3C] disabled:opacity-50"
+    >
+      {loading ? 'Generating...' : 'Generate'}
+    </button>
+  </div>
+)
+
+interface IncomeSectionProps {
+  section: StatementSection
+  priorSection: StatementSection | null
+}
+
+/** Renders a section (Revenue or Expenses) with line items. */
+const IncomeSection: React.FC<IncomeSectionProps> = ({ section, priorSection }) => {
+  const priorMap = useMemo(() => {
+    if (!priorSection) return new Map<string, number>()
+    return new Map(priorSection.items.map((i) => [i.accountNumber, i.balanceMinor]))
+  }, [priorSection])
+
+  return (
+    <div className="mb-6">
+      <h3 className="text-sm font-semibold uppercase tracking-wider text-[#294050] dark:text-[#9FB4BE] mb-2 px-1">
+        {section.label}
+      </h3>
+      <table className="min-w-full">
+        <thead>
+          <tr className="border-b border-[rgba(95,227,192,0.2)]">
+            <th className="px-4 py-2 text-left text-xs font-medium text-[#647D8B] uppercase">
+              Account
+            </th>
+            <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
+              Current
+            </th>
+            {priorSection !== null && (
+              <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
+                Prior
+              </th>
+            )}
+            {priorSection !== null && (
+              <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
+                Change
+              </th>
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {section.items.map((item) => {
+            const prior = priorMap.get(item.accountNumber) ?? 0
+            const changePct = priorSection !== null ? computeChangePercent(item.balanceMinor, prior) : null
+            return (
+              <tr
+                key={item.accountNumber}
+                className="border-b border-[rgba(95,227,192,0.08)] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F]"
+              >
+                <td className="px-4 py-2 text-sm text-[#11202B] dark:text-[#EAF3F2]">
+                  <span className="font-mono text-[#5FE3C0] mr-2">{item.accountNumber}</span>
+                  {item.accountName}
+                </td>
+                <td className="px-4 py-2 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+                  {formatMinorAsDollars(item.balanceMinor)}
+                </td>
+                {priorSection !== null && (
+                  <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
+                    {formatMinorAsDollars(prior)}
+                  </td>
+                )}
+                {priorSection !== null && (
+                  <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
+                    {formatChangePercent(changePct)}
+                  </td>
+                )}
+              </tr>
+            )
+          })}
+        </tbody>
+        <tfoot>
+          <tr className="border-t-2 border-[#5FE3C0] font-bold">
+            <td className="px-4 py-2 text-sm text-[#11202B] dark:text-[#EAF3F2]">
+              Total {section.label}
+            </td>
+            <td className="px-4 py-2 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+              {formatMinorAsDollars(section.subtotalMinor)}
+            </td>
+            {priorSection !== null && (
+              <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
+                {formatMinorAsDollars(priorSection.subtotalMinor)}
+              </td>
+            )}
+            {priorSection !== null && (
+              <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
+                {formatChangePercent(computeChangePercent(section.subtotalMinor, priorSection.subtotalMinor))}
+              </td>
+            )}
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  )
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+/** Income Statement page with comparative prior period. */
+const IncomeStatement: React.FC = () => {
+  const defaults = useMemo(() => defaultPeriodDates(), [])
+  const [startDate, setStartDate] = useState(defaults.startDate)
+  const [endDate, setEndDate] = useState(defaults.endDate)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [data, setData] = useState<ComparativeIncomeStatement | null>(null)
+
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await invoke<ComparativeIncomeStatement>('get_income_statement', {
+        params: { startDate, endDate },
+      })
+      setData(result)
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [startDate, endDate])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const handleExportCsv = useCallback(async () => {
+    const filePath = await save({
+      filters: [{ name: 'CSV', extensions: ['csv'] }],
+      defaultPath: `income-statement-${startDate}-to-${endDate}.csv`,
+    })
+    if (!filePath) return
+    try {
+      await invoke('export_income_statement_csv', {
+        params: { startDate, endDate },
+        path: filePath,
+      })
+    } catch (err) {
+      setError(String(err))
+    }
+  }, [startDate, endDate])
+
+  const hasPrior = data !== null
+    && (data.prior.revenue.items.length > 0
+      || data.prior.expenses.items.length > 0)
+
+  return (
+    <div className="p-4 sm:p-6 lg:p-8 max-w-6xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-[#11202B] dark:text-[#EAF3F2]">
+            Income Statement
+          </h1>
+          {data !== null && (
+            <p className="text-sm text-[#294050] dark:text-[#9FB4BE] mt-1">
+              {formatStatementDate(data.current.startDate)} &mdash;{' '}
+              {formatStatementDate(data.current.endDate)}
+            </p>
+          )}
+        </div>
+        <button
+          onClick={handleExportCsv}
+          disabled={data === null}
+          className="flex items-center gap-2 px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.3)] rounded text-[#294050] dark:text-[#9FB4BE] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F] disabled:opacity-40"
+        >
+          <Download className="w-4 h-4" />
+          Export CSV
+        </button>
+      </div>
+
+      <PeriodSelector
+        startDate={startDate}
+        endDate={endDate}
+        onStartChange={setStartDate}
+        onEndChange={setEndDate}
+        onGenerate={fetchData}
+        loading={loading}
+      />
+
+      {error !== null && (
+        <div className="flex items-start gap-3 p-4 mb-6 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+          <AlertTriangle className="w-5 h-5 text-red-600 dark:text-red-400 mt-0.5 shrink-0" />
+          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      )}
+
+      {loading && (
+        <div className="flex items-center justify-center py-16">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#294050]" />
+        </div>
+      )}
+
+      {!loading && data === null && error === null && (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <TrendingUp className="w-12 h-12 text-[#647D8B] mb-4" />
+          <h3 className="text-lg font-medium text-[#11202B] dark:text-[#EAF3F2]">
+            No data available
+          </h3>
+          <p className="text-sm text-[#294050] dark:text-[#9FB4BE] mt-1">
+            Select a period and generate the income statement.
+          </p>
+        </div>
+      )}
+
+      {!loading && data !== null && (
+        <div className="bg-white dark:bg-[#11202B] border border-[rgba(95,227,192,0.15)] rounded-lg p-6">
+          <IncomeSection
+            section={data.current.revenue}
+            priorSection={hasPrior ? data.prior.revenue : null}
+          />
+
+          <IncomeSection
+            section={data.current.expenses}
+            priorSection={hasPrior ? data.prior.expenses : null}
+          />
+
+          <div className="border-t-2 border-[#5FE3C0] mt-2 pt-3">
+            <div className="flex justify-between px-4 py-2">
+              <span className="text-base font-bold text-[#11202B] dark:text-[#EAF3F2]">
+                Net Income
+              </span>
+              <div className="text-right">
+                <span className={`text-base font-mono font-bold ${data.current.netIncomeMinor >= 0 ? 'text-[#5FE3C0]' : 'text-red-600 dark:text-red-400'}`}>
+                  {formatMinorAsDollars(data.current.netIncomeMinor)}
+                </span>
+                {hasPrior && (
+                  <span className="ml-4 text-sm font-mono text-[#647D8B]">
+                    (Prior: {formatMinorAsDollars(data.prior.netIncomeMinor)},{' '}
+                    {formatChangePercent(computeChangePercent(data.current.netIncomeMinor, data.prior.netIncomeMinor))})
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default IncomeStatement

--- a/src/app/reports/IncomeStatement.tsx
+++ b/src/app/reports/IncomeStatement.tsx
@@ -72,7 +72,7 @@ const PeriodSelector: React.FC<PeriodSelectorProps> = ({
       <input
         type="date"
         value={startDate}
-        onChange={(e) => onStartChange(e.target.value)}
+        onChange={e => onStartChange(e.target.value)}
         className="px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.25)] rounded bg-[#F7FAFA] dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2]"
       />
     </div>
@@ -83,7 +83,7 @@ const PeriodSelector: React.FC<PeriodSelectorProps> = ({
       <input
         type="date"
         value={endDate}
-        onChange={(e) => onEndChange(e.target.value)}
+        onChange={e => onEndChange(e.target.value)}
         className="px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.25)] rounded bg-[#F7FAFA] dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2]"
       />
     </div>
@@ -103,10 +103,15 @@ interface IncomeSectionProps {
 }
 
 /** Renders a section (Revenue or Expenses) with line items. */
-const IncomeSection: React.FC<IncomeSectionProps> = ({ section, priorSection }) => {
+const IncomeSection: React.FC<IncomeSectionProps> = ({
+  section,
+  priorSection,
+}) => {
   const priorMap = useMemo(() => {
     if (!priorSection) return new Map<string, number>()
-    return new Map(priorSection.items.map((i) => [i.accountNumber, i.balanceMinor]))
+    return new Map(
+      priorSection.items.map(i => [i.accountNumber, i.balanceMinor])
+    )
   }, [priorSection])
 
   return (
@@ -136,16 +141,21 @@ const IncomeSection: React.FC<IncomeSectionProps> = ({ section, priorSection }) 
           </tr>
         </thead>
         <tbody>
-          {section.items.map((item) => {
+          {section.items.map(item => {
             const prior = priorMap.get(item.accountNumber) ?? 0
-            const changePct = priorSection !== null ? computeChangePercent(item.balanceMinor, prior) : null
+            const changePct =
+              priorSection !== null
+                ? computeChangePercent(item.balanceMinor, prior)
+                : null
             return (
               <tr
                 key={item.accountNumber}
                 className="border-b border-[rgba(95,227,192,0.08)] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F]"
               >
                 <td className="px-4 py-2 text-sm text-[#11202B] dark:text-[#EAF3F2]">
-                  <span className="font-mono text-[#5FE3C0] mr-2">{item.accountNumber}</span>
+                  <span className="font-mono text-[#5FE3C0] mr-2">
+                    {item.accountNumber}
+                  </span>
                   {item.accountName}
                 </td>
                 <td className="px-4 py-2 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
@@ -180,7 +190,12 @@ const IncomeSection: React.FC<IncomeSectionProps> = ({ section, priorSection }) 
             )}
             {priorSection !== null && (
               <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
-                {formatChangePercent(computeChangePercent(section.subtotalMinor, priorSection.subtotalMinor))}
+                {formatChangePercent(
+                  computeChangePercent(
+                    section.subtotalMinor,
+                    priorSection.subtotalMinor
+                  )
+                )}
               </td>
             )}
           </tr>
@@ -207,9 +222,12 @@ const IncomeStatement: React.FC = () => {
     setLoading(true)
     setError(null)
     try {
-      const result = await invoke<ComparativeIncomeStatement>('get_income_statement', {
-        params: { startDate, endDate },
-      })
+      const result = await invoke<ComparativeIncomeStatement>(
+        'get_income_statement',
+        {
+          params: { startDate, endDate },
+        }
+      )
       setData(result)
     } catch (err) {
       setError(String(err))
@@ -238,9 +256,10 @@ const IncomeStatement: React.FC = () => {
     }
   }, [startDate, endDate])
 
-  const hasPrior = data !== null
-    && (data.prior.revenue.items.length > 0
-      || data.prior.expenses.items.length > 0)
+  const hasPrior =
+    data !== null &&
+    (data.prior.revenue.items.length > 0 ||
+      data.prior.expenses.items.length > 0)
 
   return (
     <div className="p-4 sm:p-6 lg:p-8 max-w-6xl mx-auto">
@@ -318,13 +337,21 @@ const IncomeStatement: React.FC = () => {
                 Net Income
               </span>
               <div className="text-right">
-                <span className={`text-base font-mono font-bold ${data.current.netIncomeMinor >= 0 ? 'text-[#5FE3C0]' : 'text-red-600 dark:text-red-400'}`}>
+                <span
+                  className={`text-base font-mono font-bold ${data.current.netIncomeMinor >= 0 ? 'text-[#5FE3C0]' : 'text-red-600 dark:text-red-400'}`}
+                >
                   {formatMinorAsDollars(data.current.netIncomeMinor)}
                 </span>
                 {hasPrior && (
                   <span className="ml-4 text-sm font-mono text-[#647D8B]">
                     (Prior: {formatMinorAsDollars(data.prior.netIncomeMinor)},{' '}
-                    {formatChangePercent(computeChangePercent(data.current.netIncomeMinor, data.prior.netIncomeMinor))})
+                    {formatChangePercent(
+                      computeChangePercent(
+                        data.current.netIncomeMinor,
+                        data.prior.netIncomeMinor
+                      )
+                    )}
+                    )
                   </span>
                 )}
               </div>

--- a/src/app/reports/IncomeStatement.tsx
+++ b/src/app/reports/IncomeStatement.tsx
@@ -9,6 +9,10 @@ import {
   formatChangePercent,
   defaultPeriodDates,
 } from './statementUtils'
+import {
+  StatementSectionHead,
+  StatementSectionFoot,
+} from './StatementTableParts'
 
 // ============================================================================
 // Types matching Rust serde output
@@ -120,26 +124,7 @@ const IncomeSection: React.FC<IncomeSectionProps> = ({
         {section.label}
       </h3>
       <table className="min-w-full">
-        <thead>
-          <tr className="border-b border-[rgba(95,227,192,0.2)]">
-            <th className="px-4 py-2 text-left text-xs font-medium text-[#647D8B] uppercase">
-              Account
-            </th>
-            <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
-              Current
-            </th>
-            {priorSection !== null && (
-              <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
-                Prior
-              </th>
-            )}
-            {priorSection !== null && (
-              <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
-                Change
-              </th>
-            )}
-          </tr>
-        </thead>
+        <StatementSectionHead showPrior={priorSection !== null} />
         <tbody>
           {section.items.map(item => {
             const prior = priorMap.get(item.accountNumber) ?? 0
@@ -175,35 +160,52 @@ const IncomeSection: React.FC<IncomeSectionProps> = ({
             )
           })}
         </tbody>
-        <tfoot>
-          <tr className="border-t-2 border-[#5FE3C0] font-bold">
-            <td className="px-4 py-2 text-sm text-[#11202B] dark:text-[#EAF3F2]">
-              Total {section.label}
-            </td>
-            <td className="px-4 py-2 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
-              {formatMinorAsDollars(section.subtotalMinor)}
-            </td>
-            {priorSection !== null && (
-              <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
-                {formatMinorAsDollars(priorSection.subtotalMinor)}
-              </td>
-            )}
-            {priorSection !== null && (
-              <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
-                {formatChangePercent(
-                  computeChangePercent(
-                    section.subtotalMinor,
-                    priorSection.subtotalMinor
-                  )
-                )}
-              </td>
-            )}
-          </tr>
-        </tfoot>
+        <StatementSectionFoot
+          label={`Total ${section.label}`}
+          totalMinor={section.subtotalMinor}
+          priorTotalMinor={
+            priorSection !== null ? priorSection.subtotalMinor : null
+          }
+        />
       </table>
     </div>
   )
 }
+
+interface NetIncomeSummaryProps {
+  netIncomeMinor: number
+  priorNetIncomeMinor: number | null
+}
+
+/** Bottom-line net income row with optional prior-period comparison. */
+const NetIncomeSummary: React.FC<NetIncomeSummaryProps> = ({
+  netIncomeMinor,
+  priorNetIncomeMinor,
+}) => (
+  <div className="border-t-2 border-[#5FE3C0] mt-2 pt-3">
+    <div className="flex justify-between px-4 py-2">
+      <span className="text-base font-bold text-[#11202B] dark:text-[#EAF3F2]">
+        Net Income
+      </span>
+      <div className="text-right">
+        <span
+          className={`text-base font-mono font-bold ${netIncomeMinor >= 0 ? 'text-[#5FE3C0]' : 'text-red-600 dark:text-red-400'}`}
+        >
+          {formatMinorAsDollars(netIncomeMinor)}
+        </span>
+        {priorNetIncomeMinor !== null && (
+          <span className="ml-4 text-sm font-mono text-[#647D8B]">
+            (Prior: {formatMinorAsDollars(priorNetIncomeMinor)},{' '}
+            {formatChangePercent(
+              computeChangePercent(netIncomeMinor, priorNetIncomeMinor)
+            )}
+            )
+          </span>
+        )}
+      </div>
+    </div>
+  </div>
+)
 
 // ============================================================================
 // Main Component
@@ -331,32 +333,10 @@ const IncomeStatement: React.FC = () => {
             priorSection={hasPrior ? data.prior.expenses : null}
           />
 
-          <div className="border-t-2 border-[#5FE3C0] mt-2 pt-3">
-            <div className="flex justify-between px-4 py-2">
-              <span className="text-base font-bold text-[#11202B] dark:text-[#EAF3F2]">
-                Net Income
-              </span>
-              <div className="text-right">
-                <span
-                  className={`text-base font-mono font-bold ${data.current.netIncomeMinor >= 0 ? 'text-[#5FE3C0]' : 'text-red-600 dark:text-red-400'}`}
-                >
-                  {formatMinorAsDollars(data.current.netIncomeMinor)}
-                </span>
-                {hasPrior && (
-                  <span className="ml-4 text-sm font-mono text-[#647D8B]">
-                    (Prior: {formatMinorAsDollars(data.prior.netIncomeMinor)},{' '}
-                    {formatChangePercent(
-                      computeChangePercent(
-                        data.current.netIncomeMinor,
-                        data.prior.netIncomeMinor
-                      )
-                    )}
-                    )
-                  </span>
-                )}
-              </div>
-            </div>
-          </div>
+          <NetIncomeSummary
+            netIncomeMinor={data.current.netIncomeMinor}
+            priorNetIncomeMinor={hasPrior ? data.prior.netIncomeMinor : null}
+          />
         </div>
       )}
     </div>

--- a/src/app/reports/PeriodTrialBalance.tsx
+++ b/src/app/reports/PeriodTrialBalance.tsx
@@ -64,7 +64,7 @@ const PeriodSelector: React.FC<PeriodSelectorProps> = ({
       <input
         type="date"
         value={startDate}
-        onChange={(e) => onStartChange(e.target.value)}
+        onChange={e => onStartChange(e.target.value)}
         className="px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.25)] rounded bg-[#F7FAFA] dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2]"
       />
     </div>
@@ -75,7 +75,7 @@ const PeriodSelector: React.FC<PeriodSelectorProps> = ({
       <input
         type="date"
         value={endDate}
-        onChange={(e) => onEndChange(e.target.value)}
+        onChange={e => onEndChange(e.target.value)}
         className="px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.25)] rounded bg-[#F7FAFA] dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2]"
       />
     </div>
@@ -105,7 +105,11 @@ const TrialBalanceRowComponent: React.FC<TrialBalanceRowProps> = ({
   hasPrior,
   even,
 }) => (
-  <tr className={even ? 'bg-white dark:bg-[#11202B]' : 'bg-[#EAF3F2] dark:bg-[#16242F]'}>
+  <tr
+    className={
+      even ? 'bg-white dark:bg-[#11202B]' : 'bg-[#EAF3F2] dark:bg-[#16242F]'
+    }
+  >
     <td className="px-5 py-2.5 text-sm font-mono text-[#5FE3C0] font-medium">
       {row.accountNumber}
     </td>
@@ -151,9 +155,12 @@ const PeriodTrialBalance: React.FC = () => {
     setLoading(true)
     setError(null)
     try {
-      const result = await invoke<ComparativeTrialBalance>('get_period_trial_balance', {
-        params: { startDate, endDate },
-      })
+      const result = await invoke<ComparativeTrialBalance>(
+        'get_period_trial_balance',
+        {
+          params: { startDate, endDate },
+        }
+      )
       setData(result)
     } catch (err) {
       setError(String(err))
@@ -187,10 +194,10 @@ const PeriodTrialBalance: React.FC = () => {
   const priorMap = useMemo(() => {
     if (!data) return new Map<string, { debit: number; credit: number }>()
     return new Map(
-      data.prior.rows.map((r) => [
+      data.prior.rows.map(r => [
         r.accountNumber,
         { debit: r.debitBalance, credit: r.creditBalance },
-      ]),
+      ])
     )
   }, [data])
 
@@ -304,7 +311,10 @@ const PeriodTrialBalance: React.FC = () => {
             </tbody>
             <tfoot>
               <tr className="bg-[#EAF3F2] dark:bg-[#16242F] font-bold border-t-2 border-[#5FE3C0]">
-                <td colSpan={3} className="px-5 py-3 text-sm text-[#11202B] dark:text-[#EAF3F2]">
+                <td
+                  colSpan={3}
+                  className="px-5 py-3 text-sm text-[#11202B] dark:text-[#EAF3F2]"
+                >
                   Totals
                 </td>
                 <td className="px-5 py-3 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">

--- a/src/app/reports/PeriodTrialBalance.tsx
+++ b/src/app/reports/PeriodTrialBalance.tsx
@@ -138,6 +138,97 @@ const TrialBalanceRowComponent: React.FC<TrialBalanceRowProps> = ({
   </tr>
 )
 
+interface TrialBalanceHeadProps {
+  hasPrior: boolean
+}
+
+/** Trial balance table header (Account # / Name / Type / Debit / Credit + prior columns). */
+const TrialBalanceHead: React.FC<TrialBalanceHeadProps> = ({ hasPrior }) => (
+  <thead>
+    <tr className="bg-[#294050] text-white">
+      <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider">
+        Account #
+      </th>
+      <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider">
+        Account Name
+      </th>
+      <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider">
+        Type
+      </th>
+      <th className="px-5 py-3 text-right text-xs font-semibold uppercase tracking-wider">
+        Debit
+      </th>
+      <th className="px-5 py-3 text-right text-xs font-semibold uppercase tracking-wider">
+        Credit
+      </th>
+      {hasPrior && (
+        <th className="px-5 py-3 text-right text-xs font-semibold uppercase tracking-wider text-[#9FB4BE]">
+          Prior Debit
+        </th>
+      )}
+      {hasPrior && (
+        <th className="px-5 py-3 text-right text-xs font-semibold uppercase tracking-wider text-[#9FB4BE]">
+          Prior Credit
+        </th>
+      )}
+    </tr>
+  </thead>
+)
+
+interface TrialBalanceFootProps {
+  current: TrialBalanceReport
+  prior: TrialBalanceReport
+  hasPrior: boolean
+}
+
+/** Trial balance footer: totals row plus balanced/out-of-balance status row. */
+const TrialBalanceFoot: React.FC<TrialBalanceFootProps> = ({
+  current,
+  prior,
+  hasPrior,
+}) => (
+  <tfoot>
+    <tr className="bg-[#EAF3F2] dark:bg-[#16242F] font-bold border-t-2 border-[#5FE3C0]">
+      <td
+        colSpan={3}
+        className="px-5 py-3 text-sm text-[#11202B] dark:text-[#EAF3F2]"
+      >
+        Totals
+      </td>
+      <td className="px-5 py-3 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+        {formatMinorAsDollars(current.totalDebitsMinor)}
+      </td>
+      <td className="px-5 py-3 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+        {formatMinorAsDollars(current.totalCreditsMinor)}
+      </td>
+      {hasPrior && (
+        <td className="px-5 py-3 text-sm text-right font-mono text-[#647D8B]">
+          {formatMinorAsDollars(prior.totalDebitsMinor)}
+        </td>
+      )}
+      {hasPrior && (
+        <td className="px-5 py-3 text-sm text-right font-mono text-[#647D8B]">
+          {formatMinorAsDollars(prior.totalCreditsMinor)}
+        </td>
+      )}
+    </tr>
+    <tr className="bg-[#F7FAFA] dark:bg-[#11202B]">
+      <td
+        colSpan={hasPrior ? 7 : 5}
+        className={`px-5 py-2 text-sm text-center font-medium ${
+          current.isBalanced
+            ? 'text-[#5FE3C0]'
+            : 'text-red-600 dark:text-red-400'
+        }`}
+      >
+        {current.isBalanced
+          ? 'Trial balance is in balance'
+          : `Out of balance by ${formatMinorAsDollars(Math.abs(current.totalDebitsMinor - current.totalCreditsMinor))}`}
+      </td>
+    </tr>
+  </tfoot>
+)
+
 // ============================================================================
 // Main Component
 // ============================================================================
@@ -261,35 +352,7 @@ const PeriodTrialBalance: React.FC = () => {
       {!loading && data !== null && (
         <div className="border border-[rgba(95,227,192,0.15)] rounded-lg overflow-hidden">
           <table className="min-w-full">
-            <thead>
-              <tr className="bg-[#294050] text-white">
-                <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider">
-                  Account #
-                </th>
-                <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider">
-                  Account Name
-                </th>
-                <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider">
-                  Type
-                </th>
-                <th className="px-5 py-3 text-right text-xs font-semibold uppercase tracking-wider">
-                  Debit
-                </th>
-                <th className="px-5 py-3 text-right text-xs font-semibold uppercase tracking-wider">
-                  Credit
-                </th>
-                {hasPrior && (
-                  <th className="px-5 py-3 text-right text-xs font-semibold uppercase tracking-wider text-[#9FB4BE]">
-                    Prior Debit
-                  </th>
-                )}
-                {hasPrior && (
-                  <th className="px-5 py-3 text-right text-xs font-semibold uppercase tracking-wider text-[#9FB4BE]">
-                    Prior Credit
-                  </th>
-                )}
-              </tr>
-            </thead>
+            <TrialBalanceHead hasPrior={hasPrior} />
             <tbody className="divide-y divide-[rgba(95,227,192,0.1)]">
               {data.current.rows.map((row, idx) => {
                 const prior = priorMap.get(row.accountNumber) ?? {
@@ -308,46 +371,11 @@ const PeriodTrialBalance: React.FC = () => {
                 )
               })}
             </tbody>
-            <tfoot>
-              <tr className="bg-[#EAF3F2] dark:bg-[#16242F] font-bold border-t-2 border-[#5FE3C0]">
-                <td
-                  colSpan={3}
-                  className="px-5 py-3 text-sm text-[#11202B] dark:text-[#EAF3F2]"
-                >
-                  Totals
-                </td>
-                <td className="px-5 py-3 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
-                  {formatMinorAsDollars(data.current.totalDebitsMinor)}
-                </td>
-                <td className="px-5 py-3 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
-                  {formatMinorAsDollars(data.current.totalCreditsMinor)}
-                </td>
-                {hasPrior && (
-                  <td className="px-5 py-3 text-sm text-right font-mono text-[#647D8B]">
-                    {formatMinorAsDollars(data.prior.totalDebitsMinor)}
-                  </td>
-                )}
-                {hasPrior && (
-                  <td className="px-5 py-3 text-sm text-right font-mono text-[#647D8B]">
-                    {formatMinorAsDollars(data.prior.totalCreditsMinor)}
-                  </td>
-                )}
-              </tr>
-              <tr className="bg-[#F7FAFA] dark:bg-[#11202B]">
-                <td
-                  colSpan={hasPrior ? 7 : 5}
-                  className={`px-5 py-2 text-sm text-center font-medium ${
-                    data.current.isBalanced
-                      ? 'text-[#5FE3C0]'
-                      : 'text-red-600 dark:text-red-400'
-                  }`}
-                >
-                  {data.current.isBalanced
-                    ? 'Trial balance is in balance'
-                    : `Out of balance by ${formatMinorAsDollars(Math.abs(data.current.totalDebitsMinor - data.current.totalCreditsMinor))}`}
-                </td>
-              </tr>
-            </tfoot>
+            <TrialBalanceFoot
+              current={data.current}
+              prior={data.prior}
+              hasPrior={hasPrior}
+            />
           </table>
         </div>
       )}

--- a/src/app/reports/PeriodTrialBalance.tsx
+++ b/src/app/reports/PeriodTrialBalance.tsx
@@ -1,0 +1,349 @@
+import React, { useState, useEffect, useCallback, useMemo } from 'react'
+import { invoke } from '@tauri-apps/api/core'
+import { save } from '@tauri-apps/plugin-dialog'
+import { Scale, Download, AlertTriangle } from 'lucide-react'
+import {
+  formatMinorAsDollars,
+  formatStatementDate,
+  defaultPeriodDates,
+} from './statementUtils'
+
+// ============================================================================
+// Types matching Rust serde output
+// ============================================================================
+
+interface PeriodTrialBalanceRow {
+  accountNumber: string
+  accountName: string
+  accountType: string
+  debitBalance: number
+  creditBalance: number
+}
+
+interface TrialBalanceReport {
+  startDate: string
+  endDate: string
+  rows: PeriodTrialBalanceRow[]
+  totalDebitsMinor: number
+  totalCreditsMinor: number
+  isBalanced: boolean
+}
+
+interface ComparativeTrialBalance {
+  current: TrialBalanceReport
+  prior: TrialBalanceReport
+}
+
+// ============================================================================
+// Sub-components
+// ============================================================================
+
+interface PeriodSelectorProps {
+  startDate: string
+  endDate: string
+  onStartChange: (value: string) => void
+  onEndChange: (value: string) => void
+  onGenerate: () => void
+  loading: boolean
+}
+
+/** Period date selector for financial statements. */
+const PeriodSelector: React.FC<PeriodSelectorProps> = ({
+  startDate,
+  endDate,
+  onStartChange,
+  onEndChange,
+  onGenerate,
+  loading,
+}) => (
+  <div className="flex flex-wrap items-end gap-4 mb-6 p-4 bg-white dark:bg-[#11202B] border border-[rgba(95,227,192,0.15)] rounded-lg">
+    <div>
+      <label className="block text-xs font-medium text-[#294050] dark:text-[#9FB4BE] mb-1">
+        Start Date
+      </label>
+      <input
+        type="date"
+        value={startDate}
+        onChange={(e) => onStartChange(e.target.value)}
+        className="px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.25)] rounded bg-[#F7FAFA] dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2]"
+      />
+    </div>
+    <div>
+      <label className="block text-xs font-medium text-[#294050] dark:text-[#9FB4BE] mb-1">
+        End Date
+      </label>
+      <input
+        type="date"
+        value={endDate}
+        onChange={(e) => onEndChange(e.target.value)}
+        className="px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.25)] rounded bg-[#F7FAFA] dark:bg-[#0C141B] text-[#11202B] dark:text-[#EAF3F2]"
+      />
+    </div>
+    <button
+      onClick={onGenerate}
+      disabled={loading}
+      className="px-4 py-1.5 text-sm font-medium bg-[#294050] text-white rounded hover:bg-[#1E2F3C] disabled:opacity-50"
+    >
+      {loading ? 'Generating...' : 'Generate'}
+    </button>
+  </div>
+)
+
+interface TrialBalanceRowProps {
+  row: PeriodTrialBalanceRow
+  priorDebit: number
+  priorCredit: number
+  hasPrior: boolean
+  even: boolean
+}
+
+/** A single trial balance row with optional prior-period comparison. */
+const TrialBalanceRowComponent: React.FC<TrialBalanceRowProps> = ({
+  row,
+  priorDebit,
+  priorCredit,
+  hasPrior,
+  even,
+}) => (
+  <tr className={even ? 'bg-white dark:bg-[#11202B]' : 'bg-[#EAF3F2] dark:bg-[#16242F]'}>
+    <td className="px-5 py-2.5 text-sm font-mono text-[#5FE3C0] font-medium">
+      {row.accountNumber}
+    </td>
+    <td className="px-5 py-2.5 text-sm text-[#11202B] dark:text-[#EAF3F2]">
+      {row.accountName}
+    </td>
+    <td className="px-5 py-2.5 text-sm text-[#294050] dark:text-[#9FB4BE]">
+      {row.accountType}
+    </td>
+    <td className="px-5 py-2.5 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+      {row.debitBalance > 0 ? formatMinorAsDollars(row.debitBalance) : ''}
+    </td>
+    <td className="px-5 py-2.5 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+      {row.creditBalance > 0 ? formatMinorAsDollars(row.creditBalance) : ''}
+    </td>
+    {hasPrior && (
+      <td className="px-5 py-2.5 text-sm text-right font-mono text-[#647D8B]">
+        {priorDebit > 0 ? formatMinorAsDollars(priorDebit) : ''}
+      </td>
+    )}
+    {hasPrior && (
+      <td className="px-5 py-2.5 text-sm text-right font-mono text-[#647D8B]">
+        {priorCredit > 0 ? formatMinorAsDollars(priorCredit) : ''}
+      </td>
+    )}
+  </tr>
+)
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+/** Period-aware Trial Balance page with comparative prior period. */
+const PeriodTrialBalance: React.FC = () => {
+  const defaults = useMemo(() => defaultPeriodDates(), [])
+  const [startDate, setStartDate] = useState(defaults.startDate)
+  const [endDate, setEndDate] = useState(defaults.endDate)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [data, setData] = useState<ComparativeTrialBalance | null>(null)
+
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await invoke<ComparativeTrialBalance>('get_period_trial_balance', {
+        params: { startDate, endDate },
+      })
+      setData(result)
+    } catch (err) {
+      setError(String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [startDate, endDate])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  const handleExportCsv = useCallback(async () => {
+    const filePath = await save({
+      filters: [{ name: 'CSV', extensions: ['csv'] }],
+      defaultPath: `trial-balance-${startDate}-to-${endDate}.csv`,
+    })
+    if (!filePath) return
+    try {
+      await invoke('export_trial_balance_csv', {
+        params: { startDate, endDate },
+        path: filePath,
+      })
+    } catch (err) {
+      setError(String(err))
+    }
+  }, [startDate, endDate])
+
+  const hasPrior = data !== null && data.prior.rows.length > 0
+
+  const priorMap = useMemo(() => {
+    if (!data) return new Map<string, { debit: number; credit: number }>()
+    return new Map(
+      data.prior.rows.map((r) => [
+        r.accountNumber,
+        { debit: r.debitBalance, credit: r.creditBalance },
+      ]),
+    )
+  }, [data])
+
+  return (
+    <div className="p-4 sm:p-6 lg:p-8 max-w-6xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-[#11202B] dark:text-[#EAF3F2]">
+            Trial Balance
+          </h1>
+          {data !== null && (
+            <p className="text-sm text-[#294050] dark:text-[#9FB4BE] mt-1">
+              {formatStatementDate(data.current.startDate)} &mdash;{' '}
+              {formatStatementDate(data.current.endDate)}
+            </p>
+          )}
+        </div>
+        <button
+          onClick={handleExportCsv}
+          disabled={data === null}
+          className="flex items-center gap-2 px-3 py-1.5 text-sm border border-[rgba(95,227,192,0.3)] rounded text-[#294050] dark:text-[#9FB4BE] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F] disabled:opacity-40"
+        >
+          <Download className="w-4 h-4" />
+          Export CSV
+        </button>
+      </div>
+
+      <PeriodSelector
+        startDate={startDate}
+        endDate={endDate}
+        onStartChange={setStartDate}
+        onEndChange={setEndDate}
+        onGenerate={fetchData}
+        loading={loading}
+      />
+
+      {error !== null && (
+        <div className="flex items-start gap-3 p-4 mb-6 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+          <AlertTriangle className="w-5 h-5 text-red-600 dark:text-red-400 mt-0.5 shrink-0" />
+          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+        </div>
+      )}
+
+      {loading && (
+        <div className="flex items-center justify-center py-16">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#294050]" />
+        </div>
+      )}
+
+      {!loading && data === null && error === null && (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <Scale className="w-12 h-12 text-[#647D8B] mb-4" />
+          <h3 className="text-lg font-medium text-[#11202B] dark:text-[#EAF3F2]">
+            No data available
+          </h3>
+          <p className="text-sm text-[#294050] dark:text-[#9FB4BE] mt-1">
+            Select a period and generate the trial balance.
+          </p>
+        </div>
+      )}
+
+      {!loading && data !== null && (
+        <div className="border border-[rgba(95,227,192,0.15)] rounded-lg overflow-hidden">
+          <table className="min-w-full">
+            <thead>
+              <tr className="bg-[#294050] text-white">
+                <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider">
+                  Account #
+                </th>
+                <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider">
+                  Account Name
+                </th>
+                <th className="px-5 py-3 text-left text-xs font-semibold uppercase tracking-wider">
+                  Type
+                </th>
+                <th className="px-5 py-3 text-right text-xs font-semibold uppercase tracking-wider">
+                  Debit
+                </th>
+                <th className="px-5 py-3 text-right text-xs font-semibold uppercase tracking-wider">
+                  Credit
+                </th>
+                {hasPrior && (
+                  <th className="px-5 py-3 text-right text-xs font-semibold uppercase tracking-wider text-[#9FB4BE]">
+                    Prior Debit
+                  </th>
+                )}
+                {hasPrior && (
+                  <th className="px-5 py-3 text-right text-xs font-semibold uppercase tracking-wider text-[#9FB4BE]">
+                    Prior Credit
+                  </th>
+                )}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[rgba(95,227,192,0.1)]">
+              {data.current.rows.map((row, idx) => {
+                const prior = priorMap.get(row.accountNumber) ?? {
+                  debit: 0,
+                  credit: 0,
+                }
+                return (
+                  <TrialBalanceRowComponent
+                    key={row.accountNumber}
+                    row={row}
+                    priorDebit={prior.debit}
+                    priorCredit={prior.credit}
+                    hasPrior={hasPrior}
+                    even={idx % 2 === 0}
+                  />
+                )
+              })}
+            </tbody>
+            <tfoot>
+              <tr className="bg-[#EAF3F2] dark:bg-[#16242F] font-bold border-t-2 border-[#5FE3C0]">
+                <td colSpan={3} className="px-5 py-3 text-sm text-[#11202B] dark:text-[#EAF3F2]">
+                  Totals
+                </td>
+                <td className="px-5 py-3 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+                  {formatMinorAsDollars(data.current.totalDebitsMinor)}
+                </td>
+                <td className="px-5 py-3 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+                  {formatMinorAsDollars(data.current.totalCreditsMinor)}
+                </td>
+                {hasPrior && (
+                  <td className="px-5 py-3 text-sm text-right font-mono text-[#647D8B]">
+                    {formatMinorAsDollars(data.prior.totalDebitsMinor)}
+                  </td>
+                )}
+                {hasPrior && (
+                  <td className="px-5 py-3 text-sm text-right font-mono text-[#647D8B]">
+                    {formatMinorAsDollars(data.prior.totalCreditsMinor)}
+                  </td>
+                )}
+              </tr>
+              <tr className="bg-[#F7FAFA] dark:bg-[#11202B]">
+                <td
+                  colSpan={hasPrior ? 7 : 5}
+                  className={`px-5 py-2 text-sm text-center font-medium ${
+                    data.current.isBalanced
+                      ? 'text-[#5FE3C0]'
+                      : 'text-red-600 dark:text-red-400'
+                  }`}
+                >
+                  {data.current.isBalanced
+                    ? 'Trial balance is in balance'
+                    : `Out of balance by ${formatMinorAsDollars(Math.abs(data.current.totalDebitsMinor - data.current.totalCreditsMinor))}`}
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default PeriodTrialBalance

--- a/src/app/reports/PeriodTrialBalance.tsx
+++ b/src/app/reports/PeriodTrialBalance.tsx
@@ -210,8 +210,7 @@ const PeriodTrialBalance: React.FC = () => {
           </h1>
           {data !== null && (
             <p className="text-sm text-[#294050] dark:text-[#9FB4BE] mt-1">
-              {formatStatementDate(data.current.startDate)} &mdash;{' '}
-              {formatStatementDate(data.current.endDate)}
+              As of {formatStatementDate(data.current.endDate)}
             </p>
           )}
         </div>

--- a/src/app/reports/Reports.tsx
+++ b/src/app/reports/Reports.tsx
@@ -327,6 +327,9 @@ const ReportsHeader: React.FC = () => (
 /** Route map for reports with functional sub-pages */
 const reportRoutes: Record<string, string> = {
   'cost-basis': '/reports/cost-basis',
+  'balance-sheet': '/reports/balance-sheet',
+  'income-statement': '/reports/income-statement',
+  'trial-balance': '/reports/trial-balance',
 }
 
 /** Main reports page with search, category filtering, and recent run history */

--- a/src/app/reports/StatementTableParts.tsx
+++ b/src/app/reports/StatementTableParts.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import {
+  formatMinorAsDollars,
+  computeChangePercent,
+  formatChangePercent,
+} from './statementUtils'
+
+interface StatementSectionHeadProps {
+  showPrior: boolean
+}
+
+/** Shared table header for statement section tables (Account / Current / Prior / Change). */
+export const StatementSectionHead: React.FC<StatementSectionHeadProps> = ({
+  showPrior,
+}) => (
+  <thead>
+    <tr className="border-b border-[rgba(95,227,192,0.2)]">
+      <th className="px-4 py-2 text-left text-xs font-medium text-[#647D8B] uppercase">
+        Account
+      </th>
+      <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
+        Current
+      </th>
+      {showPrior && (
+        <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
+          Prior
+        </th>
+      )}
+      {showPrior && (
+        <th className="px-4 py-2 text-right text-xs font-medium text-[#647D8B] uppercase">
+          Change
+        </th>
+      )}
+    </tr>
+  </thead>
+)
+
+interface StatementSectionFootProps {
+  label: string
+  totalMinor: number
+  priorTotalMinor: number | null
+}
+
+/** Shared table footer with the section total and optional prior comparison. */
+export const StatementSectionFoot: React.FC<StatementSectionFootProps> = ({
+  label,
+  totalMinor,
+  priorTotalMinor,
+}) => (
+  <tfoot>
+    <tr className="border-t-2 border-[#5FE3C0] font-bold">
+      <td className="px-4 py-2 text-sm text-[#11202B] dark:text-[#EAF3F2]">
+        {label}
+      </td>
+      <td className="px-4 py-2 text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
+        {formatMinorAsDollars(totalMinor)}
+      </td>
+      {priorTotalMinor !== null && (
+        <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
+          {formatMinorAsDollars(priorTotalMinor)}
+        </td>
+      )}
+      {priorTotalMinor !== null && (
+        <td className="px-4 py-2 text-sm text-right font-mono text-[#647D8B]">
+          {formatChangePercent(
+            computeChangePercent(totalMinor, priorTotalMinor)
+          )}
+        </td>
+      )}
+    </tr>
+  </tfoot>
+)

--- a/src/app/reports/statementUtils.test.ts
+++ b/src/app/reports/statementUtils.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatMinorAsDollars,
+  formatMinorPlain,
+  formatStatementDate,
+  computeChangePercent,
+  formatChangePercent,
+  defaultPeriodDates,
+} from './statementUtils'
+
+describe('formatMinorAsDollars', () => {
+  it('should format positive amounts with commas', () => {
+    expect(formatMinorAsDollars(12345)).toBe('$123.45')
+    expect(formatMinorAsDollars(100000)).toBe('$1,000.00')
+    expect(formatMinorAsDollars(5)).toBe('$0.05')
+  })
+
+  it('should format zero', () => {
+    expect(formatMinorAsDollars(0)).toBe('$0.00')
+  })
+
+  it('should format negative amounts', () => {
+    expect(formatMinorAsDollars(-500)).toBe('-$5.00')
+    expect(formatMinorAsDollars(-12345)).toBe('-$123.45')
+  })
+
+  it('should handle exact dollar amounts', () => {
+    expect(formatMinorAsDollars(100)).toBe('$1.00')
+    expect(formatMinorAsDollars(50000)).toBe('$500.00')
+  })
+})
+
+describe('formatMinorPlain', () => {
+  it('should format without currency symbol', () => {
+    expect(formatMinorPlain(12345)).toBe('123.45')
+    expect(formatMinorPlain(0)).toBe('0.00')
+    expect(formatMinorPlain(-500)).toBe('-5.00')
+  })
+
+  it('should include commas for large numbers', () => {
+    expect(formatMinorPlain(100000)).toBe('1,000.00')
+  })
+})
+
+describe('formatStatementDate', () => {
+  it('should format ISO date strings', () => {
+    expect(formatStatementDate('2025-01-01')).toBe('Jan 1, 2025')
+    expect(formatStatementDate('2025-12-31')).toBe('Dec 31, 2025')
+  })
+
+  it('should return input unchanged for invalid dates', () => {
+    expect(formatStatementDate('invalid')).toBe('invalid')
+  })
+})
+
+describe('computeChangePercent', () => {
+  it('should compute positive change', () => {
+    expect(computeChangePercent(120, 100)).toBe(20)
+  })
+
+  it('should compute negative change', () => {
+    expect(computeChangePercent(80, 100)).toBe(-20)
+  })
+
+  it('should return null when prior is zero', () => {
+    expect(computeChangePercent(100, 0)).toBeNull()
+  })
+
+  it('should return 0 when values are equal', () => {
+    expect(computeChangePercent(100, 100)).toBe(0)
+  })
+})
+
+describe('formatChangePercent', () => {
+  it('should format positive change', () => {
+    expect(formatChangePercent(12.5)).toBe('+12.5%')
+  })
+
+  it('should format negative change', () => {
+    expect(formatChangePercent(-3.2)).toBe('-3.2%')
+  })
+
+  it('should format null as N/A', () => {
+    expect(formatChangePercent(null)).toBe('N/A')
+  })
+
+  it('should format zero change', () => {
+    expect(formatChangePercent(0)).toBe('+0.0%')
+  })
+})
+
+describe('defaultPeriodDates', () => {
+  it('should return current year Jan 1 to Dec 31', () => {
+    const result = defaultPeriodDates()
+    const year = new Date().getFullYear()
+    expect(result.startDate).toBe(`${year}-01-01`)
+    expect(result.endDate).toBe(`${year}-12-31`)
+  })
+})

--- a/src/app/reports/statementUtils.ts
+++ b/src/app/reports/statementUtils.ts
@@ -1,0 +1,70 @@
+/**
+ * Utility functions for financial statement pages.
+ * Pure helpers — no React, fully testable via Vitest.
+ */
+
+/** Formats minor units (integer cents) as a dollar string: 12345 → "$123.45". */
+export function formatMinorAsDollars(minor: number): string {
+  const sign = minor < 0 ? '-' : ''
+  const abs = Math.abs(minor)
+  const dollars = Math.floor(abs / 100)
+  const cents = abs % 100
+  return `${sign}$${dollars.toLocaleString('en-US')}.${String(cents).padStart(2, '0')}`
+}
+
+/** Formats minor units without currency symbol: 12345 → "123.45". */
+export function formatMinorPlain(minor: number): string {
+  const sign = minor < 0 ? '-' : ''
+  const abs = Math.abs(minor)
+  const dollars = Math.floor(abs / 100)
+  const cents = abs % 100
+  return `${sign}${dollars.toLocaleString('en-US')}.${String(cents).padStart(2, '0')}`
+}
+
+/** Formats an ISO date string to a readable format: "2025-01-01" → "Jan 1, 2025". */
+export function formatStatementDate(isoDate: string): string {
+  const parts = isoDate.split('-')
+  if (parts.length !== 3) return isoDate
+  const date = new Date(
+    Number.parseInt(parts[0], 10),
+    Number.parseInt(parts[1], 10) - 1,
+    Number.parseInt(parts[2], 10),
+  )
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+/** Returns the period-over-period change as a percentage, or null if prior is 0. */
+export function computeChangePercent(
+  current: number,
+  prior: number,
+): number | null {
+  if (prior === 0) return null
+  return ((current - prior) / Math.abs(prior)) * 100
+}
+
+/** Formats a change percentage: "+12.5%" or "-3.2%" or "N/A". */
+export function formatChangePercent(pct: number | null): string {
+  if (pct === null) return 'N/A'
+  const sign = pct >= 0 ? '+' : ''
+  return `${sign}${pct.toFixed(1)}%`
+}
+
+/**
+ * Returns the default period dates for statements.
+ * Defaults to the current calendar year (Jan 1 – Dec 31).
+ */
+export function defaultPeriodDates(): {
+  startDate: string
+  endDate: string
+} {
+  const now = new Date()
+  const year = now.getFullYear()
+  return {
+    startDate: `${year}-01-01`,
+    endDate: `${year}-12-31`,
+  }
+}

--- a/src/app/reports/statementUtils.ts
+++ b/src/app/reports/statementUtils.ts
@@ -28,7 +28,7 @@ export function formatStatementDate(isoDate: string): string {
   const date = new Date(
     Number.parseInt(parts[0], 10),
     Number.parseInt(parts[1], 10) - 1,
-    Number.parseInt(parts[2], 10),
+    Number.parseInt(parts[2], 10)
   )
   return date.toLocaleDateString('en-US', {
     month: 'short',
@@ -40,7 +40,7 @@ export function formatStatementDate(isoDate: string): string {
 /** Returns the period-over-period change as a percentage, or null if prior is 0. */
 export function computeChangePercent(
   current: number,
-  prior: number,
+  prior: number
 ): number | null {
   if (prior === 0) return null
   return ((current - prior) / Math.abs(prior)) * 100


### PR DESCRIPTION
## Summary

Phase 6 of the Stage 1 double-entry accounting engine: financial statements v1.

- **Balance sheet**, **income statement**, and **trial balance** with period-aware date-range filtering
- **Comparative prior period** of equal duration shown alongside current period
- **`verify_ties` assertion** (non-negotiable): A = L + E, net income consistency, trial balance balance — a statement that does not tie is a hard error and never renders
- **CSV export** for all three statements via Tauri file-save dialog
- **No schema migration** — all aggregation in Rust over posted `journal_entry_lines` using i64 minor units (no floats touch money)

### Files changed

**Rust backend:**
- `src-tauri/src/api/statements.rs` — new module: period queries, statement builders, verify, CSV export, 12 unit tests
- `src-tauri/src/api/mod.rs` — register `statements` module
- `src-tauri/src/lib.rs` — register 6 new Tauri commands

**Frontend:**
- `src/app/reports/BalanceSheet.tsx` — balance sheet page with period selector + comparative columns
- `src/app/reports/IncomeStatement.tsx` — income statement page
- `src/app/reports/PeriodTrialBalance.tsx` — enhanced trial balance with period filtering
- `src/app/reports/statementUtils.ts` — pure utility functions for formatting
- `src/app/reports/statementUtils.test.ts` — 17 Vitest tests
- `src/App.tsx` — new routes
- `src/app/reports/Reports.tsx` — updated route map

**Docs:**
- `docs/accounting-model.md` — §9 Financial statements (account classification, tie verification, comparative periods)
- `docs/stage1-progress.md` — Phase 6 checkbox + Session 11 log

## Test plan

- [x] 12 Rust unit tests pass (ties, corrupted aggregate detection, voided-entry neutrality, comparative dates, empty period, zero-balance exclusion)
- [x] 17 Vitest tests pass (formatMinorAsDollars, formatMinorPlain, formatStatementDate, computeChangePercent, formatChangePercent, defaultPeriodDates)
- [x] Full Rust suite: 242 tests pass (0 failures)
- [x] ESLint clean on all new files
- [x] No new TypeScript errors beyond pre-existing module resolution (Tauri types)
- [ ] Manual: verify statement pages render with test data in the Tauri app
- [ ] Manual: verify CSV export produces correct files

🤖 Generated with [Claude Code](https://claude.com/claude-code)