### PR TITLE
feat(classification): batch classify + approve UX (GIV-725)

### DIFF
--- a/src/app/classification/ClassificationQueue.tsx
+++ b/src/app/classification/ClassificationQueue.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react'
 import { invoke } from '@tauri-apps/api/core'
+import { useNavigate } from 'react-router-dom'
 import {
   Search,
   Zap,
@@ -8,8 +9,16 @@ import {
   Inbox,
   RefreshCw,
   DollarSign,
+  CheckSquare,
+  Square,
+  MinusSquare,
+  Filter,
+  ShieldCheck,
+  ArrowRight,
+  BarChart3,
 } from 'lucide-react'
 import { useNavBadges } from '../../contexts/NavBadgeContext'
+import { useAuth } from '../../contexts/AuthContext'
 import type {
   RawTransaction,
   GLAccount,
@@ -20,23 +29,49 @@ import {
   formatTimestampFull,
   truncateHash,
   displayTxType,
+  rulePreview,
 } from './classificationUtils'
 
-/** Skip/ignore modal state. */
 interface IgnoreModal {
   transactionId: string
   hash: string
 }
 
+interface BatchResult {
+  classified: number
+  skipped: number
+  failed: number
+  journalEntryIds: number[]
+}
+
 const HEADER_CELL =
   'px-4 py-3 text-xs font-medium text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider'
 
-/** Static table header row for the classification queue. */
-const QueueHeaderRow: React.FC = () => (
+const QueueHeaderRow: React.FC<{
+  allSelected: boolean
+  someSelected: boolean
+  onToggleAll: () => void
+}> = ({ allSelected, someSelected, onToggleAll }) => (
   <tr>
+    <th className={`${HEADER_CELL} w-10 text-center`}>
+      <button
+        onClick={onToggleAll}
+        className="p-0.5 hover:bg-[#294050]/10 dark:hover:bg-[#294050]/20 rounded transition-colors"
+        title={allSelected ? 'Deselect all' : 'Select all'}
+      >
+        {allSelected ? (
+          <CheckSquare className="w-4 h-4 text-[#5FE3C0]" />
+        ) : someSelected ? (
+          <MinusSquare className="w-4 h-4 text-[#5FE3C0]" />
+        ) : (
+          <Square className="w-4 h-4" />
+        )}
+      </button>
+    </th>
     <th className={`${HEADER_CELL} text-left`}>Chain</th>
     <th className={`${HEADER_CELL} text-left`}>Hash</th>
     <th className={`${HEADER_CELL} text-left`}>Type</th>
+    <th className={`${HEADER_CELL} text-left`}>Rule</th>
     <th className={`${HEADER_CELL} text-right`}>Qty</th>
     <th className={`${HEADER_CELL} text-right`}>USD Value</th>
     <th className={`${HEADER_CELL} text-right`}>Fee</th>
@@ -45,24 +80,40 @@ const QueueHeaderRow: React.FC = () => (
   </tr>
 )
 
-/** Props for a single classification queue row. */
 interface QueueRowProps {
   tx: RawTransaction
+  selected: boolean
   busy: boolean
+  onToggleSelect: (id: string) => void
   onAutoClassify: (event: React.MouseEvent<HTMLButtonElement>) => void
   onManualClassify: (event: React.MouseEvent<HTMLButtonElement>) => void
   onIgnore: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
-/** One raw transaction row with Auto / Manual / Skip actions. */
 const QueueRow: React.FC<QueueRowProps> = ({
   tx,
+  selected,
   busy,
+  onToggleSelect,
   onAutoClassify,
   onManualClassify,
   onIgnore,
 }) => (
-  <tr className="hover:bg-[#EAF3F2] dark:hover:bg-[#11202B]">
+  <tr
+    className={`hover:bg-[#EAF3F2] dark:hover:bg-[#11202B] ${selected ? 'bg-[#5FE3C0]/5 dark:bg-[#5FE3C0]/5' : ''}`}
+  >
+    <td className="px-4 py-3 text-center">
+      <button
+        onClick={() => onToggleSelect(tx.id)}
+        className="p-0.5 hover:bg-[#294050]/10 rounded transition-colors"
+      >
+        {selected ? (
+          <CheckSquare className="w-4 h-4 text-[#5FE3C0]" />
+        ) : (
+          <Square className="w-4 h-4 text-[#647D8B]" />
+        )}
+      </button>
+    </td>
     <td className="px-4 py-3 whitespace-nowrap text-sm text-[#11202B] dark:text-[#EAF3F2]">
       {tx.chainId}
     </td>
@@ -72,6 +123,11 @@ const QueueRow: React.FC<QueueRowProps> = ({
     <td className="px-4 py-3 whitespace-nowrap">
       <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-[#294050]/10 text-[#294050] dark:bg-[#294050]/20 dark:text-[#9FB4BE]">
         {displayTxType(tx.transactionType)}
+      </span>
+    </td>
+    <td className="px-4 py-3 whitespace-nowrap text-xs text-[#647D8B] dark:text-[#647D8B] max-w-[200px] truncate">
+      <span title={rulePreview(tx.transactionType)}>
+        {rulePreview(tx.transactionType)}
       </span>
     </td>
     <td className="px-4 py-3 whitespace-nowrap text-sm text-right font-mono text-[#11202B] dark:text-[#EAF3F2]">
@@ -141,7 +197,6 @@ const QueueRow: React.FC<QueueRowProps> = ({
   </tr>
 )
 
-/** Props for the skip/ignore confirmation dialog. */
 interface IgnoreDialogProps {
   hash: string
   reason: string
@@ -151,7 +206,6 @@ interface IgnoreDialogProps {
   onCancel: () => void
 }
 
-/** Confirmation dialog for skipping/ignoring a raw transaction. */
 const IgnoreDialog: React.FC<IgnoreDialogProps> = ({
   hash,
   reason,
@@ -196,13 +250,10 @@ const IgnoreDialog: React.FC<IgnoreDialogProps> = ({
   </div>
 )
 
-/**
- * Classification queue: lists unclassified raw transactions and provides
- * actions to auto-classify, manually classify, or skip/ignore each row.
- * @returns The ClassificationQueue component
- */
 const ClassificationQueue: React.FC = () => {
+  const navigate = useNavigate()
   const { refreshCounts } = useNavBadges()
+  const { user } = useAuth()
   const [transactions, setTransactions] = useState<RawTransaction[]>([])
   const [accounts, setAccounts] = useState<GLAccount[]>([])
   const [loading, setLoading] = useState(true)
@@ -211,14 +262,21 @@ const ClassificationQueue: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('')
   const [processingId, setProcessingId] = useState<string | null>(null)
 
-  // Drawer state for manual classification
   const [drawerTx, setDrawerTx] = useState<RawTransaction | null>(null)
 
-  // Ignore modal state
   const [ignoreModal, setIgnoreModal] = useState<IgnoreModal | null>(null)
   const [ignoreReason, setIgnoreReason] = useState('')
 
   const [enriching, setEnriching] = useState(false)
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [batchProcessing, setBatchProcessing] = useState(false)
+  const [batchProgress, setBatchProgress] = useState<{
+    done: number
+    total: number
+  } | null>(null)
+  const [batchResult, setBatchResult] = useState<BatchResult | null>(null)
+  const [filterMenuOpen, setFilterMenuOpen] = useState(false)
 
   const fetchData = useCallback(async () => {
     setLoading(true)
@@ -230,6 +288,8 @@ const ClassificationQueue: React.FC = () => {
       ])
       setTransactions(txs)
       setAccounts(accts)
+      setSelectedIds(new Set())
+      setBatchResult(null)
     } catch (err) {
       setError(typeof err === 'string' ? err : 'Failed to load data')
     } finally {
@@ -266,6 +326,216 @@ const ClassificationQueue: React.FC = () => {
         (tx.toAddress?.toLowerCase().includes(needle) ?? false)
     )
   }, [transactions, searchQuery])
+
+  const uniqueChains = useMemo(
+    () => [...new Set(filtered.map(tx => tx.chainId))].sort(),
+    [filtered]
+  )
+  const uniqueTypes = useMemo(
+    () => [...new Set(filtered.map(tx => tx.transactionType))].sort(),
+    [filtered]
+  )
+
+  const allFilteredSelected =
+    filtered.length > 0 && filtered.every(tx => selectedIds.has(tx.id))
+  const someFilteredSelected =
+    filtered.some(tx => selectedIds.has(tx.id)) && !allFilteredSelected
+
+  const selectedCount = filtered.filter(tx => selectedIds.has(tx.id)).length
+
+  const handleToggleAll = useCallback(() => {
+    setSelectedIds(prev => {
+      if (filtered.every(tx => prev.has(tx.id))) {
+        const next = new Set(prev)
+        filtered.forEach(tx => next.delete(tx.id))
+        return next
+      }
+      const next = new Set(prev)
+      filtered.forEach(tx => next.add(tx.id))
+      return next
+    })
+  }, [filtered])
+
+  const handleToggleSelect = useCallback((id: string) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const handleSelectByChain = useCallback(
+    (chain: string) => {
+      setSelectedIds(prev => {
+        const next = new Set(prev)
+        filtered
+          .filter(tx => tx.chainId === chain)
+          .forEach(tx => next.add(tx.id))
+        return next
+      })
+      setFilterMenuOpen(false)
+    },
+    [filtered]
+  )
+
+  const handleSelectByType = useCallback(
+    (txType: string) => {
+      setSelectedIds(prev => {
+        const next = new Set(prev)
+        filtered
+          .filter(tx => tx.transactionType === txType)
+          .forEach(tx => next.add(tx.id))
+        return next
+      })
+      setFilterMenuOpen(false)
+    },
+    [filtered]
+  )
+
+  const handleClearSelection = useCallback(() => {
+    setSelectedIds(new Set())
+  }, [])
+
+  const handleBatchAutoClassify = useCallback(async () => {
+    const ids = filtered.filter(tx => selectedIds.has(tx.id)).map(tx => tx.id)
+    if (ids.length === 0) return
+
+    setBatchProcessing(true)
+    setBatchProgress({ done: 0, total: ids.length })
+    setActionError(null)
+
+    let classified = 0
+    let failed = 0
+    const journalEntryIds: number[] = []
+    const classifiedTxIds: string[] = []
+
+    for (const txId of ids) {
+      try {
+        const je = await invoke<JournalEntryWithLines>(
+          'auto_classify_transaction',
+          { transactionId: txId }
+        )
+        classified++
+        classifiedTxIds.push(txId)
+        journalEntryIds.push(je.id)
+      } catch {
+        failed++
+      }
+      setBatchProgress({ done: classified + failed, total: ids.length })
+    }
+
+    setTransactions(prev => prev.filter(t => !classifiedTxIds.includes(t.id)))
+    setSelectedIds(new Set())
+    refreshCounts()
+    setBatchProcessing(false)
+    setBatchProgress(null)
+    setBatchResult({ classified, skipped: 0, failed, journalEntryIds })
+
+    if (failed > 0) {
+      setActionError(
+        `${failed} transaction${failed !== 1 ? 's' : ''} failed to auto-classify (may need price enrichment or manual classification)`
+      )
+    }
+  }, [filtered, selectedIds, refreshCounts])
+
+  const handleBatchSkip = useCallback(async () => {
+    const ids = filtered.filter(tx => selectedIds.has(tx.id)).map(tx => tx.id)
+    if (ids.length === 0) return
+
+    setBatchProcessing(true)
+    setBatchProgress({ done: 0, total: ids.length })
+    setActionError(null)
+
+    let skipped = 0
+    let failed = 0
+    const skippedTxIds: string[] = []
+
+    for (const txId of ids) {
+      try {
+        await invoke('ignore_transaction', {
+          transactionId: txId,
+          reason: null,
+        })
+        skipped++
+        skippedTxIds.push(txId)
+      } catch {
+        failed++
+      }
+      setBatchProgress({ done: skipped + failed, total: ids.length })
+    }
+
+    setTransactions(prev => prev.filter(t => !skippedTxIds.includes(t.id)))
+    setSelectedIds(new Set())
+    refreshCounts()
+    setBatchProcessing(false)
+    setBatchProgress(null)
+    setBatchResult({
+      classified: 0,
+      skipped,
+      failed,
+      journalEntryIds: [],
+    })
+
+    if (failed > 0) {
+      setActionError(
+        `${failed} transaction${failed !== 1 ? 's' : ''} failed to skip`
+      )
+    }
+  }, [filtered, selectedIds, refreshCounts])
+
+  const handleBatchApprove = useCallback(async () => {
+    if (!batchResult || batchResult.journalEntryIds.length === 0) return
+
+    setBatchProcessing(true)
+    setActionError(null)
+    const approver = user?.email ?? user?.display_name ?? 'unknown'
+
+    let approved = 0
+    let failed = 0
+
+    for (const id of batchResult.journalEntryIds) {
+      try {
+        await invoke('approve_journal_entry', { id, approver })
+        approved++
+      } catch {
+        failed++
+      }
+    }
+
+    refreshCounts()
+    setBatchProcessing(false)
+    setBatchResult(prev =>
+      prev
+        ? {
+            ...prev,
+            journalEntryIds: [],
+          }
+        : null
+    )
+
+    if (failed > 0) {
+      setActionError(
+        `${failed} journal entr${failed !== 1 ? 'ies' : 'y'} failed to approve`
+      )
+    } else {
+      setActionError(null)
+    }
+
+    setBatchResult(prev =>
+      prev
+        ? {
+            ...prev,
+            classified: 0,
+            journalEntryIds: [],
+          }
+        : null
+    )
+  }, [batchResult, user, refreshCounts])
+
+  const handleDismissBatchResult = useCallback(() => {
+    setBatchResult(null)
+  }, [])
 
   const handleAutoClassify = useCallback(
     async (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -339,7 +609,6 @@ const ClassificationQueue: React.FC = () => {
 
   const handleDrawerSaved = useCallback(() => {
     setDrawerTx(null)
-    // Remove the classified transaction from the local list
     setTransactions(prev => prev.filter(t => t.id !== drawerTx?.id))
     refreshCounts()
   }, [drawerTx, refreshCounts])
@@ -420,17 +689,184 @@ const ClassificationQueue: React.FC = () => {
         </div>
       )}
 
-      {/* Search */}
-      <div className="mb-6 relative max-w-md">
-        <Search className="absolute right-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-[#647D8B]" />
-        <input
-          type="text"
-          placeholder="Search by hash, chain, type, address..."
-          value={searchQuery}
-          onChange={handleSearchChange}
-          className="w-full pl-4 pr-10 py-2 border border-[rgba(95,227,192,0.15)] rounded-lg bg-[#F7FAFA] dark:bg-[#11202B] text-[#11202B] dark:text-[#EAF3F2] placeholder-[#647D8B] dark:placeholder-[#294050] focus:outline-none focus:ring-2 focus:ring-[#5FE3C0] focus:border-[#5FE3C0]"
-        />
+      {/* Batch result banner */}
+      {batchResult !== null &&
+        (batchResult.classified > 0 || batchResult.skipped > 0) && (
+          <div className="mb-4 p-4 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800">
+            <div className="flex items-center justify-between">
+              <div className="text-sm text-emerald-800 dark:text-emerald-300">
+                {batchResult.classified > 0 && (
+                  <span>
+                    {batchResult.classified} transaction
+                    {batchResult.classified !== 1 ? 's' : ''} classified into
+                    draft journal{' '}
+                    {batchResult.classified !== 1 ? 'entries' : 'entry'}.
+                  </span>
+                )}
+                {batchResult.skipped > 0 && (
+                  <span>
+                    {batchResult.skipped} transaction
+                    {batchResult.skipped !== 1 ? 's' : ''} skipped.
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {batchResult.journalEntryIds.length > 0 && (
+                  <button
+                    onClick={handleBatchApprove}
+                    disabled={batchProcessing}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                  >
+                    <ShieldCheck className="w-4 h-4" />
+                    Approve {batchResult.journalEntryIds.length} Draft
+                    {batchResult.journalEntryIds.length !== 1 ? 's' : ''}
+                  </button>
+                )}
+                <button
+                  onClick={() => navigate('/journal-entries?filter=draft')}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-900/40 transition-colors"
+                >
+                  View Drafts
+                  <ArrowRight className="w-3.5 h-3.5" />
+                </button>
+                <button
+                  onClick={handleDismissBatchResult}
+                  className="text-emerald-500 hover:text-emerald-700 dark:hover:text-emerald-200 text-sm font-medium"
+                >
+                  Dismiss
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+      {/* Search + filter row */}
+      <div className="mb-6 flex items-center gap-3">
+        <div className="relative flex-1 max-w-md">
+          <Search className="absolute right-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-[#647D8B]" />
+          <input
+            type="text"
+            placeholder="Search by hash, chain, type, address..."
+            value={searchQuery}
+            onChange={handleSearchChange}
+            className="w-full pl-4 pr-10 py-2 border border-[rgba(95,227,192,0.15)] rounded-lg bg-[#F7FAFA] dark:bg-[#11202B] text-[#11202B] dark:text-[#EAF3F2] placeholder-[#647D8B] dark:placeholder-[#294050] focus:outline-none focus:ring-2 focus:ring-[#5FE3C0] focus:border-[#5FE3C0]"
+          />
+        </div>
+        {filtered.length > 0 && (
+          <div className="relative">
+            <button
+              onClick={() => setFilterMenuOpen(prev => !prev)}
+              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm border border-[rgba(95,227,192,0.15)] rounded-lg bg-[#F7FAFA] dark:bg-[#11202B] text-[#294050] dark:text-[#9FB4BE] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F] transition-colors"
+            >
+              <Filter className="w-4 h-4" />
+              Select by...
+            </button>
+            {filterMenuOpen && (
+              <>
+                <div
+                  className="fixed inset-0 z-40"
+                  onClick={() => setFilterMenuOpen(false)}
+                />
+                <div className="absolute right-0 top-full mt-1 z-50 w-56 bg-[#F7FAFA] dark:bg-[#11202B] border border-[rgba(95,227,192,0.15)] rounded-lg shadow-lg py-1">
+                  {uniqueChains.length > 1 && (
+                    <>
+                      <div className="px-3 py-1.5 text-xs font-medium text-[#647D8B] uppercase tracking-wider">
+                        By Chain
+                      </div>
+                      {uniqueChains.map(chain => (
+                        <button
+                          key={chain}
+                          onClick={() => handleSelectByChain(chain)}
+                          className="w-full text-left px-3 py-1.5 text-sm text-[#11202B] dark:text-[#EAF3F2] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F]"
+                        >
+                          {chain} (
+                          {filtered.filter(tx => tx.chainId === chain).length})
+                        </button>
+                      ))}
+                    </>
+                  )}
+                  {uniqueTypes.length > 1 && (
+                    <>
+                      <div className="px-3 py-1.5 text-xs font-medium text-[#647D8B] uppercase tracking-wider border-t border-[rgba(95,227,192,0.1)] mt-1">
+                        By Type
+                      </div>
+                      {uniqueTypes.map(txType => (
+                        <button
+                          key={txType}
+                          onClick={() => handleSelectByType(txType)}
+                          className="w-full text-left px-3 py-1.5 text-sm text-[#11202B] dark:text-[#EAF3F2] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F]"
+                        >
+                          {displayTxType(txType)} (
+                          {
+                            filtered.filter(tx => tx.transactionType === txType)
+                              .length
+                          }
+                          )
+                        </button>
+                      ))}
+                    </>
+                  )}
+                </div>
+              </>
+            )}
+          </div>
+        )}
       </div>
+
+      {/* Batch action toolbar */}
+      {selectedCount > 0 && (
+        <div className="mb-4 flex items-center justify-between p-3 rounded-lg bg-[#294050]/5 dark:bg-[#294050]/20 border border-[rgba(95,227,192,0.15)]">
+          <span className="text-sm font-medium text-[#11202B] dark:text-[#EAF3F2]">
+            {selectedCount} selected
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleBatchAutoClassify}
+              disabled={batchProcessing}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-[#5FE3C0]/15 text-[#294050] dark:text-[#5FE3C0] hover:bg-[#5FE3C0]/25 disabled:opacity-50 transition-colors"
+            >
+              <Zap className="w-4 h-4" />
+              Auto-classify {selectedCount}
+            </button>
+            <button
+              onClick={handleBatchSkip}
+              disabled={batchProcessing}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-gray-100 text-gray-700 dark:bg-gray-800/50 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700/50 disabled:opacity-50 transition-colors"
+            >
+              <EyeOff className="w-4 h-4" />
+              Skip {selectedCount}
+            </button>
+            <button
+              onClick={handleClearSelection}
+              className="px-3 py-1.5 text-sm text-[#647D8B] hover:text-[#11202B] dark:hover:text-[#EAF3F2] transition-colors"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Batch progress bar */}
+      {batchProgress !== null && (
+        <div className="mb-4">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-xs text-[#294050] dark:text-[#9FB4BE]">
+              Processing {batchProgress.done} of {batchProgress.total}...
+            </span>
+            <span className="text-xs font-mono text-[#647D8B]">
+              {Math.round((batchProgress.done / batchProgress.total) * 100)}%
+            </span>
+          </div>
+          <div className="h-1.5 bg-[#294050]/10 dark:bg-[#294050]/20 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-[#5FE3C0] rounded-full transition-all duration-300"
+              style={{
+                width: `${(batchProgress.done / batchProgress.total) * 100}%`,
+              }}
+            />
+          </div>
+        </div>
+      )}
 
       {/* Count summary */}
       <div className="mb-4 text-sm text-[#294050] dark:text-[#9FB4BE]">
@@ -478,14 +914,20 @@ const ClassificationQueue: React.FC = () => {
           <div className="overflow-x-auto">
             <table className="w-full">
               <thead className="bg-[#EAF3F2] dark:bg-[#11202B] border-b border-[rgba(95,227,192,0.15)]">
-                <QueueHeaderRow />
+                <QueueHeaderRow
+                  allSelected={allFilteredSelected}
+                  someSelected={someFilteredSelected}
+                  onToggleAll={handleToggleAll}
+                />
               </thead>
               <tbody className="divide-y divide-[rgba(95,227,192,0.1)]">
                 {filtered.map(tx => (
                   <QueueRow
                     key={tx.id}
                     tx={tx}
-                    busy={processingId === tx.id}
+                    selected={selectedIds.has(tx.id)}
+                    busy={processingId === tx.id || batchProcessing}
+                    onToggleSelect={handleToggleSelect}
                     onAutoClassify={handleAutoClassify}
                     onManualClassify={handleManualClassify}
                     onIgnore={handleIgnoreClick}
@@ -497,13 +939,31 @@ const ClassificationQueue: React.FC = () => {
         </div>
       ) : (
         <div className="text-center py-12 bg-[#F7FAFA] dark:bg-[#0C141B] rounded-lg border border-[rgba(95,227,192,0.15)]">
-          <Inbox className="mx-auto h-12 w-12 text-[#647D8B]" />
-          <h3 className="mt-2 text-sm font-medium text-[#11202B] dark:text-[#EAF3F2]">
-            No unclassified transactions
+          <Inbox className="mx-auto h-12 w-12 text-[#5FE3C0]" />
+          <h3 className="mt-3 text-lg font-medium text-[#11202B] dark:text-[#EAF3F2]">
+            All caught up
           </h3>
-          <p className="mt-1 text-sm text-[#294050] dark:text-[#9FB4BE]">
-            All raw transactions have been classified or ignored.
+          <p className="mt-1 text-sm text-[#294050] dark:text-[#9FB4BE] max-w-sm mx-auto">
+            Every raw transaction has been classified or skipped. Your next step
+            is to review and approve draft journal entries, then view your trial
+            balance.
           </p>
+          <div className="mt-5 flex items-center justify-center gap-3">
+            <button
+              onClick={() => navigate('/journal-entries?filter=draft')}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#294050] text-white hover:bg-[#1E2F3C] transition-colors text-sm font-medium"
+            >
+              <ShieldCheck className="w-4 h-4" />
+              Review Drafts
+            </button>
+            <button
+              onClick={() => navigate('/reports')}
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[rgba(95,227,192,0.15)] text-[#294050] dark:text-[#9FB4BE] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F] transition-colors text-sm font-medium"
+            >
+              <BarChart3 className="w-4 h-4" />
+              View Trial Balance
+            </button>
+          </div>
         </div>
       )}
 
@@ -519,7 +979,7 @@ const ClassificationQueue: React.FC = () => {
         />
       )}
 
-      {/* Manual classification drawer (Phase 3 JournalEntryDrawer) */}
+      {/* Manual classification drawer */}
       {drawerTx !== null && (
         <JournalEntryDrawer
           accounts={accounts}

--- a/src/app/classification/ClassificationQueue.tsx
+++ b/src/app/classification/ClassificationQueue.tsx
@@ -47,6 +47,7 @@ interface BatchResult {
 const HEADER_CELL =
   'px-4 py-3 text-xs font-medium text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider'
 
+/** @returns Header row with select-all checkbox for the classification queue table. */
 const QueueHeaderRow: React.FC<{
   allSelected: boolean
   someSelected: boolean
@@ -90,6 +91,7 @@ interface QueueRowProps {
   onIgnore: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
+/** @returns Single transaction row with action buttons (auto, manual, skip). */
 const QueueRow: React.FC<QueueRowProps> = ({
   tx,
   selected,
@@ -207,6 +209,7 @@ interface IgnoreDialogProps {
   onCancel: () => void
 }
 
+/** @returns Confirmation modal for skipping/ignoring a transaction. */
 const IgnoreDialog: React.FC<IgnoreDialogProps> = ({
   hash,
   reason,
@@ -251,6 +254,108 @@ const IgnoreDialog: React.FC<IgnoreDialogProps> = ({
   </div>
 )
 
+interface BatchResultBannerProps {
+  result: BatchResult
+  processing: boolean
+  onApprove: () => void
+  onNavigateDrafts: () => void
+  onDismiss: () => void
+}
+
+/** @returns Success banner after batch classify/skip with approve + navigate actions. */
+const BatchResultBanner: React.FC<BatchResultBannerProps> = ({
+  result,
+  processing,
+  onApprove,
+  onNavigateDrafts,
+  onDismiss,
+}) => {
+  if (result.classified === 0 && result.skipped === 0) return null
+  return (
+    <div className="mb-4 p-4 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800">
+      <div className="flex items-center justify-between">
+        <div className="text-sm text-emerald-800 dark:text-emerald-300">
+          {result.classified > 0 && (
+            <span>
+              {result.classified} transaction
+              {result.classified !== 1 ? 's' : ''} classified into draft journal{' '}
+              {result.classified !== 1 ? 'entries' : 'entry'}.
+            </span>
+          )}
+          {result.skipped > 0 && (
+            <span>
+              {result.skipped} transaction
+              {result.skipped !== 1 ? 's' : ''} skipped.
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {result.journalEntryIds.length > 0 && (
+            <button
+              onClick={onApprove}
+              disabled={processing}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              <ShieldCheck className="w-4 h-4" />
+              Approve {result.journalEntryIds.length} Draft
+              {result.journalEntryIds.length !== 1 ? 's' : ''}
+            </button>
+          )}
+          <button
+            onClick={onNavigateDrafts}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-900/40 transition-colors"
+          >
+            View Drafts
+            <ArrowRight className="w-3.5 h-3.5" />
+          </button>
+          <button
+            onClick={onDismiss}
+            className="text-emerald-500 hover:text-emerald-700 dark:hover:text-emerald-200 text-sm font-medium"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** @returns Inline summary of priced/unpriced/unavailable counts. */
+const ValuationSummary: React.FC<{ transactions: RawTransaction[] }> = ({
+  transactions,
+}) => {
+  const priced = transactions.filter(
+    t => t.valuationStatus === 'priced'
+  ).length
+  const unpriced = transactions.filter(
+    t => t.valuationStatus === 'unpriced'
+  ).length
+  const unavail = transactions.filter(
+    t => t.valuationStatus === 'unavailable'
+  ).length
+  return (
+    <span className="ml-2">
+      ({priced} priced
+      {unpriced > 0 && (
+        <>
+          ,{' '}
+          <span className="text-[#647D8B]">{unpriced} awaiting prices</span>
+        </>
+      )}
+      {unavail > 0 && (
+        <>
+          ,{' '}
+          <span className="text-amber-600 dark:text-amber-400">
+            {unavail} price unavailable
+          </span>
+        </>
+      )}
+      )
+    </span>
+  )
+}
+
+/** @returns Main classification queue page with batch operations and filtering. */
 const ClassificationQueue: React.FC = () => {
   const navigate = useNavigate()
   const { refreshCounts } = useNavBadges()
@@ -714,55 +819,15 @@ const ClassificationQueue: React.FC = () => {
       )}
 
       {/* Batch result banner */}
-      {batchResult !== null &&
-        (batchResult.classified > 0 || batchResult.skipped > 0) && (
-          <div className="mb-4 p-4 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800">
-            <div className="flex items-center justify-between">
-              <div className="text-sm text-emerald-800 dark:text-emerald-300">
-                {batchResult.classified > 0 && (
-                  <span>
-                    {batchResult.classified} transaction
-                    {batchResult.classified !== 1 ? 's' : ''} classified into
-                    draft journal{' '}
-                    {batchResult.classified !== 1 ? 'entries' : 'entry'}.
-                  </span>
-                )}
-                {batchResult.skipped > 0 && (
-                  <span>
-                    {batchResult.skipped} transaction
-                    {batchResult.skipped !== 1 ? 's' : ''} skipped.
-                  </span>
-                )}
-              </div>
-              <div className="flex items-center gap-2">
-                {batchResult.journalEntryIds.length > 0 && (
-                  <button
-                    onClick={handleBatchApprove}
-                    disabled={batchProcessing}
-                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors"
-                  >
-                    <ShieldCheck className="w-4 h-4" />
-                    Approve {batchResult.journalEntryIds.length} Draft
-                    {batchResult.journalEntryIds.length !== 1 ? 's' : ''}
-                  </button>
-                )}
-                <button
-                  onClick={handleNavigateToDrafts}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-900/40 transition-colors"
-                >
-                  View Drafts
-                  <ArrowRight className="w-3.5 h-3.5" />
-                </button>
-                <button
-                  onClick={handleDismissBatchResult}
-                  className="text-emerald-500 hover:text-emerald-700 dark:hover:text-emerald-200 text-sm font-medium"
-                >
-                  Dismiss
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
+      {batchResult !== null && (
+        <BatchResultBanner
+          result={batchResult}
+          processing={batchProcessing}
+          onApprove={handleBatchApprove}
+          onNavigateDrafts={handleNavigateToDrafts}
+          onDismiss={handleDismissBatchResult}
+        />
+      )}
 
       {/* Search + filter row */}
       <div className="mb-6 flex items-center gap-3">
@@ -898,40 +963,9 @@ const ClassificationQueue: React.FC = () => {
       <div className="mb-4 text-sm text-[#294050] dark:text-[#9FB4BE]">
         {filtered.length} unclassified transaction
         {filtered.length !== 1 ? 's' : ''}
-        {filtered.length > 0 &&
-          (() => {
-            const priced = filtered.filter(
-              t => t.valuationStatus === 'priced'
-            ).length
-            const unpriced = filtered.filter(
-              t => t.valuationStatus === 'unpriced'
-            ).length
-            const unavail = filtered.filter(
-              t => t.valuationStatus === 'unavailable'
-            ).length
-            return (
-              <span className="ml-2">
-                ({priced} priced
-                {unpriced > 0 && (
-                  <>
-                    ,{' '}
-                    <span className="text-[#647D8B]">
-                      {unpriced} awaiting prices
-                    </span>
-                  </>
-                )}
-                {unavail > 0 && (
-                  <>
-                    ,{' '}
-                    <span className="text-amber-600 dark:text-amber-400">
-                      {unavail} price unavailable
-                    </span>
-                  </>
-                )}
-                )
-              </span>
-            )
-          })()}
+        {filtered.length > 0 && (
+          <ValuationSummary transactions={filtered} />
+        )}
       </div>
 
       {/* Table */}

--- a/src/app/classification/ClassificationQueue.tsx
+++ b/src/app/classification/ClassificationQueue.tsx
@@ -84,7 +84,7 @@ interface QueueRowProps {
   tx: RawTransaction
   selected: boolean
   busy: boolean
-  onToggleSelect: (id: string) => void
+  onToggleSelect: (event: React.MouseEvent<HTMLButtonElement>) => void
   onAutoClassify: (event: React.MouseEvent<HTMLButtonElement>) => void
   onManualClassify: (event: React.MouseEvent<HTMLButtonElement>) => void
   onIgnore: (event: React.MouseEvent<HTMLButtonElement>) => void
@@ -104,7 +104,8 @@ const QueueRow: React.FC<QueueRowProps> = ({
   >
     <td className="px-4 py-3 text-center">
       <button
-        onClick={() => onToggleSelect(tx.id)}
+        data-txid={tx.id}
+        onClick={onToggleSelect}
         className="p-0.5 hover:bg-[#294050]/10 rounded transition-colors"
       >
         {selected ? (
@@ -356,17 +357,24 @@ const ClassificationQueue: React.FC = () => {
     })
   }, [filtered])
 
-  const handleToggleSelect = useCallback((id: string) => {
-    setSelectedIds(prev => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }, [])
+  const handleToggleSelect = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const id = event.currentTarget.dataset.txid
+      if (!id) return
+      setSelectedIds(prev => {
+        const next = new Set(prev)
+        if (next.has(id)) next.delete(id)
+        else next.add(id)
+        return next
+      })
+    },
+    []
+  )
 
   const handleSelectByChain = useCallback(
-    (chain: string) => {
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const chain = event.currentTarget.dataset.chain
+      if (!chain) return
       setSelectedIds(prev => {
         const next = new Set(prev)
         filtered
@@ -380,7 +388,9 @@ const ClassificationQueue: React.FC = () => {
   )
 
   const handleSelectByType = useCallback(
-    (txType: string) => {
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const txType = event.currentTarget.dataset.txtype
+      if (!txType) return
       setSelectedIds(prev => {
         const next = new Set(prev)
         filtered
@@ -533,6 +543,22 @@ const ClassificationQueue: React.FC = () => {
 
   const handleDismissBatchResult = useCallback(() => {
     setBatchResult(null)
+  }, [])
+
+  const handleNavigateToDrafts = useCallback(() => {
+    navigate('/journal-entries?filter=draft')
+  }, [navigate])
+
+  const handleNavigateToReports = useCallback(() => {
+    navigate('/reports')
+  }, [navigate])
+
+  const handleToggleFilterMenu = useCallback(() => {
+    setFilterMenuOpen(prev => !prev)
+  }, [])
+
+  const handleCloseFilterMenu = useCallback(() => {
+    setFilterMenuOpen(false)
   }, [])
 
   const handleAutoClassify = useCallback(
@@ -721,7 +747,7 @@ const ClassificationQueue: React.FC = () => {
                   </button>
                 )}
                 <button
-                  onClick={() => navigate('/journal-entries?filter=draft')}
+                  onClick={handleNavigateToDrafts}
                   className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg border border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-900/40 transition-colors"
                 >
                   View Drafts
@@ -753,7 +779,7 @@ const ClassificationQueue: React.FC = () => {
         {filtered.length > 0 && (
           <div className="relative">
             <button
-              onClick={() => setFilterMenuOpen(prev => !prev)}
+              onClick={handleToggleFilterMenu}
               className="inline-flex items-center gap-1.5 px-3 py-2 text-sm border border-[rgba(95,227,192,0.15)] rounded-lg bg-[#F7FAFA] dark:bg-[#11202B] text-[#294050] dark:text-[#9FB4BE] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F] transition-colors"
             >
               <Filter className="w-4 h-4" />
@@ -763,7 +789,7 @@ const ClassificationQueue: React.FC = () => {
               <>
                 <div
                   className="fixed inset-0 z-40"
-                  onClick={() => setFilterMenuOpen(false)}
+                  onClick={handleCloseFilterMenu}
                 />
                 <div className="absolute right-0 top-full mt-1 z-50 w-56 bg-[#F7FAFA] dark:bg-[#11202B] border border-[rgba(95,227,192,0.15)] rounded-lg shadow-lg py-1">
                   {uniqueChains.length > 1 && (
@@ -774,7 +800,8 @@ const ClassificationQueue: React.FC = () => {
                       {uniqueChains.map(chain => (
                         <button
                           key={chain}
-                          onClick={() => handleSelectByChain(chain)}
+                          data-chain={chain}
+                          onClick={handleSelectByChain}
                           className="w-full text-left px-3 py-1.5 text-sm text-[#11202B] dark:text-[#EAF3F2] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F]"
                         >
                           {chain} (
@@ -791,7 +818,8 @@ const ClassificationQueue: React.FC = () => {
                       {uniqueTypes.map(txType => (
                         <button
                           key={txType}
-                          onClick={() => handleSelectByType(txType)}
+                          data-txtype={txType}
+                          onClick={handleSelectByType}
                           className="w-full text-left px-3 py-1.5 text-sm text-[#11202B] dark:text-[#EAF3F2] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F]"
                         >
                           {displayTxType(txType)} (
@@ -948,14 +976,14 @@ const ClassificationQueue: React.FC = () => {
           </p>
           <div className="mt-5 flex items-center justify-center gap-3">
             <button
-              onClick={() => navigate('/journal-entries?filter=draft')}
+              onClick={handleNavigateToDrafts}
               className="inline-flex items-center gap-2 px-4 py-2 rounded-lg bg-[#294050] text-white hover:bg-[#1E2F3C] transition-colors text-sm font-medium"
             >
               <ShieldCheck className="w-4 h-4" />
               Review Drafts
             </button>
             <button
-              onClick={() => navigate('/reports')}
+              onClick={handleNavigateToReports}
               className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-[rgba(95,227,192,0.15)] text-[#294050] dark:text-[#9FB4BE] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F] transition-colors text-sm font-medium"
             >
               <BarChart3 className="w-4 h-4" />

--- a/src/app/classification/ClassificationQueue.tsx
+++ b/src/app/classification/ClassificationQueue.tsx
@@ -324,9 +324,7 @@ const BatchResultBanner: React.FC<BatchResultBannerProps> = ({
 const ValuationSummary: React.FC<{ transactions: RawTransaction[] }> = ({
   transactions,
 }) => {
-  const priced = transactions.filter(
-    t => t.valuationStatus === 'priced'
-  ).length
+  const priced = transactions.filter(t => t.valuationStatus === 'priced').length
   const unpriced = transactions.filter(
     t => t.valuationStatus === 'unpriced'
   ).length
@@ -338,8 +336,7 @@ const ValuationSummary: React.FC<{ transactions: RawTransaction[] }> = ({
       ({priced} priced
       {unpriced > 0 && (
         <>
-          ,{' '}
-          <span className="text-[#647D8B]">{unpriced} awaiting prices</span>
+          , <span className="text-[#647D8B]">{unpriced} awaiting prices</span>
         </>
       )}
       {unavail > 0 && (
@@ -963,9 +960,7 @@ const ClassificationQueue: React.FC = () => {
       <div className="mb-4 text-sm text-[#294050] dark:text-[#9FB4BE]">
         {filtered.length} unclassified transaction
         {filtered.length !== 1 ? 's' : ''}
-        {filtered.length > 0 && (
-          <ValuationSummary transactions={filtered} />
-        )}
+        {filtered.length > 0 && <ValuationSummary transactions={filtered} />}
       </div>
 
       {/* Table */}

--- a/src/app/classification/ClassificationQueue.tsx
+++ b/src/app/classification/ClassificationQueue.tsx
@@ -491,13 +491,13 @@ const ClassificationQueue: React.FC = () => {
     setActionError(null)
     const approver = user?.email ?? user?.display_name ?? 'unknown'
 
-    let approved = 0
+    let approvedCount = 0
     let failed = 0
 
     for (const id of batchResult.journalEntryIds) {
       try {
         await invoke('approve_journal_entry', { id, approver })
-        approved++
+        approvedCount++
       } catch {
         failed++
       }
@@ -516,7 +516,7 @@ const ClassificationQueue: React.FC = () => {
 
     if (failed > 0) {
       setActionError(
-        `${failed} journal entr${failed !== 1 ? 'ies' : 'y'} failed to approve`
+        `${approvedCount} approved, ${failed} failed`
       )
     } else {
       setActionError(null)

--- a/src/app/classification/ClassificationQueue.tsx
+++ b/src/app/classification/ClassificationQueue.tsx
@@ -515,9 +515,7 @@ const ClassificationQueue: React.FC = () => {
     )
 
     if (failed > 0) {
-      setActionError(
-        `${approvedCount} approved, ${failed} failed`
-      )
+      setActionError(`${approvedCount} approved, ${failed} failed`)
     } else {
       setActionError(null)
     }

--- a/src/app/classification/__tests__/classificationUtils.test.ts
+++ b/src/app/classification/__tests__/classificationUtils.test.ts
@@ -5,6 +5,7 @@ import {
   truncateHash,
   displayTxType,
   txTypeLabels,
+  rulePreview,
 } from '../classificationUtils'
 
 describe('formatTimestamp', () => {
@@ -94,5 +95,19 @@ describe('txTypeLabels', () => {
     for (const t of expectedTypes) {
       expect(txTypeLabels[t]).toBeDefined()
     }
+  })
+})
+
+describe('rulePreview', () => {
+  it('should return rule description for known tx types', () => {
+    expect(rulePreview('claim')).toContain('Staking reward')
+    expect(rulePreview('stake')).toContain('Staking reward')
+    expect(rulePreview('transfer')).toContain('Transfer')
+    expect(rulePreview('swap')).toContain('swap')
+    expect(rulePreview('approve')).toContain('approval')
+  })
+
+  it('should return generic description for unknown types', () => {
+    expect(rulePreview('some_new_type')).toContain('Heuristic')
   })
 })

--- a/src/app/classification/classificationUtils.ts
+++ b/src/app/classification/classificationUtils.ts
@@ -33,3 +33,20 @@ export const txTypeLabels: Record<string, string> = {
 export function displayTxType(txType: string): string {
   return txTypeLabels[txType] ?? txType
 }
+
+const ruleDescriptions: Record<string, string> = {
+  claim: 'Staking reward → DR Crypto Assets / CR Staking Income',
+  stake: 'Staking reward → DR Crypto Assets / CR Staking Income',
+  transfer: 'Transfer → self-transfer detection or external income',
+  swap: 'Token swap → DR new asset / CR disposed asset',
+  bridge: 'Bridge transfer → inter-chain rebalance',
+  unstake: 'Unstake → return of staked principal',
+  mint: 'Mint → DR Crypto Assets / CR Income',
+  burn: 'Burn → DR Expense / CR Crypto Assets',
+  approve: 'Contract approval → fee-only entry',
+  contract_call: 'Contract interaction → fee-only entry',
+}
+
+export function rulePreview(txType: string): string {
+  return ruleDescriptions[txType] ?? 'Heuristic classification based on tx type'
+}

--- a/src/app/classification/classificationUtils.ts
+++ b/src/app/classification/classificationUtils.ts
@@ -47,6 +47,7 @@ const ruleDescriptions: Record<string, string> = {
   contract_call: 'Contract interaction → fee-only entry',
 }
 
+/** @returns Short description of the classification heuristic for a given tx type. */
 export function rulePreview(txType: string): string {
   return ruleDescriptions[txType] ?? 'Heuristic classification based on tx type'
 }

--- a/src/app/journal-entries/JournalEntries.tsx
+++ b/src/app/journal-entries/JournalEntries.tsx
@@ -188,16 +188,23 @@ const JournalEntries: React.FC = () => {
   }, [entries, searchQuery, filterParam])
 
   const handleTabChange = useCallback(
-    (tab: StatusFilter) => {
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const tab = event.currentTarget.dataset.tab as StatusFilter | undefined
+      if (!tab) return
       setSearchParams({ filter: tab })
       setSelectedIds(new Set())
     },
     [setSearchParams]
   )
 
-  const handleToggleExpand = useCallback((id: number) => {
-    setExpandedId(prev => (prev === id ? null : id))
-  }, [])
+  const handleToggleExpand = useCallback(
+    (event: React.MouseEvent<HTMLTableRowElement>) => {
+      const id = Number(event.currentTarget.dataset.entryid)
+      if (Number.isNaN(id)) return
+      setExpandedId(prev => (prev === id ? null : id))
+    },
+    []
+  )
 
   // skipcq: JS-W1042 — undefined is the required value (React setState), not a trailing optional
   const clearEditingEntry = useCallback(() => setEditingEntry(undefined), [])
@@ -224,22 +231,27 @@ const JournalEntries: React.FC = () => {
     refreshCounts()
   }, [clearEditingEntry, fetchEntries, refreshCounts])
 
-  const handleViewDetail = useCallback((entry: JournalEntryWithLines) => {
-    setDetailEntry(entry)
-  }, [])
+  const handleViewDetail = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const id = Number(event.currentTarget.dataset.entryid)
+      if (Number.isNaN(id)) return
+      const entry = entries.find(e => e.id === id)
+      if (entry) setDetailEntry(entry)
+    },
+    [entries]
+  )
 
   const handleCloseDetail = useCallback(() => {
     // skipcq: JS-W1042 — undefined is the required value (React setState), not a trailing optional
     setDetailEntry(undefined)
   }, [])
 
-  /** Approve a draft entry */
   const handleApprove = useCallback(
-    async (id: number) => {
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      const id = Number(event.currentTarget.dataset.entryid)
+      if (Number.isNaN(id)) return
       setActionError(null)
       try {
-        // Record the real approver identity (Inv-7 provenance), not a
-        // placeholder string.
         await invoke('approve_journal_entry', {
           id,
           approver: user?.email ?? user?.display_name ?? 'unknown',
@@ -254,9 +266,10 @@ const JournalEntries: React.FC = () => {
     [fetchEntries, refreshCounts, user]
   )
 
-  /** Post an approved entry */
   const handlePost = useCallback(
-    async (id: number) => {
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      const id = Number(event.currentTarget.dataset.entryid)
+      if (Number.isNaN(id)) return
       setActionError(null)
       try {
         await invoke('post_journal_entry', { id })
@@ -270,7 +283,6 @@ const JournalEntries: React.FC = () => {
     [fetchEntries, refreshCounts]
   )
 
-  /** Void a posted entry (with confirmation) */
   const handleVoid = useCallback(
     async (id: number) => {
       setActionError(null)
@@ -295,12 +307,14 @@ const JournalEntries: React.FC = () => {
    * approved entry.)
    */
   const handleDemote = useCallback(
-    async (entry: JournalEntryWithLines) => {
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      const id = Number(event.currentTarget.dataset.entryid)
+      if (Number.isNaN(id)) return
       setActionError(null)
       try {
         const demoted = await invoke<JournalEntryWithLines>(
           'demote_journal_entry',
-          { id: entry.id }
+          { id }
         )
         fetchEntries()
         refreshCounts()
@@ -316,6 +330,25 @@ const JournalEntries: React.FC = () => {
   const handleDismissError = useCallback(() => setActionError(null), [])
 
   const handleDismissVoidConfirm = useCallback(() => setVoidConfirmId(null), [])
+
+  const handleStopPropagation = useCallback(
+    (event: React.MouseEvent<HTMLTableCellElement | HTMLDivElement>) => {
+      event.stopPropagation()
+    },
+    []
+  )
+
+  const handleVoidClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const id = Number(event.currentTarget.dataset.entryid)
+      if (!Number.isNaN(id)) setVoidConfirmId(id)
+    },
+    []
+  )
+
+  const handleConfirmVoid = useCallback(() => {
+    if (voidConfirmId !== null) handleVoid(voidConfirmId)
+  }, [voidConfirmId, handleVoid])
 
   const selectableEntries = useMemo(
     () =>
@@ -364,14 +397,19 @@ const JournalEntries: React.FC = () => {
     })
   }, [selectableEntries])
 
-  const handleToggleSelect = useCallback((id: number) => {
-    setSelectedIds(prev => {
-      const next = new Set(prev)
-      if (next.has(id)) next.delete(id)
-      else next.add(id)
-      return next
-    })
-  }, [])
+  const handleToggleSelect = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const id = Number(event.currentTarget.dataset.entryid)
+      if (Number.isNaN(id)) return
+      setSelectedIds(prev => {
+        const next = new Set(prev)
+        if (next.has(id)) next.delete(id)
+        else next.add(id)
+        return next
+      })
+    },
+    []
+  )
 
   const handleClearSelection = useCallback(() => setSelectedIds(new Set()), [])
 
@@ -479,7 +517,7 @@ const JournalEntries: React.FC = () => {
           <button
             key={tab.key}
             data-tab={tab.key}
-            onClick={() => handleTabChange(tab.key)}
+            onClick={handleTabChange}
             className={`px-4 py-2 text-sm font-medium transition-colors border-b-2 -mb-px ${
               filterParam === tab.key
                 ? 'border-[#294050] text-[#294050] dark:text-[#5FE3C0]'
@@ -520,7 +558,7 @@ const JournalEntries: React.FC = () => {
               Cancel
             </button>
             <button
-              onClick={() => handleVoid(voidConfirmId)}
+              onClick={handleConfirmVoid}
               className="px-3 py-1 text-xs font-medium rounded bg-red-600 text-white hover:bg-red-700 transition-colors"
             >
               Void Entry
@@ -663,16 +701,18 @@ const JournalEntries: React.FC = () => {
                 return (
                   <React.Fragment key={entry.id}>
                     <tr
+                      data-entryid={entry.id}
                       className={`bg-white dark:bg-[#11202B] hover:bg-[#EAF3F2]/50 dark:hover:bg-[#16242F]/50 cursor-pointer transition-colors ${selectedIds.has(entry.id) ? 'bg-[#5FE3C0]/5 dark:bg-[#5FE3C0]/5' : ''}`}
-                      onClick={() => handleToggleExpand(entry.id)}
+                      onClick={handleToggleExpand}
                     >
                       <td
                         className="px-4 py-3 text-center"
-                        onClick={e => e.stopPropagation()}
+                        onClick={handleStopPropagation}
                       >
                         {(status === 'draft' || status === 'approved') && (
                           <button
-                            onClick={() => handleToggleSelect(entry.id)}
+                            data-entryid={entry.id}
+                            onClick={handleToggleSelect}
                             className="p-0.5 hover:bg-[#294050]/10 rounded transition-colors"
                           >
                             {selectedIds.has(entry.id) ? (
@@ -714,46 +754,47 @@ const JournalEntries: React.FC = () => {
                       <td className="px-4 py-3 text-right">
                         <div
                           className="flex items-center justify-end gap-2"
-                          onClick={e => e.stopPropagation()}
+                          onClick={handleStopPropagation}
                         >
-                          {/* Draft actions: Approve */}
                           {status === 'draft' && (
                             <button
-                              onClick={() => handleApprove(entry.id)}
+                              data-entryid={entry.id}
+                              onClick={handleApprove}
                               className="px-2 py-1 text-xs font-medium rounded bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-900/50 transition-colors"
                             >
                               Approve
                             </button>
                           )}
-                          {/* Approved actions: Post, Demote */}
                           {status === 'approved' && (
                             <>
                               <button
-                                onClick={() => handlePost(entry.id)}
+                                data-entryid={entry.id}
+                                onClick={handlePost}
                                 className="px-2 py-1 text-xs font-medium rounded bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300 hover:bg-emerald-200 dark:hover:bg-emerald-900/50 transition-colors"
                               >
                                 Post
                               </button>
                               <button
-                                onClick={() => handleDemote(entry)}
+                                data-entryid={entry.id}
+                                onClick={handleDemote}
                                 className="px-2 py-1 text-xs font-medium rounded bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 hover:bg-amber-200 dark:hover:bg-amber-900/50 transition-colors"
                               >
                                 Demote
                               </button>
                             </>
                           )}
-                          {/* Posted actions: Void */}
                           {status === 'posted' && (
                             <button
-                              onClick={() => setVoidConfirmId(entry.id)}
+                              data-entryid={entry.id}
+                              onClick={handleVoidClick}
                               className="px-2 py-1 text-xs font-medium rounded bg-gray-100 text-gray-600 dark:bg-gray-800/50 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700/50 transition-colors"
                             >
                               Void
                             </button>
                           )}
-                          {/* Detail view for all */}
                           <button
-                            onClick={() => handleViewDetail(entry)}
+                            data-entryid={entry.id}
+                            onClick={handleViewDetail}
                             className="px-2 py-1 text-xs font-medium rounded border border-[rgba(95,227,192,0.2)] text-[#294050] dark:text-[#9FB4BE] hover:bg-[#EAF3F2] dark:hover:bg-[#16242F] transition-colors"
                           >
                             Detail

--- a/src/app/journal-entries/JournalEntries.tsx
+++ b/src/app/journal-entries/JournalEntries.tsx
@@ -12,6 +12,10 @@ import {
   ChevronDown,
   ChevronRight,
   Link2,
+  CheckSquare,
+  Square,
+  MinusSquare,
+  Undo2,
 } from 'lucide-react'
 import { useNavBadges } from '../../contexts/NavBadgeContext'
 import { useAuth } from '../../contexts/AuthContext'
@@ -115,6 +119,8 @@ const JournalEntries: React.FC = () => {
     JournalEntryWithLines | undefined
   >()
   const [voidConfirmId, setVoidConfirmId] = useState<number | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const [batchProcessing, setBatchProcessing] = useState(false)
   const { refreshCounts } = useNavBadges()
   const { user } = useAuth()
 
@@ -184,6 +190,7 @@ const JournalEntries: React.FC = () => {
   const handleTabChange = useCallback(
     (tab: StatusFilter) => {
       setSearchParams({ filter: tab })
+      setSelectedIds(new Set())
     },
     [setSearchParams]
   )
@@ -310,6 +317,123 @@ const JournalEntries: React.FC = () => {
 
   const handleDismissVoidConfirm = useCallback(() => setVoidConfirmId(null), [])
 
+  const selectableEntries = useMemo(
+    () =>
+      filteredEntries.filter(
+        e => displayStatus(e) === 'draft' || displayStatus(e) === 'approved'
+      ),
+    [filteredEntries]
+  )
+
+  const draftEntries = useMemo(
+    () => filteredEntries.filter(e => displayStatus(e) === 'draft'),
+    [filteredEntries]
+  )
+
+  const approvedEntries = useMemo(
+    () => filteredEntries.filter(e => displayStatus(e) === 'approved'),
+    [filteredEntries]
+  )
+
+  const selectedDraftCount = draftEntries.filter(e =>
+    selectedIds.has(e.id)
+  ).length
+  const selectedApprovedCount = approvedEntries.filter(e =>
+    selectedIds.has(e.id)
+  ).length
+  const selectedCount = filteredEntries.filter(e =>
+    selectedIds.has(e.id)
+  ).length
+
+  const allSelectableSelected =
+    selectableEntries.length > 0 &&
+    selectableEntries.every(e => selectedIds.has(e.id))
+  const someSelected =
+    selectableEntries.some(e => selectedIds.has(e.id)) && !allSelectableSelected
+
+  const handleToggleSelectAll = useCallback(() => {
+    setSelectedIds(prev => {
+      if (selectableEntries.every(e => prev.has(e.id))) {
+        const next = new Set(prev)
+        selectableEntries.forEach(e => next.delete(e.id))
+        return next
+      }
+      const next = new Set(prev)
+      selectableEntries.forEach(e => next.add(e.id))
+      return next
+    })
+  }, [selectableEntries])
+
+  const handleToggleSelect = useCallback((id: number) => {
+    setSelectedIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const handleClearSelection = useCallback(() => setSelectedIds(new Set()), [])
+
+  const handleBatchApprove = useCallback(async () => {
+    const ids = draftEntries.filter(e => selectedIds.has(e.id)).map(e => e.id)
+    if (ids.length === 0) return
+
+    setBatchProcessing(true)
+    setActionError(null)
+    const approver = user?.email ?? user?.display_name ?? 'unknown'
+
+    let failed = 0
+    for (const id of ids) {
+      try {
+        await invoke('approve_journal_entry', { id, approver })
+      } catch {
+        failed++
+      }
+    }
+
+    setSelectedIds(new Set())
+    setBatchProcessing(false)
+    fetchEntries()
+    refreshCounts()
+
+    if (failed > 0) {
+      setActionError(
+        `${failed} entr${failed !== 1 ? 'ies' : 'y'} failed to approve`
+      )
+    }
+  }, [draftEntries, selectedIds, user, fetchEntries, refreshCounts])
+
+  const handleBatchDemote = useCallback(async () => {
+    const ids = approvedEntries
+      .filter(e => selectedIds.has(e.id))
+      .map(e => e.id)
+    if (ids.length === 0) return
+
+    setBatchProcessing(true)
+    setActionError(null)
+
+    let failed = 0
+    for (const id of ids) {
+      try {
+        await invoke('demote_journal_entry', { id })
+      } catch {
+        failed++
+      }
+    }
+
+    setSelectedIds(new Set())
+    setBatchProcessing(false)
+    fetchEntries()
+    refreshCounts()
+
+    if (failed > 0) {
+      setActionError(
+        `${failed} entr${failed !== 1 ? 'ies' : 'y'} failed to revert`
+      )
+    }
+  }, [approvedEntries, selectedIds, fetchEntries, refreshCounts])
+
   const resolveAccountName = useCallback(
     (glAccountId: number) => {
       const acct = accountMap.get(glAccountId)
@@ -417,6 +541,44 @@ const JournalEntries: React.FC = () => {
         />
       </div>
 
+      {/* Batch action toolbar */}
+      {selectedCount > 0 && (
+        <div className="mb-4 flex items-center justify-between p-3 rounded-lg bg-[#294050]/5 dark:bg-[#294050]/20 border border-[rgba(95,227,192,0.15)]">
+          <span className="text-sm font-medium text-[#11202B] dark:text-[#EAF3F2]">
+            {selectedCount} selected
+          </span>
+          <div className="flex items-center gap-2">
+            {selectedDraftCount > 0 && (
+              <button
+                onClick={handleBatchApprove}
+                disabled={batchProcessing}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-900/50 disabled:opacity-50 transition-colors"
+              >
+                <ShieldCheck className="w-4 h-4" />
+                Approve {selectedDraftCount} Draft
+                {selectedDraftCount !== 1 ? 's' : ''}
+              </button>
+            )}
+            {selectedApprovedCount > 0 && (
+              <button
+                onClick={handleBatchDemote}
+                disabled={batchProcessing}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 hover:bg-amber-200 dark:hover:bg-amber-900/50 disabled:opacity-50 transition-colors"
+              >
+                <Undo2 className="w-4 h-4" />
+                Revert {selectedApprovedCount} to Draft
+              </button>
+            )}
+            <button
+              onClick={handleClearSelection}
+              className="px-3 py-1.5 text-sm text-[#647D8B] hover:text-[#11202B] dark:hover:text-[#EAF3F2] transition-colors"
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* Table */}
       {loading ? (
         <div className="flex items-center justify-center py-16">
@@ -437,6 +599,27 @@ const JournalEntries: React.FC = () => {
           <table className="min-w-full">
             <thead>
               <tr className="bg-[#EAF3F2] dark:bg-[#16242F]">
+                <th className="w-10 px-4 py-3 text-center">
+                  {selectableEntries.length > 0 && (
+                    <button
+                      onClick={handleToggleSelectAll}
+                      className="p-0.5 hover:bg-[#294050]/10 dark:hover:bg-[#294050]/20 rounded transition-colors"
+                      title={
+                        allSelectableSelected
+                          ? 'Deselect all'
+                          : 'Select all drafts & approved'
+                      }
+                    >
+                      {allSelectableSelected ? (
+                        <CheckSquare className="w-4 h-4 text-[#5FE3C0]" />
+                      ) : someSelected ? (
+                        <MinusSquare className="w-4 h-4 text-[#5FE3C0]" />
+                      ) : (
+                        <Square className="w-4 h-4 text-[#294050] dark:text-[#9FB4BE]" />
+                      )}
+                    </button>
+                  )}
+                </th>
                 <th className="w-8 px-4 py-3" />
                 <th className="px-4 py-3 text-left text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider">
                   Date
@@ -480,9 +663,26 @@ const JournalEntries: React.FC = () => {
                 return (
                   <React.Fragment key={entry.id}>
                     <tr
-                      className="bg-white dark:bg-[#11202B] hover:bg-[#EAF3F2]/50 dark:hover:bg-[#16242F]/50 cursor-pointer transition-colors"
+                      className={`bg-white dark:bg-[#11202B] hover:bg-[#EAF3F2]/50 dark:hover:bg-[#16242F]/50 cursor-pointer transition-colors ${selectedIds.has(entry.id) ? 'bg-[#5FE3C0]/5 dark:bg-[#5FE3C0]/5' : ''}`}
                       onClick={() => handleToggleExpand(entry.id)}
                     >
+                      <td
+                        className="px-4 py-3 text-center"
+                        onClick={e => e.stopPropagation()}
+                      >
+                        {(status === 'draft' || status === 'approved') && (
+                          <button
+                            onClick={() => handleToggleSelect(entry.id)}
+                            className="p-0.5 hover:bg-[#294050]/10 rounded transition-colors"
+                          >
+                            {selectedIds.has(entry.id) ? (
+                              <CheckSquare className="w-4 h-4 text-[#5FE3C0]" />
+                            ) : (
+                              <Square className="w-4 h-4 text-[#647D8B]" />
+                            )}
+                          </button>
+                        )}
+                      </td>
                       <td className="px-4 py-3">
                         {isExpanded ? (
                           <ChevronDown className="w-4 h-4 text-[#294050]" />
@@ -564,7 +764,7 @@ const JournalEntries: React.FC = () => {
                     {/* Expanded line items */}
                     {isExpanded && entry.lines.length > 0 && (
                       <tr className="bg-[#F7FAFA] dark:bg-[#0C141B]">
-                        <td colSpan={9} className="px-8 py-3">
+                        <td colSpan={10} className="px-8 py-3">
                           {/* Provenance info */}
                           <div className="flex flex-wrap gap-4 mb-3 text-xs text-[#294050] dark:text-[#9FB4BE]">
                             <span>

--- a/src/contexts/TransactionContext.tsx
+++ b/src/contexts/TransactionContext.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useState,
   useEffect,
+  useMemo,
   ReactNode,
   useCallback,
   useRef,
@@ -326,25 +327,44 @@ export const TransactionProvider: React.FC<{
     []
   )
 
-  const pendingApprovals = transactions.filter(
-    txn => txn.status === 'pending_approval' && txn.approvalStatus === 'pending'
+  const pendingApprovals = useMemo(
+    () =>
+      transactions.filter(
+        txn =>
+          txn.status === 'pending_approval' && txn.approvalStatus === 'pending'
+      ),
+    [transactions]
+  )
+
+  const contextValue = useMemo(
+    () => ({
+      transactions,
+      loading,
+      addTransaction,
+      updateTransaction,
+      deleteTransaction,
+      getTransaction,
+      approveTransaction,
+      rejectTransaction,
+      reloadTransactions: loadTransactions,
+      pendingApprovals,
+    }),
+    [
+      transactions,
+      loading,
+      addTransaction,
+      updateTransaction,
+      deleteTransaction,
+      getTransaction,
+      approveTransaction,
+      rejectTransaction,
+      loadTransactions,
+      pendingApprovals,
+    ]
   )
 
   return (
-    <TransactionContext.Provider
-      value={{
-        transactions,
-        loading,
-        addTransaction,
-        updateTransaction,
-        deleteTransaction,
-        getTransaction,
-        approveTransaction,
-        rejectTransaction,
-        reloadTransactions: loadTransactions,
-        pendingApprovals,
-      }}
-    >
+    <TransactionContext.Provider value={contextValue}>
       {children}
     </TransactionContext.Provider>
   )

--- a/src/contexts/TransactionContext.tsx
+++ b/src/contexts/TransactionContext.tsx
@@ -171,7 +171,7 @@ export const TransactionProvider: React.FC<{
     if (initRef.current && !currentProfile) return
     initRef.current = true
     loadTransactions()
-  }, [loadTransactions])
+  }, [loadTransactions, currentProfile])
 
   const addTransaction = useCallback(
     async (


### PR DESCRIPTION
## Summary
- **Batch selection** on Classification Queue: checkbox column, select-all toggle, "Select by..." dropdown (filter by chain or tx type)
- **Batch auto-classify**: classify N selected transactions in one action with progress bar
- **Batch skip**: ignore N selected transactions at once
- **One-click batch approve**: after batch classify, banner with "Approve N Drafts" button (Draft → Approved in one action)
- **Explainability**: new "Rule" column showing which heuristic classification rule will fire for each transaction type
- **Improved empty state**: "All caught up" message guiding users to Review Drafts or View Trial Balance
- **Journal Entries batch actions**: checkbox selection with batch Approve (drafts) and batch Revert to Draft (approved entries)
- New `rulePreview()` utility + tests

## Acceptance Criteria
- [x] User can select N rows and approve to Approved state in one action
- [x] Reversal is one-click while state = Approved (batch demote on JE page)
- [x] Posting requires distinct explicit action, not available from batch UI
- [x] Explainability line renders for every row (rule-origin preview)
- [x] Empty state leads user to next action (Review Drafts / View Trial Balance)
- [x] Draft→approve SQL lifecycle invariants preserved (uses existing `approve_journal_entry` backend)

## Test plan
- [ ] Select all transactions, batch auto-classify — verify progress bar, result banner with approve option
- [ ] Use "Select by..." → chain filter → verify only that chain's rows are selected
- [ ] Batch skip selected transactions → verify they leave the queue
- [ ] After batch classify, click "Approve N Drafts" → verify all move to Approved
- [ ] Navigate to Journal Entries → select approved entries → batch "Revert to Draft" → verify they return to Draft
- [ ] Verify no batch Post action is exposed (posting is single-entry only per AC)
- [ ] Verify Rule column shows correct heuristic description for each tx type
- [ ] Verify empty state shows "All caught up" with navigation buttons
- [ ] `npx tsc --noEmit` passes, `npx prettier --check` passes, `vitest run classificationUtils` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)