### PR TITLE
fix: use self-closing tag for empty th element (JS-0468)

### DIFF
--- a/src/app/reports/CostBasisReport.tsx
+++ b/src/app/reports/CostBasisReport.tsx
@@ -626,7 +626,7 @@ const DisposalTable: React.FC<{
           <th className="text-center py-3 px-3 text-xs font-semibold text-[#294050] dark:text-[#9FB4BE] uppercase tracking-wider">
             Term
           </th>
-          <th className="py-3 px-3"></th>
+          <th className="py-3 px-3" />
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
## Summary
- Fixes DeepSource JS-0468 introduced in #274: empty `<th>` in `CostBasisReport.tsx` converted to self-closing `<th />`

## Test plan
- [ ] Type-check passes
- [ ] ESLint passes
- [ ] DeepSource JS-0468 issue resolved