### PR TITLE
Migrate Moonscan V1 to Etherscan V2 API for Moonbeam/Moonriver (GIV-668)

### DIFF
--- a/src-tauri/src/chains/evm/config.rs
+++ b/src-tauri/src/chains/evm/config.rs
@@ -195,23 +195,25 @@ fn get_configs() -> &'static Vec<EvmChainConfig> {
                 3,     // ~3 second block time
             ),
             // Moonbeam (Polkadot parachain, EVM-compatible)
+            // Uses Etherscan V2 unified endpoint (Moonscan V1 deprecated)
             EvmChainConfig::new(
                 1284,
                 "moonbeam",
                 "GLMR",
                 "https://rpc.api.moonbeam.network",
-                "https://api-moonbeam.moonscan.io/api",
+                "https://api.etherscan.io/v2/api",
                 false, // Parachain
                 12,    // ~12 second block time
             )
             .with_explorer_key_env("MOONSCAN_API_KEY"),
             // Moonriver (Kusama parachain, EVM-compatible)
+            // Uses Etherscan V2 unified endpoint (Moonscan V1 deprecated)
             EvmChainConfig::new(
                 1285,
                 "moonriver",
                 "MOVR",
                 "https://rpc.api.moonriver.moonbeam.network",
-                "https://api-moonriver.moonscan.io/api",
+                "https://api.etherscan.io/v2/api",
                 false, // Parachain
                 12,    // ~12 second block time
             )

--- a/src-tauri/src/chains/evm/etherscan.rs
+++ b/src-tauri/src/chains/evm/etherscan.rs
@@ -62,13 +62,14 @@ struct ApiErrorResponse {
 /// Get the ApiProvider for a chain ID (for keychain lookup)
 fn get_api_provider_for_chain(chain_id: u64) -> ApiProvider {
     match chain_id {
-        1 => ApiProvider::Etherscan,     // Ethereum
-        137 => ApiProvider::Polygonscan, // Polygon
-        42161 => ApiProvider::Arbiscan,  // Arbitrum
-        8453 => ApiProvider::Basescan,   // Base
-        10 => ApiProvider::Optimism,     // Optimism
-        56 => ApiProvider::Etherscan,    // BSC (uses Etherscan V2 API)
-        _ => ApiProvider::Etherscan,     // Default to Etherscan for unknown chains
+        1 => ApiProvider::Etherscan,          // Ethereum
+        137 => ApiProvider::Polygonscan,      // Polygon
+        42161 => ApiProvider::Arbiscan,       // Arbitrum
+        8453 => ApiProvider::Basescan,        // Base
+        10 => ApiProvider::Optimism,          // Optimism
+        56 => ApiProvider::Etherscan,         // BSC (uses Etherscan V2 API)
+        1284 | 1285 => ApiProvider::Moonscan, // Moonbeam / Moonriver
+        _ => ApiProvider::Etherscan,          // Default to Etherscan for unknown chains
     }
 }
 

--- a/src-tauri/src/evm_indexer/mod.rs
+++ b/src-tauri/src/evm_indexer/mod.rs
@@ -61,7 +61,7 @@ impl EVMIndexer {
                 chain_id: 1284,
                 rpc_url: "https://rpc.api.moonbeam.network".to_string(),
                 ws_url: Some("wss://wss.api.moonbeam.network".to_string()),
-                explorer_api: Some("https://api-moonbeam.moonscan.io/api".to_string()),
+                explorer_api: Some("https://api.etherscan.io/v2/api".to_string()),
                 native_token: Token {
                     symbol: "GLMR".to_string(),
                     decimals: 18,
@@ -81,7 +81,7 @@ impl EVMIndexer {
                 chain_id: 1285,
                 rpc_url: "https://rpc.api.moonriver.moonbeam.network".to_string(),
                 ws_url: Some("wss://wss.api.moonriver.moonbeam.network".to_string()),
-                explorer_api: Some("https://api-moonriver.moonscan.io/api".to_string()),
+                explorer_api: Some("https://api.etherscan.io/v2/api".to_string()),
                 native_token: Token {
                     symbol: "MOVR".to_string(),
                     decimals: 18,

--- a/src/services/blockchain/evmTransactionService.ts
+++ b/src/services/blockchain/evmTransactionService.ts
@@ -19,16 +19,19 @@ export const EVM_NETWORK_MAP: Record<string, NetworkType> = {
 interface BlockExplorerConfig {
   apiUrl: string
   apiKey?: string
+  chainId?: number // For Etherscan V2 unified endpoint
   rateLimit: number // ms between requests
 }
 
 const BLOCK_EXPLORER_APIS: Record<string, BlockExplorerConfig> = {
   moonbeam: {
-    apiUrl: 'https://api-moonbeam.moonscan.io/api',
+    apiUrl: 'https://api.etherscan.io/v2/api',
+    chainId: 1284,
     rateLimit: 200,
   },
   moonriver: {
-    apiUrl: 'https://api-moonriver.moonscan.io/api',
+    apiUrl: 'https://api.etherscan.io/v2/api',
+    chainId: 1285,
     rateLimit: 200,
   },
   astar: {
@@ -249,6 +252,9 @@ class EVMTransactionService {
         offset: limit.toString(),
         sort: 'desc',
       })
+      if (explorerConfig.chainId) {
+        params.set('chainid', explorerConfig.chainId.toString())
+      }
 
       const response = await fetch(`${explorerConfig.apiUrl}?${params}`)
       const data = await response.json()
@@ -293,6 +299,9 @@ class EVMTransactionService {
         offset: limit.toString(),
         sort: 'desc',
       })
+      if (explorerConfig.chainId) {
+        params.set('chainid', explorerConfig.chainId.toString())
+      }
 
       const response = await fetch(`${explorerConfig.apiUrl}?${params}`)
       const data = await response.json()

--- a/src/services/blockchain/moonscanService.ts
+++ b/src/services/blockchain/moonscanService.ts
@@ -1,9 +1,9 @@
 /**
  * Moonscan API Service
- * Fetches EVM transaction history using direct Moonscan API endpoints
- * Used for Moonbeam and Moonriver EVM-compatible chains
+ * Fetches EVM transaction history for Moonbeam/Moonriver via the Etherscan V2
+ * unified API (per-chain V1 endpoints are deprecated).
  *
- * Note: Moonscan requires its own API key (separate from Etherscan).
+ * An Etherscan or Moonscan API key unlocks faster rate limits.
  * Get a free API key at: https://moonscan.io/myapikey
  * Without a key, requests are rate-limited to ~1 req/5s.
  */
@@ -72,18 +72,18 @@ interface MoonscanResponse<T> {
  * Service for fetching EVM transaction history using Etherscan V2 API.
  */
 export class MoonscanService {
-  // Direct Moonscan API endpoints per chain (not Etherscan V2 — Moonbeam is
-  // not supported on the V2 unified endpoint and requires its own API key)
+  // Etherscan V2 unified endpoint — Moonscan V1 per-chain endpoints are
+  // deprecated; V2 routes via the chainid query parameter instead.
   private readonly NETWORK_CONFIGS: Partial<
     Record<NetworkType, MoonscanConfig>
   > = {
     moonbeam: {
       chainId: 1284,
-      apiUrl: 'https://api-moonbeam.moonscan.io/api',
+      apiUrl: 'https://api.etherscan.io/v2/api',
     },
     moonriver: {
       chainId: 1285,
-      apiUrl: 'https://api-moonriver.moonscan.io/api',
+      apiUrl: 'https://api.etherscan.io/v2/api',
     },
   }
 
@@ -157,8 +157,9 @@ export class MoonscanService {
       sort = 'desc',
     } = options
 
-    // Build direct Moonscan API URL (not Etherscan V2)
+    // Build Etherscan V2 API URL with chainid parameter
     const params = new URLSearchParams({
+      chainid: config.chainId.toString(),
       module: 'account',
       action: 'txlist',
       address,
@@ -249,6 +250,7 @@ export class MoonscanService {
     } = options
 
     const params = new URLSearchParams({
+      chainid: config.chainId.toString(),
       module: 'account',
       action: 'tokentx',
       address,


### PR DESCRIPTION
## Summary

- Moonscan V1 per-chain endpoints (`api-moonbeam.moonscan.io/api`) are deprecated and now return: *"You are using a deprecated V1 endpoint, switch to Etherscan API V2"*
- Switches all Moonbeam (1284) and Moonriver (1285) API calls to the Etherscan V2 unified endpoint (`api.etherscan.io/v2/api`) with the `chainid` query parameter — matching how all other EVM chains already work
- Adds `Moonscan` provider mapping in `etherscan.rs` so Moonbeam/Moonriver keychain lookups use the correct provider

## Files changed (5)

| File | Change |
|------|--------|
| `src/services/blockchain/moonscanService.ts` | V2 URL + `chainid` param in txlist/tokentx |
| `src/services/blockchain/evmTransactionService.ts` | V2 URLs + optional `chainId` in `BlockExplorerConfig` |
| `src-tauri/src/chains/evm/config.rs` | V2 `explorer_api_url` for chains 1284/1285 |
| `src-tauri/src/chains/evm/etherscan.rs` | `Moonscan` provider for chains 1284/1285 |
| `src-tauri/src/evm_indexer/mod.rs` | V2 `explorer_api` URLs |

## Verification

- `cargo check` — clean
- `cargo clippy -- -D warnings` — clean
- `cargo test --lib` config + etherscan tests — 16/16 pass
- `npx tsc --noEmit` — clean

## Test plan

- [ ] Rebuild app from this branch (`pnpm install --frozen-lockfile && pnpm tauri dev`)
- [ ] Navigate to a wallet with Moonbeam activity and trigger sync
- [ ] Verify EVM transactions load without the V1 deprecation error
- [ ] Verify Moonriver sync also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)