### PR TITLE
feat(coa): schema migrations + template importer (GIV-757)

### DIFF
--- a/src-tauri/migrations/20260727000001_coa_schema_expansion.sql
+++ b/src-tauri/migrations/20260727000001_coa_schema_expansion.sql
@@ -1,0 +1,301 @@
+-- =============================================================================
+-- COA SCHEMA EXPANSION (GIV-757)
+--
+-- 1. Expands gl_accounts.account_type CHECK to include 'Revenue'.
+-- 2. Adds context, profile_id, hidden columns.
+-- 3. Changes UNIQUE from account_number alone to (profile_id, account_number).
+-- 4. Adds composite index (profile_id, context, account_type).
+-- 5. Rebuilds v_income_statement to include 'Revenue'.
+--
+-- SQLite cannot ALTER a CHECK constraint, so the table is recreated.
+-- All dependent views are dropped before the table swap and recreated after.
+-- =============================================================================
+
+PRAGMA foreign_keys = OFF;
+
+-- ---------------------------------------------------------------
+-- 1. Drop all views that depend on gl_accounts (directly or via
+--    another view that references it). Drop dependents first.
+-- ---------------------------------------------------------------
+DROP VIEW IF EXISTS v_portfolio_performance;
+DROP VIEW IF EXISTS v_token_holdings;
+DROP VIEW IF EXISTS v_balance_sheet;
+DROP VIEW IF EXISTS v_income_statement;
+DROP VIEW IF EXISTS v_token_balances;
+DROP VIEW IF EXISTS v_account_balances;
+DROP VIEW IF EXISTS v_general_ledger;
+DROP VIEW IF EXISTS v_trial_balance;
+DROP VIEW IF EXISTS v_account_activity;
+
+-- ---------------------------------------------------------------
+-- 2. Create replacement table with expanded schema
+-- ---------------------------------------------------------------
+CREATE TABLE gl_accounts_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    account_number TEXT NOT NULL,
+    account_name TEXT NOT NULL,
+    account_type TEXT NOT NULL CHECK(account_type IN ('Asset', 'Liability', 'Equity', 'Income', 'Revenue', 'Expense')),
+    parent_account_id INTEGER,
+    digital_asset_type TEXT CHECK(digital_asset_type IN (
+        'Native Protocol Token',
+        'Stablecoin',
+        'Wrapped/Bridged Token',
+        'Liquid Staking Derivative',
+        'LP Token',
+        'Governance Token',
+        'Yield-Bearing Token',
+        'NFT - Collectible',
+        'NFT - Utility',
+        'Synthetic Asset',
+        'Other Digital Asset'
+    )),
+    subcategory TEXT,
+    description TEXT,
+    is_active BOOLEAN DEFAULT 1,
+    is_editable BOOLEAN DEFAULT 1,
+    normal_balance TEXT CHECK(normal_balance IN ('debit', 'credit')),
+    context TEXT NOT NULL DEFAULT 'all' CHECK(context IN ('all','individual','sme','ngo')),
+    profile_id TEXT,
+    hidden INTEGER NOT NULL DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(profile_id, account_number),
+    FOREIGN KEY (parent_account_id) REFERENCES gl_accounts(id),
+    FOREIGN KEY (profile_id) REFERENCES profiles(id)
+);
+
+-- ---------------------------------------------------------------
+-- 3. Copy existing rows (defaults fill context='all', profile_id=NULL, hidden=0)
+-- ---------------------------------------------------------------
+INSERT INTO gl_accounts_new (
+    id, account_number, account_name, account_type,
+    parent_account_id, digital_asset_type, subcategory, description,
+    is_active, is_editable, normal_balance, created_at, updated_at
+)
+SELECT
+    id, account_number, account_name, account_type,
+    parent_account_id, digital_asset_type, subcategory, description,
+    is_active, is_editable, normal_balance, created_at, updated_at
+FROM gl_accounts;
+
+-- ---------------------------------------------------------------
+-- 4. Drop old table artifacts and swap
+-- ---------------------------------------------------------------
+DROP TRIGGER IF EXISTS gl_accounts_update_timestamp;
+DROP INDEX IF EXISTS idx_gl_accounts_number;
+DROP INDEX IF EXISTS idx_gl_accounts_type;
+DROP INDEX IF EXISTS idx_gl_accounts_digital_type;
+DROP INDEX IF EXISTS idx_gl_accounts_active;
+DROP TABLE gl_accounts;
+
+ALTER TABLE gl_accounts_new RENAME TO gl_accounts;
+
+-- ---------------------------------------------------------------
+-- 5. Recreate indexes
+-- ---------------------------------------------------------------
+CREATE INDEX idx_gl_accounts_number ON gl_accounts(account_number);
+CREATE INDEX idx_gl_accounts_type ON gl_accounts(account_type);
+CREATE INDEX idx_gl_accounts_digital_type ON gl_accounts(digital_asset_type);
+CREATE INDEX idx_gl_accounts_active ON gl_accounts(is_active);
+CREATE INDEX idx_gl_accounts_profile_context_type ON gl_accounts(profile_id, context, account_type);
+
+-- ---------------------------------------------------------------
+-- 6. Recreate update trigger
+-- ---------------------------------------------------------------
+CREATE TRIGGER gl_accounts_update_timestamp
+AFTER UPDATE ON gl_accounts
+BEGIN
+    UPDATE gl_accounts SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+END;
+
+-- ---------------------------------------------------------------
+-- 7. Recreate all dropped views
+-- ---------------------------------------------------------------
+
+-- v_token_balances (from 20250102000005 — unchanged)
+CREATE VIEW v_token_balances AS
+SELECT
+    at.gl_account_id,
+    ga.account_number,
+    ga.account_name,
+    ga.account_type,
+    at.token_id,
+    t.symbol AS token_symbol,
+    t.name AS token_name,
+    t.chain_id,
+    SUM(CASE WHEN at.transaction_type IN ('purchase', 'transfer_in', 'stake', 'swap_in', 'lp_deposit', 'airdrop', 'gift_received', 'loan_borrowed', 'reward', 'interest_earned')
+        THEN at.quantity ELSE 0 END) AS total_inflows,
+    SUM(CASE WHEN at.transaction_type IN ('sale', 'transfer_out', 'unstake', 'swap_out', 'lp_withdraw', 'gift_sent', 'donation', 'loan_repaid', 'fee', 'interest_paid')
+        THEN at.quantity ELSE 0 END) AS total_outflows,
+    SUM(CASE WHEN at.transaction_type IN ('purchase', 'transfer_in', 'stake', 'swap_in', 'lp_deposit', 'airdrop', 'gift_received', 'loan_borrowed', 'reward', 'interest_earned')
+        THEN at.quantity ELSE -at.quantity END) AS net_quantity,
+    SUM(CASE WHEN at.total_value IS NOT NULL THEN at.total_value ELSE 0 END) AS total_value_usd
+FROM accounting_transactions at
+JOIN gl_accounts ga ON at.gl_account_id = ga.id
+JOIN tokens t ON at.token_id = t.id
+WHERE ga.is_active = 1 AND t.is_active = 1
+GROUP BY at.gl_account_id, at.token_id;
+
+-- v_account_balances (from 20260715000004 — minor-unit version, unchanged)
+CREATE VIEW v_account_balances AS
+SELECT
+    ga.id AS account_id,
+    ga.account_number,
+    ga.account_name,
+    ga.account_type,
+    ga.digital_asset_type,
+    ga.normal_balance,
+    COALESCE(SUM(jel.debit_minor), 0) AS total_debits,
+    COALESCE(SUM(jel.credit_minor), 0) AS total_credits,
+    CASE
+        WHEN ga.normal_balance = 'debit' THEN COALESCE(SUM(jel.debit_minor), 0) - COALESCE(SUM(jel.credit_minor), 0)
+        ELSE COALESCE(SUM(jel.credit_minor), 0) - COALESCE(SUM(jel.debit_minor), 0)
+    END AS balance,
+    CASE
+        WHEN ga.account_type IN ('Asset', 'Expense') THEN COALESCE(SUM(jel.debit_minor), 0) - COALESCE(SUM(jel.credit_minor), 0)
+        ELSE COALESCE(SUM(jel.credit_minor), 0) - COALESCE(SUM(jel.debit_minor), 0)
+    END AS balance_signed
+FROM gl_accounts ga
+LEFT JOIN journal_entry_lines jel ON ga.id = jel.gl_account_id
+LEFT JOIN journal_entries je ON jel.journal_entry_id = je.id
+WHERE ga.is_active = 1 AND (je.is_posted = 1 OR je.id IS NULL)
+GROUP BY ga.id, ga.account_number, ga.account_name, ga.account_type, ga.normal_balance;
+
+-- v_general_ledger (from 20250102000005 — unchanged)
+CREATE VIEW v_general_ledger AS
+SELECT
+    je.entry_date,
+    je.entry_number,
+    jel.line_number,
+    ga.account_number,
+    ga.account_name,
+    ga.account_type,
+    t.symbol AS token_symbol,
+    jel.debit_amount,
+    jel.credit_amount,
+    jel.description,
+    je.reference_number,
+    je.is_posted,
+    je.is_reversed
+FROM journal_entry_lines jel
+JOIN journal_entries je ON jel.journal_entry_id = je.id
+JOIN gl_accounts ga ON jel.gl_account_id = ga.id
+LEFT JOIN tokens t ON jel.token_id = t.id
+WHERE je.is_posted = 1
+ORDER BY je.entry_date DESC, je.entry_number, jel.line_number;
+
+-- v_trial_balance (from 20260715000004 — minor-unit version, unchanged)
+CREATE VIEW v_trial_balance AS
+SELECT
+    ga.account_number,
+    ga.account_name,
+    ga.account_type,
+    CASE
+        WHEN SUM(jel.debit_minor) - SUM(jel.credit_minor) > 0
+        THEN SUM(jel.debit_minor) - SUM(jel.credit_minor)
+        ELSE 0
+    END AS debit_balance,
+    CASE
+        WHEN SUM(jel.credit_minor) - SUM(jel.debit_minor) > 0
+        THEN SUM(jel.credit_minor) - SUM(jel.debit_minor)
+        ELSE 0
+    END AS credit_balance
+FROM gl_accounts ga
+LEFT JOIN journal_entry_lines jel ON ga.id = jel.gl_account_id
+LEFT JOIN journal_entries je ON jel.journal_entry_id = je.id
+WHERE ga.is_active = 1 AND (je.is_posted = 1 OR je.id IS NULL)
+GROUP BY ga.id, ga.account_number, ga.account_name, ga.account_type
+HAVING ABS(SUM(COALESCE(jel.debit_minor, 0)) - SUM(COALESCE(jel.credit_minor, 0))) > 0
+ORDER BY ga.account_number;
+
+-- v_account_activity (from 20250102000005 — unchanged)
+CREATE VIEW v_account_activity AS
+SELECT
+    ga.account_number,
+    ga.account_name,
+    COUNT(DISTINCT at.id) AS transaction_count,
+    COUNT(DISTINCT CASE WHEN at.is_reconciled = 0 THEN at.id END) AS unreconciled_count,
+    MIN(at.transaction_date) AS earliest_transaction,
+    MAX(at.transaction_date) AS latest_transaction,
+    COUNT(DISTINCT at.token_id) AS distinct_tokens
+FROM gl_accounts ga
+LEFT JOIN accounting_transactions at ON ga.id = at.gl_account_id
+WHERE ga.is_active = 1
+GROUP BY ga.id, ga.account_number, ga.account_name
+HAVING COUNT(DISTINCT at.id) > 0
+ORDER BY ga.account_number;
+
+-- v_balance_sheet (from 20260715000004 — unchanged)
+CREATE VIEW v_balance_sheet AS
+SELECT
+    account_type,
+    account_number,
+    account_name,
+    balance,
+    CASE
+        WHEN account_type = 'Asset' THEN 1
+        WHEN account_type = 'Liability' THEN 2
+        WHEN account_type = 'Equity' THEN 3
+    END AS sort_order
+FROM v_account_balances
+WHERE account_type IN ('Asset', 'Liability', 'Equity')
+    AND balance != 0
+ORDER BY sort_order, account_number;
+
+-- v_income_statement — UPDATED to include 'Revenue'
+CREATE VIEW v_income_statement AS
+SELECT
+    account_type,
+    account_number,
+    account_name,
+    balance,
+    CASE
+        WHEN account_type IN ('Income', 'Revenue') THEN 1
+        WHEN account_type = 'Expense' THEN 2
+    END AS sort_order
+FROM v_account_balances
+WHERE account_type IN ('Income', 'Revenue', 'Expense')
+    AND balance != 0
+ORDER BY sort_order, account_number;
+
+-- v_token_holdings (from 20250102000005 — unchanged)
+CREATE VIEW v_token_holdings AS
+SELECT
+    t.id AS token_id,
+    t.symbol,
+    t.name AS token_name,
+    t.chain_id,
+    c.chain_name,
+    t.digital_asset_type,
+    SUM(tb.net_quantity) AS total_quantity,
+    (SELECT ph.price_usd
+     FROM price_history ph
+     WHERE ph.token_id = t.id
+     ORDER BY ph.price_date DESC
+     LIMIT 1) AS latest_price_usd,
+    SUM(tb.net_quantity) * (SELECT ph.price_usd
+                            FROM price_history ph
+                            WHERE ph.token_id = t.id
+                            ORDER BY ph.price_date DESC
+                            LIMIT 1) AS current_value_usd,
+    SUM(tb.total_value_usd) AS total_cost_basis_usd,
+    (SUM(tb.net_quantity) * (SELECT ph.price_usd FROM price_history ph WHERE ph.token_id = t.id ORDER BY ph.price_date DESC LIMIT 1)) - SUM(tb.total_value_usd) AS unrealized_gain_loss_usd
+FROM v_token_balances tb
+JOIN tokens t ON tb.token_id = t.id
+JOIN chains c ON t.chain_id = c.chain_id
+WHERE tb.net_quantity > 0
+GROUP BY t.id, t.symbol, t.name, t.chain_id, c.chain_name, t.digital_asset_type;
+
+-- v_portfolio_performance (from 20250102000005 — unchanged)
+CREATE VIEW v_portfolio_performance AS
+SELECT
+    DATE(ph.price_date) AS snapshot_date,
+    SUM(tb.net_quantity * ph.price_usd) AS total_portfolio_value_usd,
+    COUNT(DISTINCT tb.token_id) AS number_of_tokens_held
+FROM v_token_balances tb
+JOIN price_history ph ON tb.token_id = ph.token_id
+WHERE tb.net_quantity > 0
+GROUP BY DATE(ph.price_date)
+ORDER BY snapshot_date DESC;
+
+PRAGMA foreign_keys = ON;

--- a/src-tauri/migrations/20260727000002_functional_classification.sql
+++ b/src-tauri/migrations/20260727000002_functional_classification.sql
@@ -1,0 +1,10 @@
+-- =============================================================================
+-- FUNCTIONAL CLASSIFICATION ON JOURNAL ENTRY LINES (GIV-757)
+--
+-- Adds a nullable functional_classification column for NGO dimensional tagging.
+-- UI surfaces this only for NGO profiles (Child 3 / GIV-759).
+-- =============================================================================
+
+ALTER TABLE journal_entry_lines ADD COLUMN functional_classification TEXT
+    CHECK (functional_classification IN ('program_services', 'management_general', 'fundraising')
+           OR functional_classification IS NULL);

--- a/src-tauri/src/api/accounting.rs
+++ b/src-tauri/src/api/accounting.rs
@@ -2560,12 +2560,7 @@ fn account_type_to_context(account_type: &str) -> &'static str {
 }
 
 fn is_shared_account(acct: &TemplateAccount) -> bool {
-    match acct.subcategory.as_deref() {
-        Some(s) if s.starts_with("Digital") || s.starts_with("DeFi") || s.starts_with("Crypto") => {
-            true
-        }
-        _ => false,
-    }
+    matches!(acct.subcategory.as_deref(), Some(s) if s.starts_with("Digital") || s.starts_with("DeFi") || s.starts_with("Crypto"))
 }
 
 /// Input payload for the `import_chart_of_accounts_template` command.

--- a/src-tauri/src/api/accounting.rs
+++ b/src-tauri/src/api/accounting.rs
@@ -17,21 +17,37 @@ use super::persistence::DatabaseState;
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 #[serde(rename_all = "camelCase")]
 pub struct GlAccount {
+    /// Primary key.
     pub id: i64,
+    /// Unique account number (e.g. "1000").
     pub account_number: String,
+    /// Human-readable account name.
     pub account_name: String,
+    /// Account type: Asset, Liability, Equity, Income, Revenue, or Expense.
     pub account_type: String,
+    /// Optional parent account for sub-account hierarchy.
     pub parent_account_id: Option<i64>,
+    /// Optional digital-asset sub-classification.
     pub digital_asset_type: Option<String>,
+    /// Optional subcategory within the account type.
     pub subcategory: Option<String>,
+    /// Optional free-text description.
     pub description: Option<String>,
+    /// Whether the account is active.
     pub is_active: bool,
+    /// Whether the user may edit this account.
     pub is_editable: bool,
+    /// Debit or Credit.
     pub normal_balance: Option<String>,
+    /// Profile scope: all, individual, sme, or ngo.
     pub context: String,
+    /// Owning profile, or None for global seed accounts.
     pub profile_id: Option<String>,
+    /// 1 to hide from default views.
     pub hidden: i64,
+    /// Row creation timestamp.
     pub created_at: Option<NaiveDateTime>,
+    /// Row last-update timestamp.
     pub updated_at: Option<NaiveDateTime>,
 }
 
@@ -2488,6 +2504,7 @@ struct TemplateAccount {
     #[serde(rename = "isActive")]
     is_active: bool,
     #[serde(default)]
+    #[allow(dead_code)]
     editable: bool,
 }
 
@@ -2551,11 +2568,15 @@ fn is_shared_account(acct: &TemplateAccount) -> bool {
     }
 }
 
+/// Input payload for the `import_chart_of_accounts_template` command.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ImportCoaInput {
+    /// Accounting jurisdiction (e.g. "us-gaap", "ifrs").
     pub jurisdiction: String,
+    /// Entity type: "individual", "for-profit-enterprise", or "not-for-profit".
     pub account_type: String,
+    /// Profile to import the template into.
     pub profile_id: String,
 }
 

--- a/src-tauri/src/api/accounting.rs
+++ b/src-tauri/src/api/accounting.rs
@@ -17,31 +17,21 @@ use super::persistence::DatabaseState;
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 #[serde(rename_all = "camelCase")]
 pub struct GlAccount {
-    /// Auto-incremented primary key.
     pub id: i64,
-    /// Unique account number (e.g. "1200", "5100").
     pub account_number: String,
-    /// Human-readable account name.
     pub account_name: String,
-    /// One of: Asset, Liability, Equity, Income, Expense.
     pub account_type: String,
-    /// Optional parent account for sub-account hierarchy.
     pub parent_account_id: Option<i64>,
-    /// Optional digital-asset sub-classification.
     pub digital_asset_type: Option<String>,
-    /// Optional subcategory label.
     pub subcategory: Option<String>,
-    /// Optional description of the account's purpose.
     pub description: Option<String>,
-    /// Whether the account is active.
     pub is_active: bool,
-    /// Whether the account can be edited or deleted by users.
     pub is_editable: bool,
-    /// Either "debit" or "credit".
     pub normal_balance: Option<String>,
-    /// Timestamp when the account was created.
+    pub context: String,
+    pub profile_id: Option<String>,
+    pub hidden: i64,
     pub created_at: Option<NaiveDateTime>,
-    /// Timestamp when the account was last updated.
     pub updated_at: Option<NaiveDateTime>,
 }
 
@@ -2480,6 +2470,228 @@ pub async fn reopen_period(
         .fetch_one(&state.pool)
         .await
         .map_err(|e| e.to_string())
+}
+
+// ============================================================================
+// Chart-of-Accounts Template Importer (GIV-757)
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+struct TemplateAccount {
+    code: String,
+    name: String,
+    #[serde(rename = "type")]
+    account_type: String,
+    description: Option<String>,
+    subcategory: Option<String>,
+    #[serde(default = "default_true")]
+    #[serde(rename = "isActive")]
+    is_active: bool,
+    #[serde(default)]
+    editable: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize)]
+struct ChartTemplate {
+    #[allow(dead_code)]
+    name: String,
+    #[allow(dead_code)]
+    jurisdiction: String,
+    #[serde(rename = "accountType")]
+    #[allow(dead_code)]
+    account_type_field: String,
+    accounts: Vec<TemplateAccount>,
+}
+
+const TPL_US_GAAP_INDIVIDUAL: &str =
+    include_str!("../../../src/data/chart-of-accounts/us-gaap-individual.json");
+const TPL_US_GAAP_ENTERPRISE: &str =
+    include_str!("../../../src/data/chart-of-accounts/us-gaap-for-profit-enterprise.json");
+const TPL_US_GAAP_NFP: &str =
+    include_str!("../../../src/data/chart-of-accounts/us-gaap-not-for-profit.json");
+const TPL_IFRS_INDIVIDUAL: &str =
+    include_str!("../../../src/data/chart-of-accounts/ifrs-individual.json");
+const TPL_IFRS_SME: &str = include_str!("../../../src/data/chart-of-accounts/ifrs-sme.json");
+const TPL_IFRS_NFP: &str =
+    include_str!("../../../src/data/chart-of-accounts/ifrs-not-for-profit.json");
+
+fn resolve_template(jurisdiction: &str, account_type: &str) -> Result<&'static str, String> {
+    match (jurisdiction, account_type) {
+        ("us-gaap", "individual") => Ok(TPL_US_GAAP_INDIVIDUAL),
+        ("us-gaap", "for-profit-enterprise") => Ok(TPL_US_GAAP_ENTERPRISE),
+        ("us-gaap", "not-for-profit") => Ok(TPL_US_GAAP_NFP),
+        ("ifrs", "individual") => Ok(TPL_IFRS_INDIVIDUAL),
+        ("ifrs", "for-profit-enterprise") => Ok(TPL_IFRS_SME),
+        ("ifrs", "not-for-profit") => Ok(TPL_IFRS_NFP),
+        _ => Err(format!(
+            "Unknown template: jurisdiction={jurisdiction}, accountType={account_type}"
+        )),
+    }
+}
+
+fn account_type_to_context(account_type: &str) -> &'static str {
+    match account_type {
+        "individual" => "individual",
+        "for-profit-enterprise" => "sme",
+        "not-for-profit" => "ngo",
+        _ => "all",
+    }
+}
+
+fn is_shared_account(acct: &TemplateAccount) -> bool {
+    match acct.subcategory.as_deref() {
+        Some(s)
+            if s.starts_with("Digital")
+                || s.starts_with("DeFi")
+                || s.starts_with("Crypto") =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ImportCoaInput {
+    pub jurisdiction: String,
+    pub account_type: String,
+    pub profile_id: String,
+}
+
+/// Imports a chart-of-accounts template into `gl_accounts` for a profile.
+///
+/// Idempotent — uses `(profile_id, account_number)` as the natural key.
+/// Template-seeded rows are marked `is_editable = 0`.
+#[tauri::command]
+pub async fn import_chart_of_accounts_template(
+    state: State<'_, DatabaseState>,
+    input: ImportCoaInput,
+) -> Result<u64, String> {
+    let tpl_json = resolve_template(&input.jurisdiction, &input.account_type)?;
+    let tpl: ChartTemplate =
+        serde_json::from_str(tpl_json).map_err(|e| format!("Template parse error: {e}"))?;
+
+    let profile_context = account_type_to_context(&input.account_type);
+    let mut inserted: u64 = 0;
+
+    for acct in &tpl.accounts {
+        let context = if is_shared_account(acct) {
+            "all"
+        } else {
+            profile_context
+        };
+
+        let normal_balance = match acct.account_type.as_str() {
+            "Asset" | "Expense" => "debit",
+            _ => "credit",
+        };
+
+        let result = sqlx::query(
+            r#"
+            INSERT INTO gl_accounts (
+                account_number, account_name, account_type,
+                digital_asset_type, subcategory, description,
+                is_active, is_editable, normal_balance,
+                context, profile_id, hidden
+            )
+            VALUES (?, ?, ?, NULL, ?, ?, ?, 0, ?, ?, ?, 0)
+            ON CONFLICT (profile_id, account_number) DO UPDATE SET
+                account_name = excluded.account_name,
+                account_type = excluded.account_type,
+                subcategory  = excluded.subcategory,
+                description  = excluded.description,
+                context      = excluded.context,
+                normal_balance = excluded.normal_balance,
+                hidden       = 0
+            "#,
+        )
+        .bind(&acct.code)
+        .bind(&acct.name)
+        .bind(&acct.account_type)
+        .bind(&acct.subcategory)
+        .bind(&acct.description)
+        .bind(acct.is_active)
+        .bind(normal_balance)
+        .bind(context)
+        .bind(&input.profile_id)
+        .execute(&state.pool)
+        .await
+        .map_err(|e| format!("Failed to upsert account {}: {e}", acct.code))?;
+
+        inserted += result.rows_affected();
+    }
+
+    Ok(inserted)
+}
+
+/// Imports a chart-of-accounts template directly against a pool (for tests).
+#[cfg(test)]
+async fn import_coa_template_raw(
+    pool: &sqlx::SqlitePool,
+    jurisdiction: &str,
+    account_type: &str,
+    profile_id: &str,
+) -> Result<u64, String> {
+    let tpl_json = resolve_template(jurisdiction, account_type)?;
+    let tpl: ChartTemplate =
+        serde_json::from_str(tpl_json).map_err(|e| format!("Template parse error: {e}"))?;
+
+    let profile_context = account_type_to_context(account_type);
+    let mut inserted: u64 = 0;
+
+    for acct in &tpl.accounts {
+        let context = if is_shared_account(acct) {
+            "all"
+        } else {
+            profile_context
+        };
+
+        let normal_balance = match acct.account_type.as_str() {
+            "Asset" | "Expense" => "debit",
+            _ => "credit",
+        };
+
+        let result = sqlx::query(
+            r#"
+            INSERT INTO gl_accounts (
+                account_number, account_name, account_type,
+                digital_asset_type, subcategory, description,
+                is_active, is_editable, normal_balance,
+                context, profile_id, hidden
+            )
+            VALUES (?, ?, ?, NULL, ?, ?, ?, 0, ?, ?, ?, 0)
+            ON CONFLICT (profile_id, account_number) DO UPDATE SET
+                account_name = excluded.account_name,
+                account_type = excluded.account_type,
+                subcategory  = excluded.subcategory,
+                description  = excluded.description,
+                context      = excluded.context,
+                normal_balance = excluded.normal_balance,
+                hidden       = 0
+            "#,
+        )
+        .bind(&acct.code)
+        .bind(&acct.name)
+        .bind(&acct.account_type)
+        .bind(&acct.subcategory)
+        .bind(&acct.description)
+        .bind(acct.is_active)
+        .bind(normal_balance)
+        .bind(context)
+        .bind(profile_id)
+        .execute(pool)
+        .await
+        .map_err(|e| format!("Failed to upsert account {}: {e}", acct.code))?;
+
+        inserted += result.rows_affected();
+    }
+
+    Ok(inserted)
 }
 
 // ============================================================================
@@ -5102,6 +5314,187 @@ mod tests {
         assert!(
             price_result.unwrap_err().contains("USD price unavailable"),
             "Error must mention 'USD price unavailable'"
+        );
+    }
+
+    // ========================================================================
+    // GIV-757 — CoA schema + importer tests
+    // ========================================================================
+
+    async fn create_test_profile(pool: &SqlitePool, id: &str) {
+        sqlx::query("INSERT OR IGNORE INTO profiles (id, name) VALUES (?, ?)")
+            .bind(id)
+            .bind(format!("Test Profile {id}"))
+            .execute(pool)
+            .await
+            .expect("Failed to create test profile");
+    }
+
+    #[tokio::test]
+    async fn importer_idempotent_row_count_stable() {
+        let pool = setup_test_db().await;
+        create_test_profile(&pool, "profile-1").await;
+
+        let first =
+            import_coa_template_raw(&pool, "us-gaap", "individual", "profile-1")
+                .await
+                .expect("First import should succeed");
+        assert!(first > 0, "Should insert at least one row");
+
+        let count_after_first: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM gl_accounts WHERE profile_id = 'profile-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let _second =
+            import_coa_template_raw(&pool, "us-gaap", "individual", "profile-1")
+                .await
+                .expect("Second import should succeed");
+
+        let count_after_second: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM gl_accounts WHERE profile_id = 'profile-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            count_after_first.0, count_after_second.0,
+            "Row count must be stable after re-import"
+        );
+    }
+
+    #[tokio::test]
+    async fn revenue_type_accepted_income_still_valid() {
+        let pool = setup_test_db().await;
+
+        sqlx::query(
+            "INSERT INTO gl_accounts (account_number, account_name, account_type, normal_balance, context) VALUES ('9901', 'Revenue Test', 'Revenue', 'credit', 'all')",
+        )
+        .execute(&pool)
+        .await
+        .expect("INSERT with account_type='Revenue' should succeed");
+
+        sqlx::query(
+            "INSERT INTO gl_accounts (account_number, account_name, account_type, normal_balance, context) VALUES ('9902', 'Income Test', 'Income', 'credit', 'all')",
+        )
+        .execute(&pool)
+        .await
+        .expect("INSERT with account_type='Income' should still succeed");
+    }
+
+    #[tokio::test]
+    async fn existing_views_return_rows_after_migration() {
+        let pool = setup_test_db().await;
+
+        let seed_count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM gl_accounts WHERE profile_id IS NULL")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(seed_count.0, 21, "21 seed rows must survive migration");
+
+        let bs_result =
+            sqlx::query_as::<_, (String,)>("SELECT account_type FROM v_balance_sheet LIMIT 1")
+                .fetch_optional(&pool)
+                .await;
+        assert!(bs_result.is_ok(), "v_balance_sheet must be queryable");
+
+        let is_result = sqlx::query_as::<_, (String,)>(
+            "SELECT account_type FROM v_income_statement LIMIT 1",
+        )
+        .fetch_optional(&pool)
+        .await;
+        assert!(is_result.is_ok(), "v_income_statement must be queryable");
+
+        let tb_result = sqlx::query_as::<_, (String,)>(
+            "SELECT account_type FROM v_trial_balance LIMIT 1",
+        )
+        .fetch_optional(&pool)
+        .await;
+        assert!(tb_result.is_ok(), "v_trial_balance must be queryable");
+    }
+
+    #[tokio::test]
+    async fn importer_all_six_templates_succeed() {
+        let pool = setup_test_db().await;
+
+        let combos = [
+            ("us-gaap", "individual"),
+            ("us-gaap", "for-profit-enterprise"),
+            ("us-gaap", "not-for-profit"),
+            ("ifrs", "individual"),
+            ("ifrs", "for-profit-enterprise"),
+            ("ifrs", "not-for-profit"),
+        ];
+
+        for (i, (jur, at)) in combos.iter().enumerate() {
+            let pid = format!("profile-{i}");
+            create_test_profile(&pool, &pid).await;
+            let result = import_coa_template_raw(&pool, jur, at, &pid).await;
+            assert!(
+                result.is_ok(),
+                "Template {jur}/{at} failed: {:?}",
+                result.err()
+            );
+            assert!(result.unwrap() > 0, "Template {jur}/{at} must insert rows");
+        }
+    }
+
+    #[tokio::test]
+    async fn importer_sets_context_correctly() {
+        let pool = setup_test_db().await;
+        create_test_profile(&pool, "ctx-test").await;
+
+        import_coa_template_raw(&pool, "us-gaap", "individual", "ctx-test")
+            .await
+            .unwrap();
+
+        let individual_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM gl_accounts WHERE profile_id = 'ctx-test' AND context = 'individual'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let all_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM gl_accounts WHERE profile_id = 'ctx-test' AND context = 'all'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert!(
+            individual_count.0 > 0,
+            "Some accounts should have context='individual'"
+        );
+        assert!(
+            all_count.0 > 0,
+            "DeFi/crypto accounts should have context='all'"
+        );
+    }
+
+    #[tokio::test]
+    async fn importer_marks_template_rows_not_editable() {
+        let pool = setup_test_db().await;
+        create_test_profile(&pool, "edit-test").await;
+
+        import_coa_template_raw(&pool, "us-gaap", "not-for-profit", "edit-test")
+            .await
+            .unwrap();
+
+        let editable_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM gl_accounts WHERE profile_id = 'edit-test' AND is_editable = 1",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            editable_count.0, 0,
+            "All template-seeded rows must have is_editable = 0"
         );
     }
 }

--- a/src-tauri/src/api/accounting.rs
+++ b/src-tauri/src/api/accounting.rs
@@ -2544,11 +2544,7 @@ fn account_type_to_context(account_type: &str) -> &'static str {
 
 fn is_shared_account(acct: &TemplateAccount) -> bool {
     match acct.subcategory.as_deref() {
-        Some(s)
-            if s.starts_with("Digital")
-                || s.starts_with("DeFi")
-                || s.starts_with("Crypto") =>
-        {
+        Some(s) if s.starts_with("Digital") || s.starts_with("DeFi") || s.starts_with("Crypto") => {
             true
         }
         _ => false,
@@ -5335,30 +5331,26 @@ mod tests {
         let pool = setup_test_db().await;
         create_test_profile(&pool, "profile-1").await;
 
-        let first =
-            import_coa_template_raw(&pool, "us-gaap", "individual", "profile-1")
-                .await
-                .expect("First import should succeed");
+        let first = import_coa_template_raw(&pool, "us-gaap", "individual", "profile-1")
+            .await
+            .expect("First import should succeed");
         assert!(first > 0, "Should insert at least one row");
 
-        let count_after_first: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM gl_accounts WHERE profile_id = 'profile-1'",
-        )
-        .fetch_one(&pool)
-        .await
-        .unwrap();
-
-        let _second =
-            import_coa_template_raw(&pool, "us-gaap", "individual", "profile-1")
+        let count_after_first: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM gl_accounts WHERE profile_id = 'profile-1'")
+                .fetch_one(&pool)
                 .await
-                .expect("Second import should succeed");
+                .unwrap();
 
-        let count_after_second: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*) FROM gl_accounts WHERE profile_id = 'profile-1'",
-        )
-        .fetch_one(&pool)
-        .await
-        .unwrap();
+        let _second = import_coa_template_raw(&pool, "us-gaap", "individual", "profile-1")
+            .await
+            .expect("Second import should succeed");
+
+        let count_after_second: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM gl_accounts WHERE profile_id = 'profile-1'")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
 
         assert_eq!(
             count_after_first.0, count_after_second.0,
@@ -5402,18 +5394,16 @@ mod tests {
                 .await;
         assert!(bs_result.is_ok(), "v_balance_sheet must be queryable");
 
-        let is_result = sqlx::query_as::<_, (String,)>(
-            "SELECT account_type FROM v_income_statement LIMIT 1",
-        )
-        .fetch_optional(&pool)
-        .await;
+        let is_result =
+            sqlx::query_as::<_, (String,)>("SELECT account_type FROM v_income_statement LIMIT 1")
+                .fetch_optional(&pool)
+                .await;
         assert!(is_result.is_ok(), "v_income_statement must be queryable");
 
-        let tb_result = sqlx::query_as::<_, (String,)>(
-            "SELECT account_type FROM v_trial_balance LIMIT 1",
-        )
-        .fetch_optional(&pool)
-        .await;
+        let tb_result =
+            sqlx::query_as::<_, (String,)>("SELECT account_type FROM v_trial_balance LIMIT 1")
+                .fetch_optional(&pool)
+                .await;
         assert!(tb_result.is_ok(), "v_trial_balance must be queryable");
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -486,7 +486,9 @@ pub fn run() {
             api::rules::toggle_classification_rule,
             api::rules::reorder_classification_rules,
             api::rules::delete_classification_rule,
-            api::rules::install_starter_rules
+            api::rules::install_starter_rules,
+            // Chart-of-accounts template importer (GIV-757)
+            api::accounting::import_chart_of_accounts_template
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Summary

- **Migration 1** (`20260727000001`): Recreates `gl_accounts` with expanded `account_type` CHECK (adds `Revenue`), new columns (`context`, `profile_id`, `hidden`), composite UNIQUE on `(profile_id, account_number)`, and index on `(profile_id, context, account_type)`. Rebuilds all 9 dependent views; `v_income_statement` now includes `Revenue`.
- **Migration 2** (`20260727000002`): Adds nullable `functional_classification` column to `journal_entry_lines` for NGO dimensional tagging (used by GIV-759).
- **Tauri command** `import_chart_of_accounts_template`: Idempotent upsert of any of the 6 template JSON files into `gl_accounts` scoped to a profile. DeFi/crypto accounts get `context='all'`; profile-specific accounts get `context='individual'|'sme'|'ngo'`. Template rows are marked `is_editable=0`.
- **6 new tests**: idempotency, Revenue type acceptance, existing view survival, all-6-templates success, context correctness, editability.

All 374 existing tests pass with 0 regressions.

## Unblocks

GIV-758 (onboarding wiring + presentation filter) and GIV-759 (NGO functional classification).