### PR TITLE
fix(giv-445): add aria-label to real-time sync toggle

### DIFF
--- a/src/app/settings/GeneralSettings.tsx
+++ b/src/app/settings/GeneralSettings.tsx
@@ -788,6 +788,7 @@ const BlockchainSyncSection: React.FC = () => {
         <button
           type="button"
           role="switch"
+          aria-label="Real-time sync"
           aria-checked={enabled}
           onClick={handleToggle}
           className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-[#5FE3C0] focus:ring-offset-2 ${


### PR DESCRIPTION
## Summary
- The real-time sync toggle in Settings (`GeneralSettings.tsx`) had `role="switch"` and `aria-checked` but no accessible name
- Playwright's `getByRole('switch', { name: /real.?time sync/i })` in `e2e/settings.spec.ts` couldn't find it, causing CI failure in PR #264
- Added `aria-label="Real-time sync"` to the button — one-line fix

## Test plan
- [ ] `pnpm type-check` passes (verified locally, clean)
- [ ] `e2e/settings.spec.ts` → `real-time sync toggle persists state` now finds the element
- [ ] PR #264 (DeepSource autofix that unskipped the test) should pass CI after this lands

Closes GIV-445 CI failure. PR #264 can be merged after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)