### PR TITLE
feat(chains): Moonbeam/Moonriver sunset — full-archive sync + graceful deprecation (GIV-751)

### DIFF
--- a/src-tauri/src/chains/evm/etherscan.rs
+++ b/src-tauri/src/chains/evm/etherscan.rs
@@ -17,6 +17,7 @@ use super::types::{
 };
 use crate::chains::{ChainError, ChainResult};
 use crate::fetchers::{ApiKeyManager, ApiProvider, FetcherConfig, ResilientFetcher};
+use chrono::Utc;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use std::time::Duration;
@@ -37,6 +38,14 @@ const MAX_RETRIES: u32 = 5;
 
 /// Base delay for exponential backoff (milliseconds)
 const BASE_RETRY_DELAY_MS: u64 = 200;
+
+const MOONBEAM_SUNSET_MESSAGE: &str = "The Moonbeam network ceased operations on 31 July 2026. \
+     New transactions can no longer be synced; your previously synced \
+     history remains available in Pacioli.";
+
+fn is_moonbeam_sunset(chain_id: u64) -> bool {
+    matches!(chain_id, 1284 | 1285) && Utc::now().timestamp() > 1_785_331_199
+}
 
 // =============================================================================
 // API RESPONSE TYPES
@@ -225,6 +234,10 @@ impl EtherscanClient {
     /// - Proactive rate limiting (waits before request to prevent 429s)
     /// - Exponential backoff retries for transient failures
     async fn request<T: DeserializeOwned>(&self, url: &str) -> ChainResult<T> {
+        if is_moonbeam_sunset(self.chain_id) {
+            return Err(ChainError::ApiError(MOONBEAM_SUNSET_MESSAGE.to_string()));
+        }
+
         // Wait for rate limiter (Governor GCRA algorithm)
         self.fetcher.wait_for_permit().await;
 
@@ -297,6 +310,17 @@ impl EtherscanClient {
                 || error_response.result.contains("Invalid address")
             {
                 return Err(ChainError::InvalidAddress(error_response.result));
+            }
+
+            // Detect Moonbeam/Moonriver chain deprecation errors
+            if matches!(self.chain_id, 1284 | 1285) {
+                let lower = error_response.result.to_lowercase();
+                if lower.contains("chain")
+                    || lower.contains("not supported")
+                    || lower.contains("deprecated")
+                {
+                    return Err(ChainError::ApiError(MOONBEAM_SUNSET_MESSAGE.to_string()));
+                }
             }
 
             return Err(ChainError::ApiError(format!(

--- a/src-tauri/src/chains/evm/etherscan.rs
+++ b/src-tauri/src/chains/evm/etherscan.rs
@@ -43,8 +43,10 @@ const MOONBEAM_SUNSET_MESSAGE: &str = "The Moonbeam network ceased operations on
      New transactions can no longer be synced; your previously synced \
      history remains available in Pacioli.";
 
+/// Moonbeam/Moonriver ceased operations after 2026-07-31 23:59:59 UTC
+/// (unix epoch 1785542399, matching MOONBEAM_SUNSET_UTC in moonscanService.ts).
 fn is_moonbeam_sunset(chain_id: u64) -> bool {
-    matches!(chain_id, 1284 | 1285) && Utc::now().timestamp() > 1_785_331_199
+    matches!(chain_id, 1284 | 1285) && Utc::now().timestamp() > 1_785_542_399
 }
 
 // =============================================================================

--- a/src/app/settings/DataProviders.tsx
+++ b/src/app/settings/DataProviders.tsx
@@ -128,9 +128,10 @@ const PROVIDER_CONFIGS: ProviderConfig[] = [
   },
   {
     id: 'moonscan',
-    name: 'Moonscan',
-    description: 'Moonbeam and Moonriver block explorer API',
-    docsUrl: 'https://moonscan.io/myapikey',
+    name: 'Moonscan (Etherscan V2)',
+    description:
+      'Moonbeam/Moonriver via Etherscan V2. Networks shut down 31 Jul 2026 — sync history before then.',
+    docsUrl: 'https://etherscan.io/myapikey',
     chains: ['Moonbeam', 'Moonriver'],
   },
   {

--- a/src/services/blockchain/moonscanService.ts
+++ b/src/services/blockchain/moonscanService.ts
@@ -111,6 +111,11 @@ export class MoonscanService {
     'NOTE: Moonbeam/Moonriver networks shut down on 31 July 2026 — complete ' +
     'a full sync before that date to preserve your complete transaction history.'
 
+  /**
+   * True once the Moonbeam/Moonriver networks have ceased operations
+   * (after 2026-07-31 23:59:59 UTC) and the Etherscan V2 API no longer
+   * serves chainids 1284/1285.
+   */
   static isSunset(): boolean {
     return Date.now() > MOONBEAM_SUNSET_UTC
   }
@@ -167,6 +172,10 @@ export class MoonscanService {
     )
   }
 
+  /**
+   * True when the response is an Etherscan V2 chain-deprecation error,
+   * i.e. the API has stopped serving Moonbeam/Moonriver post-sunset.
+   */
   private static isChainDeprecationError(
     data: MoonscanResponse<unknown>
   ): boolean {
@@ -411,54 +420,57 @@ export class MoonscanService {
 
     const { limit = 10000, fullArchive = true, onProgress } = options
     const PAGE_SIZE = 10000
-    const MAX_PAGES = 100
+    const MAX_FETCHES = 100
     const allTransactions: SubstrateTransaction[] = []
 
-    // 1. Paginate normal transactions
+    // Etherscan V2 rejects page × offset > 10000 ("Result window is too
+    // large"), so deep history cannot be paged by incrementing the page
+    // number. Instead keep page=1 and advance startBlock (sort=asc) past
+    // each full window. The boundary block is re-fetched on each advance;
+    // the hash dedup below removes the overlap.
+    const fetchWindowed = async (
+      label: string,
+      fetchPage: (startBlock: number) => Promise<SubstrateTransaction[]>
+    ): Promise<void> => {
+      let startBlock = 0
+      for (let fetches = 1; fetches <= MAX_FETCHES; fetches++) {
+        const txs = await fetchPage(startBlock)
+        allTransactions.push(...txs)
+        onProgress?.(`${label} (${fetches})...`, allTransactions.length, 0)
+        if (!fullArchive || txs.length < PAGE_SIZE) return
+        const lastBlock = txs[txs.length - 1].blockNumber
+        // Guard against a full window contained in a single block, which
+        // would otherwise re-fetch the same window forever.
+        startBlock = lastBlock > startBlock ? lastBlock : startBlock + 1
+        await new Promise(resolve => setTimeout(resolve, 250))
+      }
+    }
+
+    // 1. Fetch normal transactions (full history via block windows)
     onProgress?.('Fetching EVM transactions from Moonscan...', 0, 0)
-    let page = 1
-    while (page <= MAX_PAGES) {
-      const txs = await this.fetchTransactions(network, address, {
-        page,
+    await fetchWindowed('Fetching EVM transactions', startBlock =>
+      this.fetchTransactions(network, address, {
+        startBlock,
         offset: PAGE_SIZE,
         sort: 'asc',
       })
-      allTransactions.push(...txs)
-      onProgress?.(
-        `Fetching EVM transactions (page ${page})...`,
-        allTransactions.length,
-        0
-      )
-      if (!fullArchive || txs.length < PAGE_SIZE) break
-      page++
-      await new Promise(resolve => setTimeout(resolve, 250))
-    }
+    )
 
     await new Promise(resolve => setTimeout(resolve, 250))
 
-    // 2. Paginate token transfers
+    // 2. Fetch token transfers (full history via block windows)
     onProgress?.(
       'Fetching token transfers from Moonscan...',
       allTransactions.length,
       0
     )
-    page = 1
-    while (page <= MAX_PAGES) {
-      const txs = await this.fetchTokenTransfers(network, address, {
-        page,
+    await fetchWindowed('Fetching token transfers', startBlock =>
+      this.fetchTokenTransfers(network, address, {
+        startBlock,
         offset: PAGE_SIZE,
         sort: 'asc',
       })
-      allTransactions.push(...txs)
-      onProgress?.(
-        `Fetching token transfers (page ${page})...`,
-        allTransactions.length,
-        0
-      )
-      if (!fullArchive || txs.length < PAGE_SIZE) break
-      page++
-      await new Promise(resolve => setTimeout(resolve, 250))
-    }
+    )
 
     // Sort by block number (newest first)
     allTransactions.sort((a, b) => b.blockNumber - a.blockNumber)

--- a/src/services/blockchain/moonscanService.ts
+++ b/src/services/blockchain/moonscanService.ts
@@ -6,10 +6,21 @@
  * Etherscan V2 requires an API key for all requests.
  * A free Etherscan key (https://etherscan.io/myapikey) works for all V2 chains
  * including Moonbeam/Moonriver. A Moonscan-specific key also works.
+ *
+ * SUNSET NOTICE: Moonbeam and Moonriver cease operations on 2026-07-31.
+ * After this date the Etherscan V2 API will reject chainids 1284/1285.
+ * Previously synced history remains available locally.
  */
 
 import { invoke } from '@tauri-apps/api/core'
 import type { NetworkType, SubstrateTransaction } from '../wallet/types'
+
+const MOONBEAM_SUNSET_UTC = Date.UTC(2026, 6, 31, 23, 59, 59)
+
+const SUNSET_MESSAGE =
+  'The Moonbeam network ceased operations on 31 July 2026. ' +
+  'New transactions can no longer be synced; your previously synced ' +
+  'history remains available in Pacioli.'
 
 interface MoonscanConfig {
   chainId: number
@@ -96,7 +107,13 @@ export class MoonscanService {
     'Moonbeam/Moonriver sync uses the Etherscan V2 API, which requires a free ' +
     'Etherscan API key (legacy moonscan.io keys no longer work). Create a key ' +
     'at https://etherscan.io/myapikey, then save it in Settings → Data ' +
-    'Providers under "Etherscan" and retry the sync.'
+    'Providers under "Etherscan" and retry the sync. ' +
+    'NOTE: Moonbeam/Moonriver networks shut down on 31 July 2026 — complete ' +
+    'a full sync before that date to preserve your complete transaction history.'
+
+  static isSunset(): boolean {
+    return Date.now() > MOONBEAM_SUNSET_UTC
+  }
 
   /**
    * Collect every configured API key, in preference order:
@@ -150,6 +167,18 @@ export class MoonscanService {
     )
   }
 
+  private static isChainDeprecationError(
+    data: MoonscanResponse<unknown>
+  ): boolean {
+    if (data.status === '1') return false
+    const msg = typeof data.result === 'string' ? data.result.toLowerCase() : ''
+    return (
+      msg.includes('chain') ||
+      msg.includes('not supported') ||
+      msg.includes('deprecated')
+    )
+  }
+
   /**
    * Fetch from the Etherscan V2 API, retrying with each configured key
    * candidate if the current one is rejected. Throws an actionable error
@@ -159,9 +188,11 @@ export class MoonscanService {
     apiUrl: string,
     params: URLSearchParams
   ): Promise<MoonscanResponse<T>> {
+    if (MoonscanService.isSunset()) {
+      throw new Error(SUNSET_MESSAGE)
+    }
+
     const candidates = await MoonscanService.getApiKeyCandidates()
-    // With no keys configured, still attempt once so the server's own
-    // "Missing/Invalid API Key" surfaces through the same error path.
     const attempts = candidates.length > 0 ? candidates : ['']
     let lastRejection: string | null = null
 
@@ -180,6 +211,10 @@ export class MoonscanService {
         throw new Error(
           `Invalid JSON response from Etherscan API: ${responseText.substring(0, 200)}`
         )
+      }
+
+      if (MoonscanService.isChainDeprecationError(data)) {
+        throw new Error(SUNSET_MESSAGE)
       }
 
       if (!MoonscanService.isKeyRejection(data)) {
@@ -323,88 +358,120 @@ export class MoonscanService {
       sort,
     })
 
-    try {
-      const data =
-        await MoonscanService.fetchWithKeyFallback<MoonscanTokenTransfer>(
-          config.apiUrl,
-          params
-        )
-
-      if (data.status !== '1') {
-        // No transactions found or other non-error status - return empty
-        return []
-      }
-
-      if (!Array.isArray(data.result)) {
-        return []
-      }
-
-      return data.result.map(tx =>
-        MoonscanService.mapTokenTransferToSubstrateTransaction(
-          tx,
-          network,
-          address
-        )
+    const data =
+      await MoonscanService.fetchWithKeyFallback<MoonscanTokenTransfer>(
+        config.apiUrl,
+        params
       )
-    } catch (error) {
-      console.error('Moonscan token transfer fetch error:', error)
-      // Don't throw - token transfers are optional
+
+    if (data.status !== '1') {
+      if (
+        data.message === 'No transactions found' ||
+        (typeof data.result === 'string' &&
+          data.result.includes('No transactions'))
+      ) {
+        return []
+      }
+      if (typeof data.result === 'string') {
+        throw new Error(`Moonscan token transfer API error: ${data.result}`)
+      }
+      throw new Error(`Moonscan token transfer API error: ${data.message}`)
+    }
+
+    if (!Array.isArray(data.result)) {
       return []
     }
+
+    return data.result.map(tx =>
+      MoonscanService.mapTokenTransferToSubstrateTransaction(
+        tx,
+        network,
+        address
+      )
+    )
   }
 
   /**
-   * Fetch all transactions (normal + token transfers)
+   * Fetch all transactions (normal + token transfers) with full pagination.
+   * When fullArchive is true (default after sunset announcement), fetches
+   * every page to ensure complete history before API shutdown.
    */
   async fetchAllTransactions(
     network: NetworkType,
     address: string,
     options: {
       limit?: number
+      fullArchive?: boolean
       onProgress?: (stage: string, current: number, total: number) => void
     } = {}
   ): Promise<SubstrateTransaction[]> {
-    const { limit = 100, onProgress } = options
+    if (MoonscanService.isSunset()) {
+      throw new Error(SUNSET_MESSAGE)
+    }
+
+    const { limit = 10000, fullArchive = true, onProgress } = options
+    const PAGE_SIZE = 10000
+    const MAX_PAGES = 100
     const allTransactions: SubstrateTransaction[] = []
 
-    try {
-      // 1. Fetch normal transactions
-      onProgress?.('Fetching EVM transactions from Moonscan...', 0, limit)
-      const normalTxs = await this.fetchTransactions(network, address, {
-        offset: limit,
+    // 1. Paginate normal transactions
+    onProgress?.('Fetching EVM transactions from Moonscan...', 0, 0)
+    let page = 1
+    while (page <= MAX_PAGES) {
+      const txs = await this.fetchTransactions(network, address, {
+        page,
+        offset: PAGE_SIZE,
+        sort: 'asc',
       })
-      allTransactions.push(...normalTxs)
-
-      // Small delay to avoid rate limiting
-      await new Promise(resolve => setTimeout(resolve, 250))
-
-      // 2. Fetch token transfers
+      allTransactions.push(...txs)
       onProgress?.(
-        'Fetching token transfers from Moonscan...',
-        normalTxs.length,
-        limit
+        `Fetching EVM transactions (page ${page})...`,
+        allTransactions.length,
+        0
       )
-      const tokenTxs = await this.fetchTokenTransfers(network, address, {
-        offset: limit,
-      })
-      allTransactions.push(...tokenTxs)
-
-      // Sort by block number (newest first)
-      allTransactions.sort((a, b) => b.blockNumber - a.blockNumber)
-
-      // Deduplicate by hash (token transfers might duplicate normal txs)
-      const seen = new Set<string>()
-      const deduplicated = allTransactions.filter(tx => {
-        if (seen.has(tx.hash)) return false
-        seen.add(tx.hash)
-        return true
-      })
-
-      return deduplicated.slice(0, limit)
-    } catch (error) {
-      console.error('Moonscan fetchAllTransactions error:', error)
-      throw error
+      if (!fullArchive || txs.length < PAGE_SIZE) break
+      page++
+      await new Promise(resolve => setTimeout(resolve, 250))
     }
+
+    await new Promise(resolve => setTimeout(resolve, 250))
+
+    // 2. Paginate token transfers
+    onProgress?.(
+      'Fetching token transfers from Moonscan...',
+      allTransactions.length,
+      0
+    )
+    page = 1
+    while (page <= MAX_PAGES) {
+      const txs = await this.fetchTokenTransfers(network, address, {
+        page,
+        offset: PAGE_SIZE,
+        sort: 'asc',
+      })
+      allTransactions.push(...txs)
+      onProgress?.(
+        `Fetching token transfers (page ${page})...`,
+        allTransactions.length,
+        0
+      )
+      if (!fullArchive || txs.length < PAGE_SIZE) break
+      page++
+      await new Promise(resolve => setTimeout(resolve, 250))
+    }
+
+    // Sort by block number (newest first)
+    allTransactions.sort((a, b) => b.blockNumber - a.blockNumber)
+
+    // Deduplicate by hash (token transfers might duplicate normal txs)
+    const seen = new Set<string>()
+    const deduplicated = allTransactions.filter(tx => {
+      if (seen.has(tx.hash)) return false
+      seen.add(tx.hash)
+      return true
+    })
+
+    return limit ? deduplicated.slice(0, limit) : deduplicated
   }
 
   /**

--- a/src/services/blockchain/polkadotService.ts
+++ b/src/services/blockchain/polkadotService.ts
@@ -385,7 +385,8 @@ class PolkadotService {
           network,
           address,
           {
-            limit,
+            limit: 0,
+            fullArchive: true,
             onProgress: (stage, current, total) => {
               onProgress?.({
                 stage: 'fetching',


### PR DESCRIPTION
## Summary

- **Full-archive pagination**: `fetchAllTransactions` now loops through all pages (10k results/page, up to 100 pages) to capture complete Moonbeam/Moonriver history before the 2026-07-31 shutdown — previously it only fetched a single page.
- **Token transfer errors surfaced**: `fetchTokenTransfers` now propagates errors instead of silently returning `[]`, which is critical for verifying final-sync completeness.
- **Graceful sunset detection** (both TS + Rust): After 2026-07-31 UTC, or when the API returns chain-deprecation errors, shows the message _"The Moonbeam network ceased operations on 31 July 2026. New transactions can no longer be synced; your previously synced history remains available in Pacioli."_ instead of cryptic `Invalid API Key (#err2)` errors.
- **Updated guidance text**: `KEY_HELP` constant warns about the 7/31 deadline; `DataProviders.tsx` Moonscan entry updated with sunset notice and corrected docs URL.

## Files changed

| File | Change |
|------|--------|
| `src/services/blockchain/moonscanService.ts` | Pagination loop, error propagation, sunset constants + detection |
| `src/services/blockchain/polkadotService.ts` | Pass `fullArchive: true, limit: 0` for complete history capture |
| `src-tauri/src/chains/evm/etherscan.rs` | Date-based + error-based sunset detection for chains 1284/1285 |
| `src/app/settings/DataProviders.tsx` | Moonscan entry: sunset notice, corrected docs URL |

## Test plan

- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] Rust compiles (`cargo check` + `cargo clippy`)
- [ ] Before 2026-07-31: sync with valid Etherscan V2 key fetches full paginated history
- [ ] After 2026-07-31 (or mock date): sunset message shown instead of sync attempt
- [ ] Previously synced Moonbeam data remains visible in all reports
- [ ] DataProviders settings page shows updated Moonscan description

🤖 Generated with [Claude Code](https://claude.com/claude-code)