### PR TITLE
Fix import button label: Import All to Ledger → Import to Transactions (GIV-716)

### DIFF
--- a/src/components/wallet/TransactionList.tsx
+++ b/src/components/wallet/TransactionList.tsx
@@ -590,7 +590,7 @@ export const TransactionList: React.FC<TransactionListProps> = ({
                   <Upload className="w-4 h-4" />
                   {selectedCount > 0
                     ? `Import ${selectedCount} Selected`
-                    : 'Import All to Ledger'}
+                    : 'Import to Transactions'}
                 </>
               )}
             </button>


### PR DESCRIPTION
## Summary
- Changes the fallback import button label from **"Import All to Ledger"** to **"Import to Transactions"** per board feedback on GIV-716.
- 1-line change in `TransactionList.tsx:593`.
- The `Import N Selected` variant when rows are checked is unchanged.

## Test plan
- [ ] Open `/wallet-manager`, sync a wallet, confirm the import button reads **"Import to Transactions"** when no rows are selected.
- [ ] Select one or more rows — button should still read **"Import N Selected"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)