### PR TITLE
feat(db): Phase 4a Part 1 — descriptive columns, error surfacing (GIV-712)

### DIFF
--- a/docs/stage1-progress.md
+++ b/docs/stage1-progress.md
@@ -34,16 +34,16 @@ class behind rehearsal findings #1/#2/#3.**
       auto-classified entries, classification_status flip — Engineer)
 - [ ] **Phase 4a — Import resilience and canonical store** (added by board
       amendment to the Stage 1 mandate, 2026-07-18; formalizes "Option B"
-      from the rehearsal findings #1-#3 options analysis): per-chain
-      provider registry with fallback (Etherscan V2 → Alchemy → direct RPC
-      for EVM chains; Polkadot.js with fallback endpoints for Substrate;
-      dedicated fallbacks for the existing Solana/Bitcoin services) with
-      retry/backoff and graceful "provider temporarily unavailable" errors;
-      resumable sync cursors (per wallet/chain high-water mark, no
-      duplicate ingestion on re-sync); idempotent ingestion enforced at the
-      data layer; descriptive human-legible raw-transaction column names;
-      provider-flakiness simulation in tests (5xx/timeout/partial data).
-      Runs in parallel with the Phase 10 rehearsal. Delegated: Engineer.
+      from the rehearsal findings #1-#3 options analysis). Split into two
+      parts per CTO review:
+      - **Part 1 (PR in review):** descriptive column renames
+        (`hash→transaction_hash`, `value→transfer_value`, etc.), all
+        Rust/TS readers updated, error surfacing in `insert_transactions`
+        (no more silent swallowing), `wallet_address` provenance column,
+        docs updated with Part 1/Part 2 split. Delegated: Engineer.
+      - **Part 2 (follow-up):** wire provider fallback into live import
+        path, resumable sync cursor logic, Solana/Bitcoin fallback
+        endpoints, vitest flakiness simulation tests. Delegated: Engineer.
 - [x] **Phase 5 — Periods, close, and lock**
       (GIV-684: accounting_periods table with open/closed lifecycle,
       DB trigger blocks posting into closed periods, list_periods/
@@ -1073,3 +1073,38 @@ WHERE status='approved'` (the M5 state machine explicitly allows
     step 2) is unchanged.
   - Bookkeeping: GIV-702 (Option A, save-time key validation) PR #232 is
     merged on main (`d99ef72`); issue closed.
+- **Session 20 (2026-07-18, Engineer — Phase 4a Part 1):**
+  - **Scope split (CTO-recommended):** Phase 4a split into two parts per
+    CTO review of PR #234. Part 1 (this PR): descriptive column renames,
+    all Rust/TS reader updates, error surfacing in `insert_transactions`.
+    Part 2 (follow-up): provider fallback wiring into live import path,
+    sync cursor resume logic, vitest flakiness simulation tests.
+  - **Rebased onto current main** (`8c73359`, post Phases 4-10 + Gate 1
+    rehearsal + Moonscan fixes) — clean stack, no stale parent.
+  - **Migration `20260718000001_phase4a_descriptive_columns.sql`:**
+    `hash→transaction_hash`, `tx_type→transaction_type`,
+    `value→transfer_value`, `fee→transaction_fee`,
+    `raw_data→raw_json_data`, `token_transfers.value→transfer_amount`,
+    new `wallet_address` column with index.
+  - **All Rust readers updated:** `db/multi_chain.rs` (Transaction,
+    TransactionRow, TokenTransfer, TokenTransferRow structs + all SQL),
+    `api/persistence.rs` (ChainTransactionInput, ChainTransactionRow +
+    save/get SQL), `api/accounting.rs` (MultiChainTx, MultiChainTransaction
+    + all SQL queries + test helper `insert_raw_tx`).
+  - **Error surfacing:** `insert_transactions` and `insert_token_transfers`
+    in `db/multi_chain.rs`, `save_chain_transactions` and
+    `save_transactions` in `api/persistence.rs` now propagate per-row
+    errors via `?` instead of silently swallowing with `if result.is_ok()`.
+    This eliminates the "silently incomplete history" failure class.
+  - **TS consumers updated:** `tauriPersistence.ts` serialization mapping,
+    `database.ts` `RawTransaction` interface, `ClassificationQueue.tsx`
+    all field references.
+  - **Idempotency note:** the existing `UNIQUE(chain_id, hash)` constraint
+    (now `UNIQUE(chain_id, transaction_hash)` post-rename) predates this
+    PR — it was part of the original `20260118000001` migration. The
+    one-row-per-tx + first-importer `wallet_address` design is documented
+    here rather than claimed as new work.
+  - **Part 2 remaining (follow-up PR):** wire `provider_fallback` module
+    into the live `ChainManager` import path (not dead code); resume sync
+    from `address_sync_status.last_block_synced`; add Solana/Bitcoin
+    fallback endpoints; vitest flakiness simulation tests.

--- a/docs/stage1-progress.md
+++ b/docs/stage1-progress.md
@@ -35,15 +35,13 @@ class behind rehearsal findings #1/#2/#3.**
 - [ ] **Phase 4a — Import resilience and canonical store** (added by board
       amendment to the Stage 1 mandate, 2026-07-18; formalizes "Option B"
       from the rehearsal findings #1-#3 options analysis). Split into two
-      parts per CTO review:
-      - **Part 1 (PR in review):** descriptive column renames
-        (`hash→transaction_hash`, `value→transfer_value`, etc.), all
-        Rust/TS readers updated, error surfacing in `insert_transactions`
-        (no more silent swallowing), `wallet_address` provenance column,
-        docs updated with Part 1/Part 2 split. Delegated: Engineer.
-      - **Part 2 (follow-up):** wire provider fallback into live import
-        path, resumable sync cursor logic, Solana/Bitcoin fallback
-        endpoints, vitest flakiness simulation tests. Delegated: Engineer.
+      parts per CTO review: - **Part 1 (PR in review):** descriptive column renames
+      (`hash→transaction_hash`, `value→transfer_value`, etc.), all
+      Rust/TS readers updated, error surfacing in `insert_transactions`
+      (no more silent swallowing), `wallet_address` provenance column,
+      docs updated with Part 1/Part 2 split. Delegated: Engineer. - **Part 2 (follow-up):** wire provider fallback into live import
+      path, resumable sync cursor logic, Solana/Bitcoin fallback
+      endpoints, vitest flakiness simulation tests. Delegated: Engineer.
 - [x] **Phase 5 — Periods, close, and lock**
       (GIV-684: accounting_periods table with open/closed lifecycle,
       DB trigger blocks posting into closed periods, list_periods/
@@ -1090,7 +1088,7 @@ WHERE status='approved'` (the M5 state machine explicitly allows
     TransactionRow, TokenTransfer, TokenTransferRow structs + all SQL),
     `api/persistence.rs` (ChainTransactionInput, ChainTransactionRow +
     save/get SQL), `api/accounting.rs` (MultiChainTx, MultiChainTransaction
-    + all SQL queries + test helper `insert_raw_tx`).
+    - all SQL queries + test helper `insert_raw_tx`).
   - **Error surfacing:** `insert_transactions` and `insert_token_transfers`
     in `db/multi_chain.rs`, `save_chain_transactions` and
     `save_transactions` in `api/persistence.rs` now propagate per-row

--- a/src-tauri/migrations/20260718000001_phase4a_descriptive_columns.sql
+++ b/src-tauri/migrations/20260718000001_phase4a_descriptive_columns.sql
@@ -1,0 +1,26 @@
+-- =============================================================================
+-- PHASE 4A: DESCRIPTIVE COLUMN NAMING (GIV-712)
+-- Renames developer-shorthand columns to human-readable names per
+-- Stage 1 mandate scope item 4.  All renames use ALTER TABLE ... RENAME
+-- COLUMN (supported since SQLite 3.25.0 / 2018-09-15).
+-- =============================================================================
+
+-- multi_chain_transactions: rename shorthand columns
+ALTER TABLE multi_chain_transactions RENAME COLUMN hash TO transaction_hash;
+ALTER TABLE multi_chain_transactions RENAME COLUMN tx_type TO transaction_type;
+ALTER TABLE multi_chain_transactions RENAME COLUMN value TO transfer_value;
+ALTER TABLE multi_chain_transactions RENAME COLUMN fee TO transaction_fee;
+ALTER TABLE multi_chain_transactions RENAME COLUMN raw_data TO raw_json_data;
+
+-- Add wallet_address for import-source provenance tracking.
+-- Existing rows get empty string; new imports populate this from the
+-- requesting wallet address so the same on-chain tx can appear in
+-- multiple wallet imports without duplication ambiguity.
+ALTER TABLE multi_chain_transactions ADD COLUMN wallet_address TEXT NOT NULL DEFAULT '';
+
+-- Create index on wallet_address for efficient per-wallet queries
+CREATE INDEX IF NOT EXISTS idx_mct_wallet_address
+    ON multi_chain_transactions(wallet_address);
+
+-- token_transfers: rename value to transfer_amount
+ALTER TABLE token_transfers RENAME COLUMN value TO transfer_amount;

--- a/src-tauri/src/api/accounting.rs
+++ b/src-tauri/src/api/accounting.rs
@@ -1238,7 +1238,7 @@ pub async fn auto_classify_transaction(
 ) -> Result<JournalEntryWithLines, String> {
     // Fetch the raw transaction
     let tx = sqlx::query_as::<_, MultiChainTx>(
-        "SELECT id, chain_id, hash, from_address, to_address, value, fee, timestamp, tx_type, status FROM multi_chain_transactions WHERE id = ? AND classification_status = 'unclassified'",
+        "SELECT id, chain_id, transaction_hash, from_address, to_address, transfer_value, transaction_fee, timestamp, transaction_type, status FROM multi_chain_transactions WHERE id = ? AND classification_status = 'unclassified'",
     )
     .bind(&transaction_id)
     .fetch_optional(&state.pool)
@@ -1257,22 +1257,22 @@ pub async fn auto_classify_transaction(
     // Rounding is explicit half-away-from-zero: Decimal::round() defaults to
     // banker's rounding (10000.5 -> 10000), which is not the money convention
     // used elsewhere in this codebase.
-    let amount_dec = Decimal::from_str(&tx.value)
-        .map_err(|e| format!("Cannot parse value '{}': {e}", tx.value))?;
+    let amount_dec = Decimal::from_str(&tx.transfer_value)
+        .map_err(|e| format!("Cannot parse value '{}': {e}", tx.transfer_value))?;
     let amount_minor: i64 = decimal_to_minor_units(amount_dec)
-        .ok_or_else(|| format!("Value out of range: {}", tx.value))?;
+        .ok_or_else(|| format!("Value out of range: {}", tx.transfer_value))?;
     let fee_dec = tx
-        .fee
+        .transaction_fee
         .as_deref()
         .unwrap_or("0")
         .parse::<Decimal>()
         .unwrap_or(Decimal::ZERO);
     let fee_minor: i64 =
-        decimal_to_minor_units(fee_dec).ok_or_else(|| format!("Fee out of range: {:?}", tx.fee))?;
+        decimal_to_minor_units(fee_dec).ok_or_else(|| format!("Fee out of range: {:?}", tx.transaction_fee))?;
 
-    // Build lines based on tx_type heuristics
+    // Build lines based on transaction_type heuristics
     let mut lines = Vec::new();
-    let description = match tx.tx_type.as_str() {
+    let description = match tx.transaction_type.as_str() {
         "claim" | "stake" => {
             // Staking reward: DR Crypto Assets / CR Staking Income
             if amount_minor > 0 {
@@ -1322,7 +1322,7 @@ pub async fn auto_classify_transaction(
             format!(
                 "Transfer on {} ({})",
                 tx.chain_id,
-                &tx.hash[..8.min(tx.hash.len())]
+                &tx.transaction_hash[..8.min(tx.transaction_hash.len())]
             )
         }
         _ => {
@@ -1349,9 +1349,9 @@ pub async fn auto_classify_transaction(
             }
             format!(
                 "{} on {} ({})",
-                tx.tx_type,
+                tx.transaction_type,
                 tx.chain_id,
-                &tx.hash[..8.min(tx.hash.len())]
+                &tx.transaction_hash[..8.min(tx.transaction_hash.len())]
             )
         }
     };
@@ -1386,7 +1386,7 @@ pub async fn auto_classify_transaction(
     let input = NewJournalEntryInput {
         entry_date,
         description,
-        reference_number: Some(tx.hash.clone()),
+        reference_number: Some(tx.transaction_hash.clone()),
         raw_transaction_id: Some(transaction_id),
         origin: Some("rule".to_string()),
         lines,
@@ -1404,7 +1404,7 @@ struct MultiChainTx {
     /// Blockchain identifier.
     chain_id: String,
     /// Transaction hash.
-    hash: String,
+    transaction_hash: String,
     /// Sender address.
     #[allow(dead_code)]
     from_address: String,
@@ -1412,13 +1412,13 @@ struct MultiChainTx {
     #[allow(dead_code)]
     to_address: Option<String>,
     /// Transaction value as string.
-    value: String,
+    transfer_value: String,
     /// Transaction fee as string.
-    fee: Option<String>,
+    transaction_fee: Option<String>,
     /// Unix timestamp.
     timestamp: i64,
     /// Transaction type classification.
-    tx_type: String,
+    transaction_type: String,
     /// Transaction status.
     #[allow(dead_code)]
     status: String,
@@ -1453,24 +1453,24 @@ async fn get_account_id_by_number(pool: &sqlx::SqlitePool, number: &str) -> Resu
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 #[serde(rename_all = "camelCase")]
 pub struct MultiChainTransaction {
-    /// Composite ID: chain_id + "_" + hash.
+    /// Composite ID: chain_id + "_" + transaction_hash.
     pub id: String,
     /// Blockchain identifier.
     pub chain_id: String,
     /// Transaction hash.
-    pub hash: String,
+    pub transaction_hash: String,
     /// Sender address.
     pub from_address: String,
     /// Recipient address.
     pub to_address: Option<String>,
     /// Transaction value as string (raw, never mutated — Inv-5).
-    pub value: String,
+    pub transfer_value: String,
     /// Transaction fee as string.
-    pub fee: Option<String>,
+    pub transaction_fee: Option<String>,
     /// Unix timestamp.
     pub timestamp: i64,
     /// Transaction type.
-    pub tx_type: String,
+    pub transaction_type: String,
     /// Transaction status (success/failed/pending).
     pub status: String,
     /// Classification status.
@@ -1483,7 +1483,7 @@ pub async fn get_unclassified_transactions(
     state: State<'_, DatabaseState>,
 ) -> Result<Vec<MultiChainTransaction>, String> {
     sqlx::query_as::<_, MultiChainTransaction>(
-        "SELECT id, chain_id, hash, from_address, to_address, value, fee, timestamp, tx_type, status, classification_status FROM multi_chain_transactions WHERE classification_status = 'unclassified' ORDER BY timestamp DESC",
+        "SELECT id, chain_id, transaction_hash, from_address, to_address, transfer_value, transaction_fee, timestamp, transaction_type, status, classification_status FROM multi_chain_transactions WHERE classification_status = 'unclassified' ORDER BY timestamp DESC",
     )
     .fetch_all(&state.pool)
     .await
@@ -3356,23 +3356,23 @@ mod tests {
         pool: &SqlitePool,
         id: &str,
         chain: &str,
-        hash: &str,
-        value: &str,
-        fee: Option<&str>,
-        tx_type: &str,
+        transaction_hash: &str,
+        transfer_value: &str,
+        transaction_fee: Option<&str>,
+        transaction_type: &str,
         timestamp: i64,
     ) {
         sqlx::query(
-            r#"INSERT INTO multi_chain_transactions (id, chain_id, hash, from_address, to_address, value, fee, timestamp, tx_type, status)
+            r#"INSERT INTO multi_chain_transactions (id, chain_id, transaction_hash, from_address, to_address, transfer_value, transaction_fee, timestamp, transaction_type, status)
                VALUES (?, ?, ?, '0xSender', '0xReceiver', ?, ?, ?, ?, 'success')"#,
         )
         .bind(id)
         .bind(chain)
-        .bind(hash)
-        .bind(value)
-        .bind(fee)
+        .bind(transaction_hash)
+        .bind(transfer_value)
+        .bind(transaction_fee)
         .bind(timestamp)
-        .bind(tx_type)
+        .bind(transaction_type)
         .execute(pool)
         .await
         .expect("Insert raw tx");
@@ -3684,17 +3684,17 @@ mod tests {
         .await
         .expect("Classify");
 
-        // Verify value and fee are untouched
-        let (value, fee): (String, Option<String>) =
-            sqlx::query_as("SELECT value, fee FROM multi_chain_transactions WHERE id = ?")
+        // Verify transfer_value and transaction_fee are untouched
+        let (transfer_value, transaction_fee): (String, Option<String>) =
+            sqlx::query_as("SELECT transfer_value, transaction_fee FROM multi_chain_transactions WHERE id = ?")
                 .bind(tx_id)
                 .fetch_one(&pool)
                 .await
                 .expect("Fetch raw tx");
 
-        assert_eq!(value, "25.50", "Raw value must be untouched (Inv-5)");
+        assert_eq!(transfer_value, "25.50", "Raw value must be untouched (Inv-5)");
         assert_eq!(
-            fee.as_deref(),
+            transaction_fee.as_deref(),
             Some("0.01"),
             "Raw fee must be untouched (Inv-5)"
         );

--- a/src-tauri/src/api/accounting.rs
+++ b/src-tauri/src/api/accounting.rs
@@ -1267,8 +1267,8 @@ pub async fn auto_classify_transaction(
         .unwrap_or("0")
         .parse::<Decimal>()
         .unwrap_or(Decimal::ZERO);
-    let fee_minor: i64 =
-        decimal_to_minor_units(fee_dec).ok_or_else(|| format!("Fee out of range: {:?}", tx.transaction_fee))?;
+    let fee_minor: i64 = decimal_to_minor_units(fee_dec)
+        .ok_or_else(|| format!("Fee out of range: {:?}", tx.transaction_fee))?;
 
     // Build lines based on transaction_type heuristics
     let mut lines = Vec::new();
@@ -3685,14 +3685,18 @@ mod tests {
         .expect("Classify");
 
         // Verify transfer_value and transaction_fee are untouched
-        let (transfer_value, transaction_fee): (String, Option<String>) =
-            sqlx::query_as("SELECT transfer_value, transaction_fee FROM multi_chain_transactions WHERE id = ?")
-                .bind(tx_id)
-                .fetch_one(&pool)
-                .await
-                .expect("Fetch raw tx");
+        let (transfer_value, transaction_fee): (String, Option<String>) = sqlx::query_as(
+            "SELECT transfer_value, transaction_fee FROM multi_chain_transactions WHERE id = ?",
+        )
+        .bind(tx_id)
+        .fetch_one(&pool)
+        .await
+        .expect("Fetch raw tx");
 
-        assert_eq!(transfer_value, "25.50", "Raw value must be untouched (Inv-5)");
+        assert_eq!(
+            transfer_value, "25.50",
+            "Raw value must be untouched (Inv-5)"
+        );
         assert_eq!(
             transaction_fee.as_deref(),
             Some("0.01"),

--- a/src-tauri/src/api/persistence.rs
+++ b/src-tauri/src/api/persistence.rs
@@ -353,7 +353,7 @@ pub async fn save_transactions(
             .and_then(|t| DateTime::parse_from_rfc3339(t).ok())
             .map(|t| t.with_timezone(&Utc));
 
-        let result = sqlx::query(
+        sqlx::query(
             r#"
             INSERT INTO transactions (
                 id, wallet_id, hash, block_number, timestamp, from_address, to_address,
@@ -387,11 +387,10 @@ pub async fn save_transactions(
         .bind(now)
         .bind(&tx.price_at_acquisition_usd)
         .execute(&state.pool)
-        .await;
+        .await
+        .map_err(|e| e.to_string())?;
 
-        if result.is_ok() {
-            saved_count += 1;
-        }
+        saved_count += 1;
     }
 
     Ok(saved_count)
@@ -551,21 +550,21 @@ pub async fn get_all_settings(
 // ============================================================================
 
 /// Input for chain-level transaction saving. The frontend serializes the full
-/// Transaction object into raw_data so it can be reconstructed on read.
+/// Transaction object into raw_json_data so it can be reconstructed on read.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ChainTransactionInput {
     #[allow(dead_code)]
     pub id: String,
-    pub hash: String,
+    pub transaction_hash: String,
     pub block_number: Option<i64>,
     pub timestamp: i64,
     pub from_address: String,
     pub to_address: Option<String>,
-    pub value: String,
-    pub fee: Option<String>,
+    pub transfer_value: String,
+    pub transaction_fee: Option<String>,
     pub status: String,
-    pub tx_type: String,
-    pub raw_data: String,
+    pub transaction_type: String,
+    pub raw_json_data: String,
 }
 
 /// Row type for reading chain transactions back.
@@ -573,16 +572,16 @@ pub struct ChainTransactionInput {
 pub struct ChainTransactionRow {
     pub id: String,
     pub chain_id: String,
-    pub hash: String,
+    pub transaction_hash: String,
     pub from_address: String,
     pub to_address: Option<String>,
-    pub value: String,
-    pub fee: Option<String>,
+    pub transfer_value: String,
+    pub transaction_fee: Option<String>,
     pub timestamp: i64,
     pub block_number: Option<i64>,
-    pub tx_type: String,
+    pub transaction_type: String,
     pub status: String,
-    pub raw_data: Option<String>,
+    pub raw_json_data: Option<String>,
 }
 
 /// Row type for sync status.
@@ -596,7 +595,10 @@ pub struct ChainSyncStatusRow {
 }
 
 /// Saves chain transactions into multi_chain_transactions with upsert semantics.
-/// The full frontend Transaction object is preserved in raw_data for lossless round-trips.
+/// The full frontend Transaction object is preserved in raw_json_data for lossless round-trips.
+///
+/// Propagates per-row errors instead of silently swallowing them — callers
+/// must know when a wallet's history is incomplete.
 #[tauri::command]
 pub async fn save_chain_transactions(
     state: State<'_, DatabaseState>,
@@ -604,49 +606,48 @@ pub async fn save_chain_transactions(
     address: String,
     transactions: Vec<ChainTransactionInput>,
 ) -> Result<usize, String> {
-    let _ = &address; // address captured for context; chain_id from network
     let mut saved = 0;
 
     for tx in &transactions {
-        let composite_id = format!("{}_{}", network, tx.hash);
+        let composite_id = format!("{}_{}", network, tx.transaction_hash);
 
-        let result = sqlx::query(
+        sqlx::query(
             r#"
             INSERT INTO multi_chain_transactions (
-                id, chain_id, hash, from_address, to_address,
-                value, fee, timestamp, block_number, tx_type,
-                status, raw_data
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(chain_id, hash) DO UPDATE SET
+                id, chain_id, transaction_hash, from_address, to_address,
+                transfer_value, transaction_fee, timestamp, block_number,
+                transaction_type, status, raw_json_data, wallet_address
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(chain_id, transaction_hash) DO UPDATE SET
                 from_address = excluded.from_address,
                 to_address = excluded.to_address,
-                value = excluded.value,
-                fee = excluded.fee,
+                transfer_value = excluded.transfer_value,
+                transaction_fee = excluded.transaction_fee,
                 timestamp = excluded.timestamp,
                 block_number = excluded.block_number,
-                tx_type = excluded.tx_type,
+                transaction_type = excluded.transaction_type,
                 status = excluded.status,
-                raw_data = excluded.raw_data
+                raw_json_data = excluded.raw_json_data
             "#,
         )
         .bind(&composite_id)
         .bind(&network)
-        .bind(&tx.hash)
+        .bind(&tx.transaction_hash)
         .bind(&tx.from_address)
         .bind(&tx.to_address)
-        .bind(&tx.value)
-        .bind(&tx.fee)
+        .bind(&tx.transfer_value)
+        .bind(&tx.transaction_fee)
         .bind(tx.timestamp)
         .bind(tx.block_number)
-        .bind(&tx.tx_type)
+        .bind(&tx.transaction_type)
         .bind(&tx.status)
-        .bind(&tx.raw_data)
+        .bind(&tx.raw_json_data)
+        .bind(&address)
         .execute(&state.pool)
-        .await;
+        .await
+        .map_err(|e| e.to_string())?;
 
-        if result.is_ok() {
-            saved += 1;
-        }
+        saved += 1;
     }
 
     Ok(saved)
@@ -662,8 +663,9 @@ pub async fn get_chain_transactions(
 ) -> Result<Vec<ChainTransactionRow>, String> {
     let rows = sqlx::query_as::<_, ChainTransactionRow>(
         r#"
-        SELECT id, chain_id, hash, from_address, to_address, value, fee,
-               timestamp, block_number, tx_type, status, raw_data
+        SELECT id, chain_id, transaction_hash, from_address, to_address,
+               transfer_value, transaction_fee, timestamp, block_number,
+               transaction_type, status, raw_json_data
         FROM multi_chain_transactions
         WHERE chain_id = ?
         AND (from_address = ? OR to_address = ?

--- a/src-tauri/src/db/multi_chain.rs
+++ b/src-tauri/src/db/multi_chain.rs
@@ -197,30 +197,32 @@ impl WalletType {
 /// Multi-chain transaction record.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Transaction {
-    /// Composite ID: chain_id + "_" + hash
+    /// Composite ID: chain_id + "_" + transaction_hash
     pub id: String,
     /// Chain identifier (e.g., "ethereum", "polygon", "1", "137")
     pub chain_id: String,
     /// Transaction hash
-    pub hash: String,
+    pub transaction_hash: String,
     /// Sender address
     pub from_address: String,
     /// Recipient address (None for contract creation)
     pub to_address: Option<String>,
     /// Transaction value in native units (string for precision)
-    pub value: String,
+    pub transfer_value: String,
     /// Transaction fee in native units
-    pub fee: Option<String>,
+    pub transaction_fee: Option<String>,
     /// Unix timestamp
     pub timestamp: i64,
     /// Block number
     pub block_number: Option<i64>,
     /// Transaction type classification
-    pub tx_type: TxType,
+    pub transaction_type: TxType,
     /// Transaction status
     pub status: TxStatus,
     /// Raw transaction data as JSON
-    pub raw_data: Option<String>,
+    pub raw_json_data: Option<String>,
+    /// Wallet address that imported this transaction
+    pub wallet_address: String,
     /// Record creation timestamp
     pub created_at: Option<i64>,
     /// Record update timestamp
@@ -232,31 +234,33 @@ impl Transaction {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         chain_id: String,
-        hash: String,
+        transaction_hash: String,
         from_address: String,
         to_address: Option<String>,
-        value: String,
-        fee: Option<String>,
+        transfer_value: String,
+        transaction_fee: Option<String>,
         timestamp: i64,
         block_number: Option<i64>,
-        tx_type: TxType,
+        transaction_type: TxType,
         status: TxStatus,
-        raw_data: Option<String>,
+        raw_json_data: Option<String>,
+        wallet_address: String,
     ) -> Self {
-        let id = format!("{}_{}", chain_id, hash);
+        let id = format!("{}_{}", chain_id, transaction_hash);
         Self {
             id,
             chain_id,
-            hash,
+            transaction_hash,
             from_address,
             to_address,
-            value,
-            fee,
+            transfer_value,
+            transaction_fee,
             timestamp,
             block_number,
-            tx_type,
+            transaction_type,
             status,
-            raw_data,
+            raw_json_data,
+            wallet_address,
             created_at: None,
             updated_at: None,
         }
@@ -268,16 +272,17 @@ impl Transaction {
 struct TransactionRow {
     id: String,
     chain_id: String,
-    hash: String,
+    transaction_hash: String,
     from_address: String,
     to_address: Option<String>,
-    value: String,
-    fee: Option<String>,
+    transfer_value: String,
+    transaction_fee: Option<String>,
     timestamp: i64,
     block_number: Option<i64>,
-    tx_type: String,
+    transaction_type: String,
     status: String,
-    raw_data: Option<String>,
+    raw_json_data: Option<String>,
+    wallet_address: String,
     created_at: Option<i64>,
     updated_at: Option<i64>,
 }
@@ -287,16 +292,17 @@ impl From<TransactionRow> for Transaction {
         Transaction {
             id: row.id,
             chain_id: row.chain_id,
-            hash: row.hash,
+            transaction_hash: row.transaction_hash,
             from_address: row.from_address,
             to_address: row.to_address,
-            value: row.value,
-            fee: row.fee,
+            transfer_value: row.transfer_value,
+            transaction_fee: row.transaction_fee,
             timestamp: row.timestamp,
             block_number: row.block_number,
-            tx_type: TxType::from_str(&row.tx_type),
+            transaction_type: TxType::from_str(&row.transaction_type),
             status: TxStatus::from_str(&row.status),
-            raw_data: row.raw_data,
+            raw_json_data: row.raw_json_data,
+            wallet_address: row.wallet_address,
             created_at: row.created_at,
             updated_at: row.updated_at,
         }
@@ -322,8 +328,8 @@ pub struct TokenTransfer {
     pub from_address: String,
     /// Recipient address
     pub to_address: String,
-    /// Transfer value (string for precision)
-    pub value: String,
+    /// Transfer amount (string for precision)
+    pub transfer_amount: String,
     /// Log index in transaction
     pub log_index: Option<i32>,
     /// Token type/standard
@@ -345,7 +351,7 @@ struct TokenTransferRow {
     token_decimals: Option<i32>,
     from_address: String,
     to_address: String,
-    value: String,
+    transfer_amount: String,
     log_index: Option<i32>,
     token_type: Option<String>,
     token_id: Option<String>,
@@ -363,7 +369,7 @@ impl From<TokenTransferRow> for TokenTransfer {
             token_decimals: row.token_decimals,
             from_address: row.from_address,
             to_address: row.to_address,
-            value: row.value,
+            transfer_amount: row.transfer_amount,
             log_index: row.log_index,
             token_type: row.token_type.map(|s| TokenType::from_str(&s)),
             token_id: row.token_id,
@@ -469,48 +475,49 @@ impl MultiChainRepository {
 
     /// Inserts multiple transactions with upsert semantics.
     ///
-    /// Returns the number of successfully inserted/updated transactions.
+    /// Returns the number of inserted/updated transactions. Propagates the
+    /// first per-row error instead of silently swallowing failures — callers
+    /// must know when a wallet's history is incomplete.
     pub async fn insert_transactions(&self, txs: &[Transaction]) -> Result<usize, sqlx::Error> {
         let mut count = 0;
 
         for tx in txs {
-            let result = sqlx::query(
+            sqlx::query(
                 r#"
                 INSERT INTO multi_chain_transactions (
-                    id, chain_id, hash, from_address, to_address,
-                    value, fee, timestamp, block_number, tx_type,
-                    status, raw_data
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(chain_id, hash) DO UPDATE SET
+                    id, chain_id, transaction_hash, from_address, to_address,
+                    transfer_value, transaction_fee, timestamp, block_number,
+                    transaction_type, status, raw_json_data, wallet_address
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(chain_id, transaction_hash) DO UPDATE SET
                     from_address = excluded.from_address,
                     to_address = excluded.to_address,
-                    value = excluded.value,
-                    fee = excluded.fee,
+                    transfer_value = excluded.transfer_value,
+                    transaction_fee = excluded.transaction_fee,
                     timestamp = excluded.timestamp,
                     block_number = excluded.block_number,
-                    tx_type = excluded.tx_type,
+                    transaction_type = excluded.transaction_type,
                     status = excluded.status,
-                    raw_data = excluded.raw_data
+                    raw_json_data = excluded.raw_json_data
                 "#,
             )
             .bind(&tx.id)
             .bind(&tx.chain_id)
-            .bind(&tx.hash)
+            .bind(&tx.transaction_hash)
             .bind(&tx.from_address)
             .bind(&tx.to_address)
-            .bind(&tx.value)
-            .bind(&tx.fee)
+            .bind(&tx.transfer_value)
+            .bind(&tx.transaction_fee)
             .bind(tx.timestamp)
             .bind(tx.block_number)
-            .bind(tx.tx_type.as_str())
+            .bind(tx.transaction_type.as_str())
             .bind(tx.status.as_str())
-            .bind(&tx.raw_data)
+            .bind(&tx.raw_json_data)
+            .bind(&tx.wallet_address)
             .execute(&self.pool)
-            .await;
+            .await?;
 
-            if result.is_ok() {
-                count += 1;
-            }
+            count += 1;
         }
 
         Ok(count)
@@ -617,12 +624,12 @@ impl MultiChainRepository {
     /// Retrieves transactions by hash across all chains.
     pub async fn get_transactions_by_hash(
         &self,
-        hash: &str,
+        transaction_hash: &str,
     ) -> Result<Vec<Transaction>, sqlx::Error> {
         let rows = sqlx::query_as::<_, TransactionRow>(
-            "SELECT * FROM multi_chain_transactions WHERE hash = ? ORDER BY chain_id",
+            "SELECT * FROM multi_chain_transactions WHERE transaction_hash = ? ORDER BY chain_id",
         )
-        .bind(hash)
+        .bind(transaction_hash)
         .fetch_all(&self.pool)
         .await?;
 
@@ -658,6 +665,8 @@ impl MultiChainRepository {
     // =========================================================================
 
     /// Inserts token transfers for a transaction.
+    ///
+    /// Propagates per-row errors instead of silently swallowing them.
     pub async fn insert_token_transfers(
         &self,
         transfers: &[TokenTransfer],
@@ -665,11 +674,11 @@ impl MultiChainRepository {
         let mut count = 0;
 
         for transfer in transfers {
-            let result = sqlx::query(
+            sqlx::query(
                 r#"
                 INSERT INTO token_transfers (
                     transaction_id, contract_address, token_symbol, token_name,
-                    token_decimals, from_address, to_address, value,
+                    token_decimals, from_address, to_address, transfer_amount,
                     log_index, token_type, token_id
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 "#,
@@ -681,16 +690,14 @@ impl MultiChainRepository {
             .bind(transfer.token_decimals)
             .bind(&transfer.from_address)
             .bind(&transfer.to_address)
-            .bind(&transfer.value)
+            .bind(&transfer.transfer_amount)
             .bind(transfer.log_index)
             .bind(transfer.token_type.as_ref().map(|t| t.as_str()))
             .bind(&transfer.token_id)
             .execute(&self.pool)
-            .await;
+            .await?;
 
-            if result.is_ok() {
-                count += 1;
-            }
+            count += 1;
         }
 
         Ok(count)
@@ -982,6 +989,7 @@ mod tests {
             TxType::Transfer,
             TxStatus::Success,
             None,
+            "0xwallet".to_string(),
         );
 
         assert_eq!(tx.id, "ethereum_0x123");

--- a/src/app/classification/ClassificationQueue.tsx
+++ b/src/app/classification/ClassificationQueue.tsx
@@ -58,18 +58,18 @@ const QueueRow: React.FC<QueueRowProps> = ({
       {tx.chainId}
     </td>
     <td className="px-4 py-3 whitespace-nowrap text-sm font-mono text-[#294050] dark:text-[#9FB4BE]">
-      <span title={tx.hash}>{truncateHash(tx.hash)}</span>
+      <span title={tx.transactionHash}>{truncateHash(tx.transactionHash)}</span>
     </td>
     <td className="px-4 py-3 whitespace-nowrap">
       <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-[#294050]/10 text-[#294050] dark:bg-[#294050]/20 dark:text-[#9FB4BE]">
-        {displayTxType(tx.txType)}
+        {displayTxType(tx.transactionType)}
       </span>
     </td>
     <td className="px-4 py-3 whitespace-nowrap text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
-      {tx.value}
+      {tx.transferValue}
     </td>
     <td className="px-4 py-3 whitespace-nowrap text-sm text-right font-mono text-[#647D8B]">
-      {tx.fee ?? '—'}
+      {tx.transactionFee ?? '—'}
     </td>
     <td className="px-4 py-3 whitespace-nowrap text-sm text-[#294050] dark:text-[#9FB4BE]">
       {formatTimestampFull(tx.timestamp)}
@@ -214,9 +214,9 @@ const ClassificationQueue: React.FC = () => {
     const needle = searchQuery.toLowerCase()
     return transactions.filter(
       tx =>
-        tx.hash.toLowerCase().includes(needle) ||
+        tx.transactionHash.toLowerCase().includes(needle) ||
         tx.chainId.toLowerCase().includes(needle) ||
-        tx.txType.toLowerCase().includes(needle) ||
+        tx.transactionType.toLowerCase().includes(needle) ||
         tx.fromAddress.toLowerCase().includes(needle) ||
         (tx.toAddress?.toLowerCase().includes(needle) ?? false)
     )
@@ -259,7 +259,7 @@ const ClassificationQueue: React.FC = () => {
       if (!txId) return
       const tx = transactions.find(t => t.id === txId)
       if (tx) {
-        setIgnoreModal({ transactionId: tx.id, hash: tx.hash })
+        setIgnoreModal({ transactionId: tx.id, hash: tx.transactionHash })
         setIgnoreReason('')
       }
     },
@@ -432,9 +432,9 @@ const ClassificationQueue: React.FC = () => {
       {drawerTx !== null && (
         <JournalEntryDrawer
           accounts={accounts}
-          transactionRef={drawerTx.hash}
+          transactionRef={drawerTx.transactionHash}
           rawTransactionId={drawerTx.id}
-          initialDescription={`${displayTxType(drawerTx.txType)} on ${drawerTx.chainId} (${truncateHash(drawerTx.hash)})`}
+          initialDescription={`${displayTxType(drawerTx.transactionType)} on ${drawerTx.chainId} (${truncateHash(drawerTx.transactionHash)})`}
           onClose={handleDrawerClose}
           onSaved={handleDrawerSaved}
         />

--- a/src/services/persistence/tauriPersistence.ts
+++ b/src/services/persistence/tauriPersistence.ts
@@ -250,12 +250,11 @@ export const tauriPersistence: PersistenceService = {
     transactions: Transaction[]
   ): Promise<void> => {
     if (USE_PERSISTENCE_TX_PATH) {
-      // Serialize each transaction to JSON for SQLite raw_data storage.
-      // price_at_acquisition_usd is stored as a first-class column so the
-      // COALESCE upsert logic can preserve manually-entered prices on re-sync.
+      // Serialize each transaction to JSON for SQLite raw_json_data storage.
+      // Column names match the Phase 4a descriptive naming convention.
       const serialized = transactions.map(tx => ({
         id: tx.id,
-        hash: tx.hash,
+        transaction_hash: tx.hash,
         block_number: tx.blockNumber,
         timestamp:
           tx.timestamp instanceof Date
@@ -263,11 +262,11 @@ export const tauriPersistence: PersistenceService = {
             : 0,
         from_address: tx.from,
         to_address: tx.to,
-        value: tx.value,
-        fee: tx.fee,
+        transfer_value: tx.value,
+        transaction_fee: tx.fee,
         status: tx.status,
-        tx_type: tx.type,
-        raw_data: JSON.stringify(tx),
+        transaction_type: tx.type,
+        raw_json_data: JSON.stringify(tx),
         price_at_acquisition_usd:
           tx.pricePerUnitUsd != null ? tx.pricePerUnitUsd.toString() : null,
       }))
@@ -286,7 +285,7 @@ export const tauriPersistence: PersistenceService = {
     address: string
   ): Promise<Transaction[]> => {
     if (USE_PERSISTENCE_TX_PATH) {
-      const rows = await invoke<Array<{ raw_data: string }>>(
+      const rows = await invoke<Array<{ raw_json_data: string }>>(
         'get_chain_transactions',
         {
           network,
@@ -294,7 +293,7 @@ export const tauriPersistence: PersistenceService = {
         }
       )
       return rows.map(row => {
-        const tx = JSON.parse(row.raw_data) as Transaction
+        const tx = JSON.parse(row.raw_json_data) as Transaction
         // Restore Date object from serialized string
         if (typeof tx.timestamp === 'string') {
           tx.timestamp = new Date(tx.timestamp)

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -302,13 +302,13 @@ export type ClassificationStatus =
 export interface RawTransaction {
   id: string
   chainId: string
-  hash: string
+  transactionHash: string
   fromAddress: string
   toAddress: string | null
-  value: string
-  fee: string | null
+  transferValue: string
+  transactionFee: string | null
   timestamp: number
-  txType: string
+  transactionType: string
   status: string
   classificationStatus: ClassificationStatus
 }


### PR DESCRIPTION
## Summary

Phase 4a Part 1 of the Stage 1 mandate (GIV-712). Rebased onto current main (`8c73359`, post Phases 4-10 + Gate 1 rehearsal + Moonscan fixes).

- **Descriptive column migration** (`20260718000001`): renames `hash→transaction_hash`, `tx_type→transaction_type`, `value→transfer_value`, `fee→transaction_fee`, `raw_data→raw_json_data`, `token_transfers.value→transfer_amount`; adds `wallet_address` column with index
- **All Rust readers updated**: `db/multi_chain.rs`, `api/persistence.rs`, `api/accounting.rs` — struct fields, SQL queries, test helpers
- **Error surfacing**: `insert_transactions`, `insert_token_transfers`, `save_chain_transactions`, `save_transactions` now propagate per-row errors via `?` instead of silently swallowing — eliminates the "silently incomplete history" failure class
- **All TS consumers updated**: `tauriPersistence.ts` serialization mapping, `database.ts` `RawTransaction` interface, `ClassificationQueue.tsx` field references
- **Idempotency documented**: existing `UNIQUE(chain_id, transaction_hash)` constraint predates this PR (20260118000001 migration) — documented in tracker, not claimed as new
- **Docs**: `docs/stage1-progress.md` updated with Part 1/Part 2 split (Session 20)

## Changes from previous submission (PR #234 v1)

Per CTO review feedback:
1. ✅ **Rebased onto current main** — clean stack off `8c73359` (was stale off `60d0d09`)
2. ✅ **Removed dead `provider_fallback.rs`** — deferred to Part 2 where it will be wired into the live import path
3. ✅ **Fixed error swallowing** — `insert_transactions` and all other batch insert functions now propagate errors
4. ✅ **Scope gap acknowledged** — Part 2 follow-up covers: provider fallback wiring, sync cursor resume, vitest flakiness tests
5. ✅ **UNIQUE constraint claim corrected** — documented as pre-existing, not claimed as new

## Test results

`cargo test --lib`: **315 passed, 0 failed**, 6 ignored (matches current main baseline exactly)

## Part 2 scope (follow-up PR)

- Wire `provider_fallback` module into live `ChainManager` import path
- Resume sync from `address_sync_status.last_block_synced`
- Solana/Bitcoin fallback endpoints
- Vitest flakiness simulation tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)