### PR TITLE
feat(chains): converge BTC/SOL commands onto resilient pipeline (GIV-713)

### DIFF
--- a/docs/stage1-progress.md
+++ b/docs/stage1-progress.md
@@ -35,37 +35,33 @@ class behind rehearsal findings #1/#2/#3.**
 - [ ] **Phase 4a — Import resilience and canonical store** (added by board
       amendment to the Stage 1 mandate, 2026-07-18; formalizes "Option B"
       from the rehearsal findings #1-#3 options analysis). Split into three
-      parts per CTO review:
-      - **Part 1 (MERGED, PR #234):** descriptive column renames
-        (`hash→transaction_hash`, `value→transfer_value`, etc.), all
-        Rust/TS readers updated, error surfacing in `insert_transactions`
-        (no more silent swallowing), `wallet_address` provenance column,
-        docs updated with Part 1/Part 2 split. Delegated: Engineer.
-      - **Part 2 (MERGED, PR #235, squash `525c3d2`):** provider fallback
-        registry with health tracking and ordered fallback, resumable sync
-        cursors via `chain_fetch_transactions_resumable`, persist-before-cursor
-        (cursor never advances past unpersisted transactions), graceful
-        `ProviderUnavailable` error surfacing, TS resilient sync wrapper,
-        vitest flakiness simulation (19 tests), CHECK-safe enum mapping,
-        4 DB integration tests. CTO hardening: 3 gaps fixed. Delegated:
-        Engineer + CTO review.
-      - **Part 3 (MERGED, PR #236):** `execute_with_fallback` wired into the
-        live `ChainManager::get_transactions` path for Bitcoin (Mempool→
-        Blockstream Esplora fallback) and Solana (primary RPC→Helius→
-        public fallback). Substrate registry infrastructure with community
-        fallback RPC (Polkadot→Dwellir, Kusama→Dwellir). EVM keeps
-        single-attempt with graceful wrapping (Alchemy `alchemy_getAssetTransfers`
-        needs separate API). `resilientSyncService` wired into
-        `useEVMService.syncTransactions` UI flow. CTO hardening: registry
-        alias mismatch + RwLock deadlock fix, substrate placeholder claim
-        fix, Helius key preservation fix. Delegated: Engineer.
-      - **Part 4 (PR in review, GIV-713):** path convergence — routed the
-        direct `get_bitcoin_transactions` and `get_solana_transactions`
-        Tauri commands through `ChainManager::get_transactions` so they
-        inherit provider fallback + health tracking instead of constructing
-        bare adapters. TS wrappers updated to unified `ChainTransaction`
-        shape. Moonscan hybrid path preserved (Gate-1 rehearsal). Delegated:
-        Engineer.
+      parts per CTO review: - **Part 1 (MERGED, PR #234):** descriptive column renames
+      (`hash→transaction_hash`, `value→transfer_value`, etc.), all
+      Rust/TS readers updated, error surfacing in `insert_transactions`
+      (no more silent swallowing), `wallet_address` provenance column,
+      docs updated with Part 1/Part 2 split. Delegated: Engineer. - **Part 2 (MERGED, PR #235, squash `525c3d2`):** provider fallback
+      registry with health tracking and ordered fallback, resumable sync
+      cursors via `chain_fetch_transactions_resumable`, persist-before-cursor
+      (cursor never advances past unpersisted transactions), graceful
+      `ProviderUnavailable` error surfacing, TS resilient sync wrapper,
+      vitest flakiness simulation (19 tests), CHECK-safe enum mapping,
+      4 DB integration tests. CTO hardening: 3 gaps fixed. Delegated:
+      Engineer + CTO review. - **Part 3 (MERGED, PR #236):** `execute_with_fallback` wired into the
+      live `ChainManager::get_transactions` path for Bitcoin (Mempool→
+      Blockstream Esplora fallback) and Solana (primary RPC→Helius→
+      public fallback). Substrate registry infrastructure with community
+      fallback RPC (Polkadot→Dwellir, Kusama→Dwellir). EVM keeps
+      single-attempt with graceful wrapping (Alchemy `alchemy_getAssetTransfers`
+      needs separate API). `resilientSyncService` wired into
+      `useEVMService.syncTransactions` UI flow. CTO hardening: registry
+      alias mismatch + RwLock deadlock fix, substrate placeholder claim
+      fix, Helius key preservation fix. Delegated: Engineer. - **Part 4 (PR in review, GIV-713):** path convergence — routed the
+      direct `get_bitcoin_transactions` and `get_solana_transactions`
+      Tauri commands through `ChainManager::get_transactions` so they
+      inherit provider fallback + health tracking instead of constructing
+      bare adapters. TS wrappers updated to unified `ChainTransaction`
+      shape. Moonscan hybrid path preserved (Gate-1 rehearsal). Delegated:
+      Engineer.
 - [x] **Phase 5 — Periods, close, and lock**
       (GIV-684: accounting_periods table with open/closed lifecycle,
       DB trigger blocks posting into closed periods, list_periods/

--- a/docs/stage1-progress.md
+++ b/docs/stage1-progress.md
@@ -35,25 +35,37 @@ class behind rehearsal findings #1/#2/#3.**
 - [ ] **Phase 4a — Import resilience and canonical store** (added by board
       amendment to the Stage 1 mandate, 2026-07-18; formalizes "Option B"
       from the rehearsal findings #1-#3 options analysis). Split into three
-      parts per CTO review: - **Part 1 (MERGED, PR #234):** descriptive column renames
-      (`hash→transaction_hash`, `value→transfer_value`, etc.), all
-      Rust/TS readers updated, error surfacing in `insert_transactions`
-      (no more silent swallowing), `wallet_address` provenance column,
-      docs updated with Part 1/Part 2 split. Delegated: Engineer. - **Part 2 (MERGED, PR #235, squash `525c3d2`):** provider fallback
-      registry with health tracking and ordered fallback, resumable sync
-      cursors via `chain_fetch_transactions_resumable`, persist-before-cursor
-      (cursor never advances past unpersisted transactions), graceful
-      `ProviderUnavailable` error surfacing, TS resilient sync wrapper,
-      vitest flakiness simulation (19 tests), CHECK-safe enum mapping,
-      4 DB integration tests. CTO hardening: 3 gaps fixed. Delegated:
-      Engineer + CTO review. - **Part 3 (PR in review):** `execute_with_fallback` wired into the
-      live `ChainManager::get_transactions` path for Bitcoin (Mempool→
-      Blockstream Esplora fallback) and Solana (primary RPC→Helius→
-      public fallback). Substrate registry infrastructure with community
-      fallback RPC (Polkadot→Dwellir, Kusama→Dwellir). EVM keeps
-      single-attempt with graceful wrapping (Alchemy `alchemy_getAssetTransfers`
-      needs separate API). `resilientSyncService` wired into
-      `useEVMService.syncTransactions` UI flow. Delegated: Engineer.
+      parts per CTO review:
+      - **Part 1 (MERGED, PR #234):** descriptive column renames
+        (`hash→transaction_hash`, `value→transfer_value`, etc.), all
+        Rust/TS readers updated, error surfacing in `insert_transactions`
+        (no more silent swallowing), `wallet_address` provenance column,
+        docs updated with Part 1/Part 2 split. Delegated: Engineer.
+      - **Part 2 (MERGED, PR #235, squash `525c3d2`):** provider fallback
+        registry with health tracking and ordered fallback, resumable sync
+        cursors via `chain_fetch_transactions_resumable`, persist-before-cursor
+        (cursor never advances past unpersisted transactions), graceful
+        `ProviderUnavailable` error surfacing, TS resilient sync wrapper,
+        vitest flakiness simulation (19 tests), CHECK-safe enum mapping,
+        4 DB integration tests. CTO hardening: 3 gaps fixed. Delegated:
+        Engineer + CTO review.
+      - **Part 3 (MERGED, PR #236):** `execute_with_fallback` wired into the
+        live `ChainManager::get_transactions` path for Bitcoin (Mempool→
+        Blockstream Esplora fallback) and Solana (primary RPC→Helius→
+        public fallback). Substrate registry infrastructure with community
+        fallback RPC (Polkadot→Dwellir, Kusama→Dwellir). EVM keeps
+        single-attempt with graceful wrapping (Alchemy `alchemy_getAssetTransfers`
+        needs separate API). `resilientSyncService` wired into
+        `useEVMService.syncTransactions` UI flow. CTO hardening: registry
+        alias mismatch + RwLock deadlock fix, substrate placeholder claim
+        fix, Helius key preservation fix. Delegated: Engineer.
+      - **Part 4 (PR in review, GIV-713):** path convergence — routed the
+        direct `get_bitcoin_transactions` and `get_solana_transactions`
+        Tauri commands through `ChainManager::get_transactions` so they
+        inherit provider fallback + health tracking instead of constructing
+        bare adapters. TS wrappers updated to unified `ChainTransaction`
+        shape. Moonscan hybrid path preserved (Gate-1 rehearsal). Delegated:
+        Engineer.
 - [x] **Phase 5 — Periods, close, and lock**
       (GIV-684: accounting_periods table with open/closed lifecycle,
       DB trigger blocks posting into closed periods, list_periods/
@@ -1272,3 +1284,27 @@ WHERE status='approved'` (the M5 state machine explicitly allows
     `chain_fetch_transactions_resumable` is follow-up work (relates to
     the pre-existing GIV-467 path-convergence scope) — tracked as a
     Phase 4a follow-up issue.
+- **Session 25 (2026-07-18, Engineer — Phase 4a Part 4 / GIV-713
+  path convergence):**
+  - **Converged `get_bitcoin_transactions` and `get_solana_transactions`
+    Tauri commands onto the resilient `ChainManager::get_transactions`
+    pipeline.** Both commands previously constructed bare adapters
+    (no fallback, no health tracking, no resumable cursors). Now they
+    accept `State<ChainManagerState>` and delegate to
+    `manager.get_transactions()`, inheriting:
+    - Bitcoin: Mempool.space → Blockstream Esplora fallback
+    - Solana: primary RPC → Helius → public endpoint fallback
+    - Per-endpoint health tracking + 60 s cooldown for Unavailable
+    - Graceful `ProviderUnavailable` wrapping (no raw API errors)
+  - **Return type converged** from chain-specific types
+    (`BitcoinTransaction`, `SolanaTransaction`) to the unified
+    `ChainTransaction` shape, matching the canonical store schema.
+    TS wrappers updated accordingly (both were orphaned — no live
+    UI consumers broken).
+  - **Unused import cleanup:** removed `SolanaTransaction` from the
+    Rust `commands.rs` import list (no longer referenced after
+    convergence).
+  - **Moonscan hybrid path preserved.** The TS
+    `polkadotService.fetchTransactionHistoryHybrid` → `moonscanService`
+    path for Moonbeam/Moonriver EVM addresses is untouched (Gate-1
+    rehearsal path — do NOT regress).

--- a/src-tauri/src/chains/commands.rs
+++ b/src-tauri/src/chains/commands.rs
@@ -445,21 +445,23 @@ use super::bitcoin::{
 
 /// Get Bitcoin transactions for an address
 ///
+/// Routes through `ChainManager::get_transactions` so the call inherits
+/// provider-fallback (Mempool.space → Blockstream), health tracking, and
+/// the unified `ChainTransaction` response shape.
+///
 /// # Arguments
 /// * `address` - Bitcoin address (legacy, SegWit, or Taproot)
 /// * `network` - Network name ("bitcoin", "testnet", "signet")
-/// * `max_pages` - Maximum pages to fetch (25 txs per page)
 #[tauri::command]
 pub async fn get_bitcoin_transactions(
+    state: State<'_, ChainManagerState>,
     address: String,
     network: Option<String>,
-    max_pages: Option<usize>,
-) -> Result<Vec<BitcoinTransaction>, String> {
+) -> Result<Vec<ChainTransaction>, String> {
     let network_name = network.as_deref().unwrap_or("bitcoin");
-    let adapter = BitcoinAdapter::from_network(network_name).map_err(|e| e.to_string())?;
-
-    adapter
-        .fetch_transactions(&address, max_pages)
+    let manager = state.read().await;
+    manager
+        .get_transactions(network_name, &address, None)
         .await
         .map_err(|e| e.to_string())
 }
@@ -515,25 +517,27 @@ pub async fn validate_bitcoin_address(address: String) -> Result<bool, String> {
 // SOLANA-SPECIFIC COMMANDS
 // =============================================================================
 
-use super::solana::{SolanaAdapter, SolanaBalance, SolanaTransaction};
+use super::solana::{SolanaAdapter, SolanaBalance};
 
 /// Get Solana transactions for an address
+///
+/// Routes through `ChainManager::get_transactions` so the call inherits
+/// provider-fallback (primary RPC → Helius → public endpoint), health
+/// tracking, and the unified `ChainTransaction` response shape.
 ///
 /// # Arguments
 /// * `address` - Solana address (base58 encoded)
 /// * `network` - Network name ("solana", "solana_devnet")
-/// * `max_pages` - Maximum pages to fetch (~100 txs per page)
 #[tauri::command]
 pub async fn get_solana_transactions(
+    state: State<'_, ChainManagerState>,
     address: String,
     network: Option<String>,
-    max_pages: Option<usize>,
-) -> Result<Vec<SolanaTransaction>, String> {
+) -> Result<Vec<ChainTransaction>, String> {
     let network_name = network.as_deref().unwrap_or("solana");
-    let adapter = SolanaAdapter::from_network(network_name).map_err(|e| e.to_string())?;
-
-    adapter
-        .fetch_transactions(&address, max_pages)
+    let manager = state.read().await;
+    manager
+        .get_transactions(network_name, &address, None)
         .await
         .map_err(|e| e.to_string())
 }

--- a/src/services/blockchain/bitcoinService.ts
+++ b/src/services/blockchain/bitcoinService.ts
@@ -6,6 +6,7 @@
  */
 
 import { invoke } from '@tauri-apps/api/core'
+import type { ChainTransaction } from '../../types/chains'
 
 // =============================================================================
 // TYPES
@@ -279,21 +280,22 @@ export function getBitcoinBalance(
 }
 
 /**
- * Get transactions for a Bitcoin address
+ * Get transactions for a Bitcoin address via the resilient pipeline.
+ *
+ * Routes through ChainManager::get_transactions (Mempool.space → Blockstream
+ * fallback, health tracking). Returns unified ChainTransaction shape.
  *
  * @param address Bitcoin address
  * @param network Network name ("bitcoin", "testnet", "signet")
- * @param maxPages Maximum pages to fetch (25 txs per page)
+ * @returns Unified chain transactions with provider fallback
  */
 export function getBitcoinTransactions(
   address: string,
-  network = 'bitcoin',
-  maxPages?: number
-): Promise<BitcoinTransaction[]> {
-  return invoke<BitcoinTransaction[]>('get_bitcoin_transactions', {
+  network = 'bitcoin'
+): Promise<ChainTransaction[]> {
+  return invoke<ChainTransaction[]>('get_bitcoin_transactions', {
     address,
     network,
-    maxPages,
   })
 }
 

--- a/src/services/blockchain/solanaService.ts
+++ b/src/services/blockchain/solanaService.ts
@@ -101,7 +101,7 @@ export interface SolanaTransaction {
  * @param address Solana address (base58 encoded)
  * @param network Network name ("solana" or "solana_devnet")
  */
-export async function getSolanaBalance(
+export function getSolanaBalance(
   address: string,
   network = 'solana'
 ): Promise<SolanaBalance> {
@@ -119,7 +119,7 @@ export async function getSolanaBalance(
  * @param network Network name ("solana" or "solana_devnet")
  * @returns Unified chain transactions with provider fallback
  */
-export async function getSolanaTransactions(
+export function getSolanaTransactions(
   address: string,
   network = 'solana'
 ): Promise<ChainTransaction[]> {
@@ -132,7 +132,7 @@ export async function getSolanaTransactions(
 /**
  * Validate a Solana address
  */
-export async function validateSolanaAddress(address: string): Promise<boolean> {
+export function validateSolanaAddress(address: string): Promise<boolean> {
   return invoke<boolean>('validate_solana_address', { address })
 }
 

--- a/src/services/blockchain/solanaService.ts
+++ b/src/services/blockchain/solanaService.ts
@@ -6,6 +6,7 @@
  */
 
 import { invoke } from '@tauri-apps/api/core'
+import type { ChainTransaction } from '../../types/chains'
 
 // =============================================================================
 // TYPES
@@ -108,21 +109,23 @@ export async function getSolanaBalance(
 }
 
 /**
- * Get transactions for a Solana address
+ * Get transactions for a Solana address via the resilient pipeline.
+ *
+ * Routes through ChainManager::get_transactions (primary RPC → Helius →
+ * public endpoint fallback, health tracking). Returns unified
+ * ChainTransaction shape.
  *
  * @param address Solana address
  * @param network Network name ("solana" or "solana_devnet")
- * @param maxPages Maximum pages to fetch (~100 txs per page)
+ * @returns Unified chain transactions with provider fallback
  */
 export async function getSolanaTransactions(
   address: string,
-  network = 'solana',
-  maxPages?: number
-): Promise<SolanaTransaction[]> {
-  return invoke<SolanaTransaction[]>('get_solana_transactions', {
+  network = 'solana'
+): Promise<ChainTransaction[]> {
+  return invoke<ChainTransaction[]>('get_solana_transactions', {
     address,
     network,
-    maxPages,
   })
 }
 


### PR DESCRIPTION
## Summary

- Routes `get_bitcoin_transactions` and `get_solana_transactions` Tauri commands through `ChainManager::get_transactions` instead of constructing bare adapters directly
- Both commands now inherit provider fallback (Mempool→Blockstream for BTC, primary→Helius→public for SOL), health tracking, and graceful `ProviderUnavailable` error surfacing
- Return type converged from chain-specific types to unified `ChainTransaction` shape; TS wrappers updated (both were orphaned — no live UI consumers broken)
- Moonscan hybrid path preserved (Gate-1 rehearsal path — not regressed)
- `docs/stage1-progress.md` updated with Session 24 / Part 4 entry

## Test plan

- [x] `cargo test --lib` — all 350 tests pass, 0 failures
- [ ] Manual verification: Bitcoin/Solana transaction fetch via Tauri dev server
- [ ] CTO review of path convergence approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>