### PR TITLE
Fix Moonscan sync: fall back to Etherscan API key (GIV-668)

### DIFF
--- a/src-tauri/src/chains/evm/etherscan.rs
+++ b/src-tauri/src/chains/evm/etherscan.rs
@@ -139,7 +139,9 @@ impl EtherscanClient {
                 // Moonscan V1 deprecated; V2 runs through api.etherscan.io —
                 // fall back to the Etherscan key when no Moonscan-specific key exists
                 if provider == ApiProvider::Moonscan {
-                    ApiKeyManager::get_api_key(ApiProvider::Etherscan).ok().flatten()
+                    ApiKeyManager::get_api_key(ApiProvider::Etherscan)
+                        .ok()
+                        .flatten()
                 } else {
                     None
                 }

--- a/src-tauri/src/chains/evm/etherscan.rs
+++ b/src-tauri/src/chains/evm/etherscan.rs
@@ -3,10 +3,13 @@
 //! Supports Etherscan and compatible block explorer APIs (Polygonscan, Arbiscan, etc.)
 //! Now uses the ResilientFetcher for Governor-based rate limiting and automatic retries.
 //!
-//! # "Batteries Included, Turbo Optional"
+//! # API Key Handling
 //!
-//! - **Default Mode**: Works out of the box with 1 req/sec (no API key required)
-//! - **Turbo Mode**: Add your API key in Settings to unlock 5 req/sec
+//! Etherscan V2 requires an API key. For chains that use the V2 unified endpoint
+//! (including Moonbeam/Moonriver), the client falls back to the Etherscan key
+//! when no chain-specific key is configured.
+//! - **Default Mode**: 1 req/sec with a free key
+//! - **Turbo Mode**: Add a paid/higher-tier API key for 5 req/sec
 
 use super::config::{get_chain_config, EvmChainConfig};
 use super::types::{
@@ -124,13 +127,23 @@ impl EtherscanClient {
     ///
     /// # API Key Priority
     /// 1. Explicitly provided `api_key` parameter
-    /// 2. Key from OS keychain (via ApiKeyManager)
-    /// 3. No key (Default Mode)
+    /// 2. Key from OS keychain for the chain's provider (via ApiKeyManager)
+    /// 3. Etherscan key fallback (for chains using V2 unified endpoint, e.g. Moonscan)
+    /// 4. No key (Default Mode — may fail on Etherscan V2 which requires a key)
     pub fn new(config: &EvmChainConfig, api_key: Option<String>) -> ChainResult<Self> {
-        // Determine the API key (explicit > keychain > none)
+        // Determine the API key (explicit > provider keychain > etherscan fallback > none)
         let provider = get_api_provider_for_chain(config.chain_id);
-        let effective_api_key =
-            api_key.or_else(|| ApiKeyManager::get_api_key(provider).ok().flatten());
+        let effective_api_key = api_key
+            .or_else(|| ApiKeyManager::get_api_key(provider).ok().flatten())
+            .or_else(|| {
+                // Moonscan V1 deprecated; V2 runs through api.etherscan.io —
+                // fall back to the Etherscan key when no Moonscan-specific key exists
+                if provider == ApiProvider::Moonscan {
+                    ApiKeyManager::get_api_key(ApiProvider::Etherscan).ok().flatten()
+                } else {
+                    None
+                }
+            });
 
         // Calculate rate limit based on API key presence
         let rate_limit = get_rate_limit_for_chain(config.chain_id, effective_api_key.is_some());

--- a/src/services/blockchain/moonscanService.ts
+++ b/src/services/blockchain/moonscanService.ts
@@ -3,9 +3,9 @@
  * Fetches EVM transaction history for Moonbeam/Moonriver via the Etherscan V2
  * unified API (per-chain V1 endpoints are deprecated).
  *
- * An Etherscan or Moonscan API key unlocks faster rate limits.
- * Get a free API key at: https://moonscan.io/myapikey
- * Without a key, requests are rate-limited to ~1 req/5s.
+ * Etherscan V2 requires an API key for all requests.
+ * A free Etherscan key (https://etherscan.io/myapikey) works for all V2 chains
+ * including Moonbeam/Moonriver. A Moonscan-specific key also works.
  */
 
 import { invoke } from '@tauri-apps/api/core'
@@ -87,14 +87,21 @@ export class MoonscanService {
     },
   }
 
-  // Retrieve API key: Tauri keychain → localStorage → env var
+  // Retrieve API key: Tauri keychain → localStorage → env var.
+  // Falls back to the Etherscan key because Moonscan V1 is deprecated and V2
+  // runs through api.etherscan.io — an Etherscan API key works for all V2 chains.
   private static async getApiKey(): Promise<string | null> {
-    // Try Tauri keychain first (desktop app)
+    // Try Tauri keychain first (desktop app): moonscan key, then etherscan key
     try {
       const key = await invoke<string | null>('get_api_key', {
         provider: 'moonscan',
       })
       if (key) return key
+      // Moonscan V1 deprecated; V2 runs through etherscan.io — etherscan key works
+      const ethKey = await invoke<string | null>('get_api_key', {
+        provider: 'etherscan',
+      })
+      if (ethKey) return ethKey
     } catch {
       // Tauri not available — fall through to browser fallbacks
     }
@@ -102,13 +109,15 @@ export class MoonscanService {
     // Check localStorage (browser dev mode, set via DataProviders page)
     const storedKey = localStorage.getItem('pacioli_api_key_moonscan')
     if (storedKey) return storedKey
+    const ethStoredKey = localStorage.getItem('pacioli_api_key_etherscan')
+    if (ethStoredKey) return ethStoredKey
 
     // Check for environment variable (build-time configured)
-    if (
-      typeof import.meta !== 'undefined' &&
-      import.meta.env?.VITE_MOONSCAN_API_KEY
-    ) {
-      return import.meta.env.VITE_MOONSCAN_API_KEY
+    if (typeof import.meta !== 'undefined') {
+      if (import.meta.env?.VITE_MOONSCAN_API_KEY)
+        return import.meta.env.VITE_MOONSCAN_API_KEY
+      if (import.meta.env?.VITE_ETHERSCAN_API_KEY)
+        return import.meta.env.VITE_ETHERSCAN_API_KEY
     }
 
     return null
@@ -169,7 +178,7 @@ export class MoonscanService {
       offset: offset.toString(),
       sort,
     })
-    // API key is optional — without it, Moonscan allows ~1 req/5s
+    // Etherscan V2 requires an API key; getApiKey() falls back to etherscan key
     if (apiKey) {
       params.set('apikey', apiKey)
     }


### PR DESCRIPTION
## Summary

- Moonscan V1 per-chain endpoints were deprecated; PR #228 switched to Etherscan V2 (`api.etherscan.io/v2/api`)
- Etherscan V2 **requires** an API key — the old keyless mode no longer works
- When no Moonscan-specific key is configured, both the Rust backend (`etherscan.rs`) and TypeScript frontend (`moonscanService.ts`) now fall back to the user's Etherscan API key
- Updated misleading "no API key required" comments

Fixes the board-reported error: "Sync Failed — Failed to fetch EVM transactions: Moonscan API error: Missing/Invalid API Key"

## Changes

- `src-tauri/src/chains/evm/etherscan.rs`: Added Etherscan key fallback in `EtherscanClient::new()` when provider is Moonscan
- `src/services/blockchain/moonscanService.ts`: Added Etherscan key fallback in `getApiKey()` across all 3 lookup layers (Tauri keychain, localStorage, env var)

## Test plan

- [ ] Rebuild desktop app from this branch (`pnpm install --frozen-lockfile && pnpm tauri:build`)
- [ ] With an Etherscan API key configured (but no Moonscan key), sync a Moonbeam wallet — should succeed
- [ ] CI: cargo check, clippy, tsc --noEmit all pass locally