### PR TITLE
feat(accounting): audit-trail FK — JE → source wallet tx (GIV-727)

### DIFF
--- a/src-tauri/migrations/20260724000002_audit_trail_fk.sql
+++ b/src-tauri/migrations/20260724000002_audit_trail_fk.sql
@@ -1,0 +1,32 @@
+-- =============================================================================
+-- AUDIT-TRAIL FK: journal_entries → multi_chain_transactions (GIV-727)
+--
+-- Every posted journal entry that originates from a wallet transaction now
+-- carries a hard foreign-key link back to its source on-chain tx.
+-- Manual JEs (no wallet source) carry NULL and work without breakage.
+-- =============================================================================
+
+-- 1. Add source_tx_id FK on journal_entries header.
+--    Points to multi_chain_transactions(id) which is the composite
+--    "chain_id_txhash" text primary key.
+ALTER TABLE journal_entries
+    ADD COLUMN source_tx_id TEXT REFERENCES multi_chain_transactions(id);
+
+-- 2. Index for fast lookups and JE → source-tx drill-down.
+CREATE INDEX IF NOT EXISTS idx_journal_entries_source_tx
+    ON journal_entries(source_tx_id);
+
+-- 3. Backfill existing rule-originated entries.
+--    auto_classify_transaction sets reference_number = bare tx hash and
+--    origin = 'rule'. Match against multi_chain_transactions.transaction_hash
+--    to recover the composite ID.
+UPDATE journal_entries
+SET source_tx_id = (
+    SELECT mct.id
+    FROM multi_chain_transactions mct
+    WHERE mct.transaction_hash = journal_entries.reference_number
+    LIMIT 1
+)
+WHERE origin = 'rule'
+  AND reference_number IS NOT NULL
+  AND source_tx_id IS NULL;

--- a/src-tauri/src/api/accounting.rs
+++ b/src-tauri/src/api/accounting.rs
@@ -662,16 +662,27 @@ pub async fn get_journal_entry(
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 #[serde(rename_all = "camelCase")]
 pub struct SourceTransactionSummary {
+    /// Unique row identifier from multi_chain_transactions.
     pub id: String,
+    /// Blockchain network identifier (e.g. "polkadot", "kusama").
     pub chain_id: String,
+    /// On-chain transaction hash.
     pub transaction_hash: String,
+    /// Sender address.
     pub from_address: String,
+    /// Recipient address (None for contract-creation transactions).
     pub to_address: Option<String>,
+    /// Transfer value in the chain's smallest unit.
     pub transfer_value: String,
+    /// Network fee paid for the transaction, if available.
     pub transaction_fee: Option<String>,
+    /// Unix timestamp of the block containing this transaction.
     pub timestamp: i64,
+    /// Classification of the transaction (e.g. "transfer", "staking").
     pub transaction_type: String,
+    /// On-chain finality status.
     pub status: String,
+    /// Address of the wallet that owns this transaction.
     pub wallet_address: String,
 }
 

--- a/src-tauri/src/api/accounting.rs
+++ b/src-tauri/src/api/accounting.rs
@@ -125,6 +125,9 @@ pub struct JournalEntry {
     pub approved_at: Option<NaiveDateTime>,
     /// When this entry was posted to the ledger.
     pub posted_at: Option<NaiveDateTime>,
+    /// FK to multi_chain_transactions(id) — the on-chain source tx.
+    /// NULL for manual entries with no wallet source.
+    pub source_tx_id: Option<String>,
 }
 
 /// A single debit or credit line within a journal entry.
@@ -655,6 +658,41 @@ pub async fn get_journal_entry(
     Ok(JournalEntryWithLines { entry, lines })
 }
 
+/// Summary of the on-chain source transaction linked to a journal entry.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceTransactionSummary {
+    pub id: String,
+    pub chain_id: String,
+    pub transaction_hash: String,
+    pub from_address: String,
+    pub to_address: Option<String>,
+    pub transfer_value: String,
+    pub transaction_fee: Option<String>,
+    pub timestamp: i64,
+    pub transaction_type: String,
+    pub status: String,
+    pub wallet_address: String,
+}
+
+/// Fetches the on-chain source transaction linked to a journal entry.
+/// Returns None (null) if the entry has no source_tx_id or the row is missing.
+#[tauri::command]
+pub async fn get_source_transaction(
+    state: State<'_, DatabaseState>,
+    source_tx_id: String,
+) -> Result<Option<SourceTransactionSummary>, String> {
+    let row = sqlx::query_as::<_, SourceTransactionSummary>(
+        "SELECT id, chain_id, transaction_hash, from_address, to_address, transfer_value, transaction_fee, timestamp, transaction_type, status, wallet_address FROM multi_chain_transactions WHERE id = ?",
+    )
+    .bind(&source_tx_id)
+    .fetch_optional(&state.pool)
+    .await
+    .map_err(|e| e.to_string())?;
+
+    Ok(row)
+}
+
 /// Creates a new journal entry as a draft with the given lines.
 #[tauri::command]
 pub async fn create_journal_entry(
@@ -706,8 +744,8 @@ pub async fn create_journal_entry(
 
     let result = sqlx::query(
         r#"
-        INSERT INTO journal_entries (entry_date, entry_number, description, reference_number, is_posted, status, origin, created_by)
-        VALUES (?, ?, ?, ?, 0, 'draft', ?, 'system')
+        INSERT INTO journal_entries (entry_date, entry_number, description, reference_number, is_posted, status, origin, created_by, source_tx_id)
+        VALUES (?, ?, ?, ?, 0, 'draft', ?, 'system', ?)
         "#,
     )
     .bind(entry_date)
@@ -715,6 +753,7 @@ pub async fn create_journal_entry(
     .bind(&input.description)
     .bind(&input.reference_number)
     .bind(origin)
+    .bind(&input.raw_transaction_id)
     .execute(&mut *tx)
     .await
     .map_err(|e| e.to_string())?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -435,6 +435,7 @@ pub fn run() {
             api::accounting::deactivate_gl_account,
             api::accounting::get_journal_entries,
             api::accounting::get_journal_entry,
+            api::accounting::get_source_transaction,
             api::accounting::create_journal_entry,
             api::accounting::approve_journal_entry,
             api::accounting::post_journal_entry,

--- a/src/app/journal-entries/JournalEntries.tsx
+++ b/src/app/journal-entries/JournalEntries.tsx
@@ -11,6 +11,7 @@ import {
   ShieldCheck,
   ChevronDown,
   ChevronRight,
+  Link2,
 } from 'lucide-react'
 import { useNavBadges } from '../../contexts/NavBadgeContext'
 import { useAuth } from '../../contexts/AuthContext'
@@ -582,9 +583,12 @@ const JournalEntries: React.FC = () => {
                             )}
                             {entry.referenceNumber && (
                               <span
-                                className="font-mono"
+                                className="font-mono inline-flex items-center gap-1"
                                 title={entry.referenceNumber}
                               >
+                                {entry.sourceTxId && (
+                                  <Link2 className="w-3 h-3 text-emerald-500" />
+                                )}
                                 Ref:{' '}
                                 {entry.referenceNumber.length > 20
                                   ? `${entry.referenceNumber.slice(0, 20)}\u2026`

--- a/src/app/journal-entries/JournalEntryDetail.tsx
+++ b/src/app/journal-entries/JournalEntryDetail.tsx
@@ -116,9 +116,7 @@ const SourceTransactionSection: React.FC<{ sourceTxId: string }> = ({
         <Link2 className="w-3.5 h-3.5" />
         Source Transaction
       </h3>
-      {loading && (
-        <p className="text-sm text-[#647D8B]">Loading&hellip;</p>
-      )}
+      {loading && <p className="text-sm text-[#647D8B]">Loading&hellip;</p>}
       {!loading && sourceTx && (
         <div className="p-3 rounded-lg bg-[#EAF3F2]/60 dark:bg-[#16242F]/60 border border-[rgba(95,227,192,0.15)] space-y-2">
           <div className="grid grid-cols-2 gap-3 text-sm">
@@ -156,9 +154,7 @@ const SourceTransactionSection: React.FC<{ sourceTxId: string }> = ({
                 className="font-mono text-[#11202B] dark:text-[#EAF3F2]"
                 title={sourceTx.toAddress ?? ''}
               >
-                {sourceTx.toAddress
-                  ? truncateAddress(sourceTx.toAddress)
-                  : '—'}
+                {sourceTx.toAddress ? truncateAddress(sourceTx.toAddress) : '—'}
               </p>
             </div>
             <div>

--- a/src/app/journal-entries/JournalEntryDetail.tsx
+++ b/src/app/journal-entries/JournalEntryDetail.tsx
@@ -89,6 +89,104 @@ function formatTxTimestamp(unixSec: number): string {
   })
 }
 
+/** Displays the linked on-chain source transaction for a journal entry. */
+const SourceTransactionSection: React.FC<{ sourceTxId: string }> = ({
+  sourceTxId,
+}) => {
+  const [sourceTx, setSourceTx] = useState<SourceTransactionSummary | null>(
+    null
+  )
+  const [fetched, setFetched] = useState(false)
+
+  const loading = isTauriAvailable() && !fetched
+
+  useEffect(() => {
+    if (!isTauriAvailable()) return
+    invoke<SourceTransactionSummary | null>('get_source_transaction', {
+      sourceTxId,
+    })
+      .then(result => setSourceTx(result ?? null))
+      .catch(() => setSourceTx(null))
+      .finally(() => setFetched(true))
+  }, [sourceTxId])
+
+  return (
+    <div>
+      <h3 className="text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider mb-3 flex items-center gap-1.5">
+        <Link2 className="w-3.5 h-3.5" />
+        Source Transaction
+      </h3>
+      {loading && (
+        <p className="text-sm text-[#647D8B]">Loading&hellip;</p>
+      )}
+      {!loading && sourceTx && (
+        <div className="p-3 rounded-lg bg-[#EAF3F2]/60 dark:bg-[#16242F]/60 border border-[rgba(95,227,192,0.15)] space-y-2">
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <div>
+              <span className="text-xs text-[#647D8B] uppercase">Chain</span>
+              <p className="font-mono text-[#11202B] dark:text-[#EAF3F2]">
+                {sourceTx.chainId}
+              </p>
+            </div>
+            <div>
+              <span className="text-xs text-[#647D8B] uppercase">Type</span>
+              <p className="text-[#11202B] dark:text-[#EAF3F2] capitalize">
+                {sourceTx.transactionType.replace('_', ' ')}
+              </p>
+            </div>
+            <div className="col-span-2">
+              <span className="text-xs text-[#647D8B] uppercase">Tx Hash</span>
+              <p className="font-mono text-[#11202B] dark:text-[#EAF3F2] break-all flex items-center gap-1.5">
+                {sourceTx.transactionHash}
+                <ExternalLink className="w-3 h-3 text-[#647D8B] flex-shrink-0" />
+              </p>
+            </div>
+            <div>
+              <span className="text-xs text-[#647D8B] uppercase">From</span>
+              <p
+                className="font-mono text-[#11202B] dark:text-[#EAF3F2]"
+                title={sourceTx.fromAddress}
+              >
+                {truncateAddress(sourceTx.fromAddress)}
+              </p>
+            </div>
+            <div>
+              <span className="text-xs text-[#647D8B] uppercase">To</span>
+              <p
+                className="font-mono text-[#11202B] dark:text-[#EAF3F2]"
+                title={sourceTx.toAddress ?? ''}
+              >
+                {sourceTx.toAddress
+                  ? truncateAddress(sourceTx.toAddress)
+                  : '—'}
+              </p>
+            </div>
+            <div>
+              <span className="text-xs text-[#647D8B] uppercase">
+                Timestamp
+              </span>
+              <p className="text-[#11202B] dark:text-[#EAF3F2]">
+                {formatTxTimestamp(sourceTx.timestamp)}
+              </p>
+            </div>
+            <div>
+              <span className="text-xs text-[#647D8B] uppercase">Value</span>
+              <p className="font-mono text-[#11202B] dark:text-[#EAF3F2]">
+                {sourceTx.transferValue}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+      {!loading && !sourceTx && (
+        <p className="text-sm text-[#647D8B] italic">
+          Source transaction not found (ID: {sourceTxId})
+        </p>
+      )}
+    </div>
+  )
+}
+
 /** Slide-over panel showing a journal entry's lines, metadata, and linked source transaction. */
 const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
   entry,
@@ -96,24 +194,6 @@ const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
   entries,
   onClose,
 }) => {
-  const [sourceTx, setSourceTx] = useState<SourceTransactionSummary | null>(
-    null
-  )
-  const [sourceTxFetched, setSourceTxFetched] = useState(false)
-
-  const sourceTxLoading =
-    Boolean(entry.sourceTxId) && isTauriAvailable() && !sourceTxFetched
-
-  useEffect(() => {
-    if (!entry.sourceTxId || !isTauriAvailable()) return
-    invoke<SourceTransactionSummary | null>('get_source_transaction', {
-      sourceTxId: entry.sourceTxId,
-    })
-      .then(result => setSourceTx(result ?? null))
-      .catch(() => setSourceTx(null))
-      .finally(() => setSourceTxFetched(true))
-  }, [entry.sourceTxId])
-
   const accountMap = useMemo(() => {
     const m = new Map<number, GLAccount>()
     accounts.forEach(a => m.set(a.id, a))
@@ -269,91 +349,7 @@ const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
 
           {/* Source on-chain transaction */}
           {entry.sourceTxId && (
-            <div>
-              <h3 className="text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider mb-3 flex items-center gap-1.5">
-                <Link2 className="w-3.5 h-3.5" />
-                Source Transaction
-              </h3>
-              {sourceTxLoading && (
-                <p className="text-sm text-[#647D8B]">Loading&hellip;</p>
-              )}
-              {!sourceTxLoading && sourceTx && (
-                <div className="p-3 rounded-lg bg-[#EAF3F2]/60 dark:bg-[#16242F]/60 border border-[rgba(95,227,192,0.15)] space-y-2">
-                  <div className="grid grid-cols-2 gap-3 text-sm">
-                    <div>
-                      <span className="text-xs text-[#647D8B] uppercase">
-                        Chain
-                      </span>
-                      <p className="font-mono text-[#11202B] dark:text-[#EAF3F2]">
-                        {sourceTx.chainId}
-                      </p>
-                    </div>
-                    <div>
-                      <span className="text-xs text-[#647D8B] uppercase">
-                        Type
-                      </span>
-                      <p className="text-[#11202B] dark:text-[#EAF3F2] capitalize">
-                        {sourceTx.transactionType.replace('_', ' ')}
-                      </p>
-                    </div>
-                    <div className="col-span-2">
-                      <span className="text-xs text-[#647D8B] uppercase">
-                        Tx Hash
-                      </span>
-                      <p className="font-mono text-[#11202B] dark:text-[#EAF3F2] break-all flex items-center gap-1.5">
-                        {sourceTx.transactionHash}
-                        <ExternalLink className="w-3 h-3 text-[#647D8B] flex-shrink-0" />
-                      </p>
-                    </div>
-                    <div>
-                      <span className="text-xs text-[#647D8B] uppercase">
-                        From
-                      </span>
-                      <p
-                        className="font-mono text-[#11202B] dark:text-[#EAF3F2]"
-                        title={sourceTx.fromAddress}
-                      >
-                        {truncateAddress(sourceTx.fromAddress)}
-                      </p>
-                    </div>
-                    <div>
-                      <span className="text-xs text-[#647D8B] uppercase">
-                        To
-                      </span>
-                      <p
-                        className="font-mono text-[#11202B] dark:text-[#EAF3F2]"
-                        title={sourceTx.toAddress ?? ''}
-                      >
-                        {sourceTx.toAddress
-                          ? truncateAddress(sourceTx.toAddress)
-                          : '—'}
-                      </p>
-                    </div>
-                    <div>
-                      <span className="text-xs text-[#647D8B] uppercase">
-                        Timestamp
-                      </span>
-                      <p className="text-[#11202B] dark:text-[#EAF3F2]">
-                        {formatTxTimestamp(sourceTx.timestamp)}
-                      </p>
-                    </div>
-                    <div>
-                      <span className="text-xs text-[#647D8B] uppercase">
-                        Value
-                      </span>
-                      <p className="font-mono text-[#11202B] dark:text-[#EAF3F2]">
-                        {sourceTx.transferValue}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              )}
-              {!sourceTxLoading && !sourceTx && (
-                <p className="text-sm text-[#647D8B] italic">
-                  Source transaction not found (ID: {entry.sourceTxId})
-                </p>
-              )}
-            </div>
+            <SourceTransactionSection sourceTxId={entry.sourceTxId} />
           )}
 
           {/* Lifecycle timestamps */}

--- a/src/app/journal-entries/JournalEntryDetail.tsx
+++ b/src/app/journal-entries/JournalEntryDetail.tsx
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
+import { invoke } from '@tauri-apps/api/core'
 import {
   X,
   Clock,
@@ -6,6 +7,8 @@ import {
   ShieldCheck,
   XCircle,
   ArrowRightLeft,
+  ExternalLink,
+  Link2,
 } from 'lucide-react'
 import type { GLAccount, JournalEntryWithLines } from '../../types/database'
 import {
@@ -14,6 +17,21 @@ import {
   formatDateTime,
   minorToDollars,
 } from './journalEntryUtils'
+import { isTauriAvailable } from '../../utils/tauri'
+
+interface SourceTransactionSummary {
+  id: string
+  chainId: string
+  transactionHash: string
+  fromAddress: string
+  toAddress?: string
+  transferValue: string
+  transactionFee?: string
+  timestamp: number
+  transactionType: string
+  status: string
+  walletAddress: string
+}
 
 interface JournalEntryDetailProps {
   entry: JournalEntryWithLines
@@ -55,20 +73,40 @@ const originLabels: Record<string, string> = {
   model: 'Model',
 }
 
-/**
- * Full detail view for a journal entry.
- * Shows lines, lifecycle timestamps, provenance (origin, created_by),
- * and reversal linkage: a voided entry links to its reversing entry
- * and vice versa.
- * @param props - Component properties
- * @returns The JournalEntryDetail overlay component
- */
+function truncateAddress(addr: string): string {
+  if (addr.length <= 14) return addr
+  return `${addr.slice(0, 8)}…${addr.slice(-6)}`
+}
+
+function formatTxTimestamp(unixSec: number): string {
+  return new Date(unixSec * 1000).toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}
+
 const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
   entry,
   accounts,
   entries,
   onClose,
 }) => {
+  const [sourceTx, setSourceTx] = useState<SourceTransactionSummary | null>(
+    null
+  )
+  const [sourceTxLoading, setSourceTxLoading] = useState(false)
+
+  useEffect(() => {
+    if (!entry.sourceTxId || !isTauriAvailable()) return
+    setSourceTxLoading(true)
+    invoke<SourceTransactionSummary | null>('get_source_transaction', {
+      sourceTxId: entry.sourceTxId,
+    })
+      .then(result => setSourceTx(result ?? null))
+      .catch(() => setSourceTx(null))
+      .finally(() => setSourceTxLoading(false))
+  }, [entry.sourceTxId])
+
   const accountMap = useMemo(() => {
     const m = new Map<number, GLAccount>()
     accounts.forEach(a => m.set(a.id, a))
@@ -78,7 +116,7 @@ const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
   const resolveAccountName = (glAccountId: number) => {
     const acct = accountMap.get(glAccountId)
     return acct
-      ? `${acct.accountNumber} \u00b7 ${acct.accountName}`
+      ? `${acct.accountNumber} · ${acct.accountName}`
       : `#${glAccountId}`
   }
 
@@ -89,7 +127,6 @@ const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
   const totalDebits = entry.lines.reduce((s, l) => s + l.debitMinor, 0)
   const totalCredits = entry.lines.reduce((s, l) => s + l.creditMinor, 0)
 
-  /** Find the linked reversal entry if one exists */
   const reversalEntry = useMemo(() => {
     if (entry.reversedByEntryId) {
       return entries.find(e => e.id === entry.reversedByEntryId)
@@ -194,7 +231,7 @@ const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
                 Entry Number
               </label>
               <span className="text-sm font-mono text-[#11202B] dark:text-[#EAF3F2]">
-                {entry.entryNumber ?? '\u2014'}
+                {entry.entryNumber ?? '—'}
               </span>
             </div>
             <div className="col-span-2">
@@ -202,7 +239,7 @@ const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
                 Description
               </label>
               <span className="text-sm text-[#11202B] dark:text-[#EAF3F2]">
-                {entry.description ?? '\u2014'}
+                {entry.description ?? '—'}
               </span>
             </div>
             <div>
@@ -210,7 +247,7 @@ const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
                 Reference
               </label>
               <span className="text-sm font-mono text-[#11202B] dark:text-[#EAF3F2] break-all">
-                {entry.referenceNumber ?? '\u2014'}
+                {entry.referenceNumber ?? '—'}
               </span>
             </div>
             <div>
@@ -222,6 +259,95 @@ const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
               </span>
             </div>
           </div>
+
+          {/* Source on-chain transaction */}
+          {entry.sourceTxId && (
+            <div>
+              <h3 className="text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider mb-3 flex items-center gap-1.5">
+                <Link2 className="w-3.5 h-3.5" />
+                Source Transaction
+              </h3>
+              {sourceTxLoading && (
+                <p className="text-sm text-[#647D8B]">Loading&hellip;</p>
+              )}
+              {!sourceTxLoading && sourceTx && (
+                <div className="p-3 rounded-lg bg-[#EAF3F2]/60 dark:bg-[#16242F]/60 border border-[rgba(95,227,192,0.15)] space-y-2">
+                  <div className="grid grid-cols-2 gap-3 text-sm">
+                    <div>
+                      <span className="text-xs text-[#647D8B] uppercase">
+                        Chain
+                      </span>
+                      <p className="font-mono text-[#11202B] dark:text-[#EAF3F2]">
+                        {sourceTx.chainId}
+                      </p>
+                    </div>
+                    <div>
+                      <span className="text-xs text-[#647D8B] uppercase">
+                        Type
+                      </span>
+                      <p className="text-[#11202B] dark:text-[#EAF3F2] capitalize">
+                        {sourceTx.transactionType.replace('_', ' ')}
+                      </p>
+                    </div>
+                    <div className="col-span-2">
+                      <span className="text-xs text-[#647D8B] uppercase">
+                        Tx Hash
+                      </span>
+                      <p className="font-mono text-[#11202B] dark:text-[#EAF3F2] break-all flex items-center gap-1.5">
+                        {sourceTx.transactionHash}
+                        <ExternalLink className="w-3 h-3 text-[#647D8B] flex-shrink-0" />
+                      </p>
+                    </div>
+                    <div>
+                      <span className="text-xs text-[#647D8B] uppercase">
+                        From
+                      </span>
+                      <p
+                        className="font-mono text-[#11202B] dark:text-[#EAF3F2]"
+                        title={sourceTx.fromAddress}
+                      >
+                        {truncateAddress(sourceTx.fromAddress)}
+                      </p>
+                    </div>
+                    <div>
+                      <span className="text-xs text-[#647D8B] uppercase">
+                        To
+                      </span>
+                      <p
+                        className="font-mono text-[#11202B] dark:text-[#EAF3F2]"
+                        title={sourceTx.toAddress ?? ''}
+                      >
+                        {sourceTx.toAddress
+                          ? truncateAddress(sourceTx.toAddress)
+                          : '—'}
+                      </p>
+                    </div>
+                    <div>
+                      <span className="text-xs text-[#647D8B] uppercase">
+                        Timestamp
+                      </span>
+                      <p className="text-[#11202B] dark:text-[#EAF3F2]">
+                        {formatTxTimestamp(sourceTx.timestamp)}
+                      </p>
+                    </div>
+                    <div>
+                      <span className="text-xs text-[#647D8B] uppercase">
+                        Value
+                      </span>
+                      <p className="font-mono text-[#11202B] dark:text-[#EAF3F2]">
+                        {sourceTx.transferValue}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              )}
+              {!sourceTxLoading && !sourceTx && (
+                <p className="text-sm text-[#647D8B] italic">
+                  Source transaction not found (ID: {entry.sourceTxId})
+                </p>
+              )}
+            </div>
+          )}
 
           {/* Lifecycle timestamps */}
           <div>
@@ -320,7 +446,7 @@ const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
                         {resolveAccountName(line.glAccountId)}
                       </td>
                       <td className="px-4 py-2 font-mono text-xs text-[#294050] dark:text-[#9FB4BE]">
-                        {line.assetId ?? '\u2014'}
+                        {line.assetId ?? '—'}
                       </td>
                       <td className="px-4 py-2 text-right font-mono text-[#294050] dark:text-[#9FB4BE]">
                         {line.quantity ?? ''}

--- a/src/app/journal-entries/JournalEntryDetail.tsx
+++ b/src/app/journal-entries/JournalEntryDetail.tsx
@@ -94,17 +94,19 @@ const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
   const [sourceTx, setSourceTx] = useState<SourceTransactionSummary | null>(
     null
   )
-  const [sourceTxLoading, setSourceTxLoading] = useState(false)
+  const [sourceTxFetched, setSourceTxFetched] = useState(false)
+
+  const sourceTxLoading =
+    Boolean(entry.sourceTxId) && isTauriAvailable() && !sourceTxFetched
 
   useEffect(() => {
     if (!entry.sourceTxId || !isTauriAvailable()) return
-    setSourceTxLoading(true)
     invoke<SourceTransactionSummary | null>('get_source_transaction', {
       sourceTxId: entry.sourceTxId,
     })
       .then(result => setSourceTx(result ?? null))
       .catch(() => setSourceTx(null))
-      .finally(() => setSourceTxLoading(false))
+      .finally(() => setSourceTxFetched(true))
   }, [entry.sourceTxId])
 
   const accountMap = useMemo(() => {

--- a/src/app/journal-entries/JournalEntryDetail.tsx
+++ b/src/app/journal-entries/JournalEntryDetail.tsx
@@ -19,6 +19,7 @@ import {
 } from './journalEntryUtils'
 import { isTauriAvailable } from '../../utils/tauri'
 
+/** On-chain source transaction summary returned by the Tauri backend. */
 interface SourceTransactionSummary {
   id: string
   chainId: string
@@ -33,6 +34,7 @@ interface SourceTransactionSummary {
   walletAddress: string
 }
 
+/** Props for the journal-entry detail overlay panel. */
 interface JournalEntryDetailProps {
   entry: JournalEntryWithLines
   accounts: GLAccount[]
@@ -73,11 +75,13 @@ const originLabels: Record<string, string> = {
   model: 'Model',
 }
 
+/** Shorten a blockchain address to first 8 + last 6 characters with an ellipsis. */
 function truncateAddress(addr: string): string {
   if (addr.length <= 14) return addr
   return `${addr.slice(0, 8)}…${addr.slice(-6)}`
 }
 
+/** Format a Unix-seconds timestamp into a localised medium-date + short-time string. */
 function formatTxTimestamp(unixSec: number): string {
   return new Date(unixSec * 1000).toLocaleString(undefined, {
     dateStyle: 'medium',
@@ -85,6 +89,7 @@ function formatTxTimestamp(unixSec: number): string {
   })
 }
 
+/** Slide-over panel showing a journal entry's lines, metadata, and linked source transaction. */
 const JournalEntryDetail: React.FC<JournalEntryDetailProps> = ({
   entry,
   accounts,

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -206,6 +206,8 @@ export interface JournalEntry {
   approvedAt?: Date
   /** When this entry was posted to the ledger. */
   postedAt?: Date
+  /** FK to multi_chain_transactions — on-chain source tx, null for manual entries. */
+  sourceTxId?: string
 }
 
 export interface JournalEntryLine {


### PR DESCRIPTION
## Summary
- Adds `source_tx_id TEXT REFERENCES multi_chain_transactions(id)` column to `journal_entries` — hard FK linking every wallet-originated journal entry to its on-chain source transaction
- New migration (`20260724000002`) includes backfill: existing `origin='rule'` entries matched by `reference_number` → `transaction_hash`
- `create_journal_entry` now writes `source_tx_id` from `raw_transaction_id` at draft creation time
- New Tauri command `get_source_transaction` returns chain/hash/timestamp/from/to for the linked tx
- JournalEntryDetail UI shows "Source Transaction" drill-down section (chain, hash, from/to, timestamp, value)
- JournalEntries list view shows chain-link icon next to reference when source_tx_id is present
- Manual JEs (no wallet source) carry NULL source_tx_id — no UI breakage

## Acceptance Criteria Coverage
- ✅ New posted JEs from wallet-tx classification carry resolvable FK
- ✅ JE detail can drill down to source on-chain tx (hash, timestamp, counterparty)
- ✅ Manual JEs carry NULL FK — handled without UI breakage
- ✅ Migration is additive (ALTER TABLE ADD COLUMN) — reversible by dropping column

## Test plan
- [x] `cargo check` — compiles clean
- [x] `npx tsc --noEmit` — no type errors
- [x] Existing Rust unit tests pass (`create_journal_entry_input_accepts_origin`)
- [ ] CI: Build Rust Backend, Build Frontend, Type Check, Lint, E2E
- [ ] Manual: classify a wallet tx → verify JE detail shows Source Transaction section
- [ ] Manual: create manual JE → verify no source tx section shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)