### PR TITLE
feat(bank): OFX/QFX/QBO + CSV parsers with dedup (GIV-826)

### DIFF
--- a/src/services/parsers/__tests__/csvParser.test.ts
+++ b/src/services/parsers/__tests__/csvParser.test.ts
@@ -128,7 +128,7 @@ describe('parseCsv', () => {
 
   it('should generate external_ids for all rows', () => {
     const result = parseCsv(SAMPLE_CSV, defaultOptions)
-    const ids = result.transactions.map((t) => t.external_id)
+    const ids = result.transactions.map(t => t.external_id)
     expect(new Set(ids).size).toBe(5)
     for (const id of ids) {
       expect(id).toMatch(/^csv_/)
@@ -208,7 +208,8 @@ describe('parseCsv', () => {
   })
 
   describe('amount sign conventions', () => {
-    const csv = 'Date,Amount,Type\n2026-07-01,45.50,Debit\n2026-07-02,100.00,Credit'
+    const csv =
+      'Date,Amount,Type\n2026-07-01,45.50,Debit\n2026-07-02,100.00,Credit'
 
     it('signed: passes through as-is', () => {
       const opts: CsvParseOptions = {
@@ -248,7 +249,7 @@ describe('parseCsv', () => {
     it('should mark known external_ids as duplicates', () => {
       const result1 = parseCsv(SAMPLE_CSV, defaultOptions)
       const existingIds = new Set(
-        result1.transactions.slice(0, 2).map((t) => t.external_id!)
+        result1.transactions.slice(0, 2).map(t => t.external_id!)
       )
 
       const opts: CsvParseOptions = {
@@ -257,7 +258,7 @@ describe('parseCsv', () => {
       }
       const result2 = parseCsv(SAMPLE_CSV, opts)
       expect(result2.duplicateCount).toBe(2)
-      expect(result2.transactions.filter((t) => t._isDuplicate)).toHaveLength(2)
+      expect(result2.transactions.filter(t => t._isDuplicate)).toHaveLength(2)
     })
   })
 

--- a/src/services/parsers/__tests__/csvParser.test.ts
+++ b/src/services/parsers/__tests__/csvParser.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect } from 'vitest'
+import { parseCsv, detectCsvFormat, inferColumnMap } from '../csvParser'
+import type { CsvParseOptions } from '../types'
+
+const SAMPLE_CSV = `Date,Description,Amount,Balance
+2026-07-01,GROCERY STORE,-45.50,5280.00
+2026-07-03,EMPLOYER INC,2500.00,7780.00
+2026-07-05,ELECTRIC BILL,-120.00,7660.00
+2026-07-08,ATM WITHDRAWAL,-200.00,7460.00
+2026-07-10,RESTAURANT,-35.25,7424.75`
+
+const QUOTED_CSV = `"Date","Payee","Memo","Amount","Balance"
+"07/01/2026","GROCERY STORE","Weekly groceries","-45.50","5280.00"
+"07/03/2026","EMPLOYER, INC","Direct deposit, payroll","2500.00","7780.00"
+"07/05/2026","ELECTRIC ""BILL""","Monthly utility","-120.00","7660.00"`
+
+const defaultOptions: CsvParseOptions = {
+  bankAccountId: 'test-bank-1',
+  columnMap: {
+    date: 'Date',
+    amount: 'Amount',
+    payee: 'Description',
+    balance: 'Balance',
+  },
+  dateFormat: 'YYYY-MM-DD',
+  amountSignConvention: 'signed',
+  currencyDefault: 'USD',
+}
+
+describe('detectCsvFormat', () => {
+  it('should detect CSV with banking headers', () => {
+    expect(detectCsvFormat(SAMPLE_CSV)).toBe(true)
+  })
+
+  it('should reject non-CSV content', () => {
+    expect(detectCsvFormat('OFXHEADER:100\nDATA:OFXSGML')).toBe(false)
+  })
+
+  it('should reject single-line content', () => {
+    expect(detectCsvFormat('just one line')).toBe(false)
+  })
+
+  it('should detect various header styles', () => {
+    expect(detectCsvFormat('Transaction Date,Debit,Credit\n1,2,3')).toBe(true)
+    expect(detectCsvFormat('posting date,amount,memo\n1,2,3')).toBe(true)
+    expect(detectCsvFormat('Reference,Check,Balance\n1,2,3')).toBe(true)
+  })
+})
+
+describe('inferColumnMap', () => {
+  it('should map standard headers', () => {
+    const headers = ['Date', 'Description', 'Amount', 'Balance']
+    const map = inferColumnMap(headers)
+    expect(map.date).toBe('Date')
+    expect(map.amount).toBe('Amount')
+    expect(map.payee).toBe('Description')
+    expect(map.balance).toBe('Balance')
+  })
+
+  it('should map alternative header names', () => {
+    const headers = ['Posted Date', 'Payee', 'Memo', 'Debit', 'Reference']
+    const map = inferColumnMap(headers)
+    expect(map.date).toBe('Posted Date')
+    expect(map.payee).toBe('Payee')
+    expect(map.memo).toBe('Memo')
+    expect(map.amount).toBe('Debit')
+    expect(map.referenceNumber).toBe('Reference')
+  })
+})
+
+describe('parseCsv', () => {
+  it('should parse all 5 data rows', () => {
+    const result = parseCsv(SAMPLE_CSV, defaultOptions)
+    expect(result.transactions).toHaveLength(5)
+    expect(result.format).toBe('csv')
+    expect(result.totalCount).toBe(5)
+  })
+
+  it('should set correct amounts', () => {
+    const result = parseCsv(SAMPLE_CSV, defaultOptions)
+    expect(result.transactions[0].amount).toBe('-45.5')
+    expect(result.transactions[1].amount).toBe('2500')
+    expect(result.transactions[2].amount).toBe('-120')
+  })
+
+  it('should set payees from description column', () => {
+    const result = parseCsv(SAMPLE_CSV, defaultOptions)
+    expect(result.transactions[0].payee).toBe('GROCERY STORE')
+    expect(result.transactions[1].payee).toBe('EMPLOYER INC')
+  })
+
+  it('should set running balance', () => {
+    const result = parseCsv(SAMPLE_CSV, defaultOptions)
+    expect(result.transactions[0].running_balance).toBe('5280.00')
+  })
+
+  it('should parse dates correctly', () => {
+    const result = parseCsv(SAMPLE_CSV, defaultOptions)
+    const date = new Date(result.transactions[0].posted_date)
+    expect(date.getUTCFullYear()).toBe(2026)
+    expect(date.getUTCMonth()).toBe(6)
+    expect(date.getUTCDate()).toBe(1)
+  })
+
+  it('should compute date range', () => {
+    const result = parseCsv(SAMPLE_CSV, defaultOptions)
+    expect(result.dateRange).toBeDefined()
+    const start = new Date(result.dateRange!.start)
+    const end = new Date(result.dateRange!.end)
+    expect(start.getUTCDate()).toBe(1)
+    expect(end.getUTCDate()).toBe(10)
+  })
+
+  it('should set currency from options', () => {
+    const result = parseCsv(SAMPLE_CSV, defaultOptions)
+    expect(result.currency).toBe('USD')
+    for (const tx of result.transactions) {
+      expect(tx.currency).toBe('USD')
+    }
+  })
+
+  it('should set bank_account_id on all transactions', () => {
+    const result = parseCsv(SAMPLE_CSV, defaultOptions)
+    for (const tx of result.transactions) {
+      expect(tx.bank_account_id).toBe('test-bank-1')
+    }
+  })
+
+  it('should generate external_ids for all rows', () => {
+    const result = parseCsv(SAMPLE_CSV, defaultOptions)
+    const ids = result.transactions.map((t) => t.external_id)
+    expect(new Set(ids).size).toBe(5)
+    for (const id of ids) {
+      expect(id).toMatch(/^csv_/)
+    }
+  })
+
+  describe('quoted CSV', () => {
+    it('should handle quoted fields with commas', () => {
+      const opts: CsvParseOptions = {
+        ...defaultOptions,
+        columnMap: {
+          date: 'Date',
+          amount: 'Amount',
+          payee: 'Payee',
+          memo: 'Memo',
+          balance: 'Balance',
+        },
+        dateFormat: 'MM/DD/YYYY',
+      }
+      const result = parseCsv(QUOTED_CSV, opts)
+      expect(result.transactions).toHaveLength(3)
+      expect(result.transactions[1].payee).toBe('EMPLOYER, INC')
+      expect(result.transactions[1].memo).toBe('Direct deposit, payroll')
+    })
+
+    it('should handle escaped quotes', () => {
+      const opts: CsvParseOptions = {
+        ...defaultOptions,
+        columnMap: {
+          date: 'Date',
+          amount: 'Amount',
+          payee: 'Payee',
+          memo: 'Memo',
+          balance: 'Balance',
+        },
+        dateFormat: 'MM/DD/YYYY',
+      }
+      const result = parseCsv(QUOTED_CSV, opts)
+      expect(result.transactions[2].payee).toBe('ELECTRIC "BILL"')
+    })
+  })
+
+  describe('date formats', () => {
+    const makeOpts = (dateFormat: string): CsvParseOptions => ({
+      ...defaultOptions,
+      dateFormat,
+    })
+
+    it('should parse MM/DD/YYYY', () => {
+      const csv = 'Date,Amount\n07/15/2026,100'
+      const opts = makeOpts('MM/DD/YYYY')
+      opts.columnMap = { date: 'Date', amount: 'Amount' }
+      const result = parseCsv(csv, opts)
+      const d = new Date(result.transactions[0].posted_date)
+      expect(d.getUTCMonth()).toBe(6)
+      expect(d.getUTCDate()).toBe(15)
+    })
+
+    it('should parse DD/MM/YYYY', () => {
+      const csv = 'Date,Amount\n15/07/2026,100'
+      const opts = makeOpts('DD/MM/YYYY')
+      opts.columnMap = { date: 'Date', amount: 'Amount' }
+      const result = parseCsv(csv, opts)
+      const d = new Date(result.transactions[0].posted_date)
+      expect(d.getUTCMonth()).toBe(6)
+      expect(d.getUTCDate()).toBe(15)
+    })
+
+    it('should parse DD.MM.YYYY', () => {
+      const csv = 'Date,Amount\n15.07.2026,100'
+      const opts = makeOpts('DD.MM.YYYY')
+      opts.columnMap = { date: 'Date', amount: 'Amount' }
+      const result = parseCsv(csv, opts)
+      const d = new Date(result.transactions[0].posted_date)
+      expect(d.getUTCMonth()).toBe(6)
+    })
+  })
+
+  describe('amount sign conventions', () => {
+    const csv = 'Date,Amount,Type\n2026-07-01,45.50,Debit\n2026-07-02,100.00,Credit'
+
+    it('signed: passes through as-is', () => {
+      const opts: CsvParseOptions = {
+        ...defaultOptions,
+        columnMap: { date: 'Date', amount: 'Amount', type: 'Type' },
+        amountSignConvention: 'signed',
+      }
+      const result = parseCsv(csv, opts)
+      expect(result.transactions[0].amount).toBe('45.5')
+    })
+
+    it('debit_positive: negates debit rows', () => {
+      const opts: CsvParseOptions = {
+        ...defaultOptions,
+        columnMap: { date: 'Date', amount: 'Amount', type: 'Type' },
+        amountSignConvention: 'debit_positive',
+      }
+      const result = parseCsv(csv, opts)
+      expect(result.transactions[0].amount).toBe('-45.5')
+      expect(result.transactions[1].amount).toBe('100')
+    })
+
+    it('debit_negative: passes through as-is', () => {
+      const negCsv = 'Date,Amount\n2026-07-01,-45.50\n2026-07-02,100.00'
+      const opts: CsvParseOptions = {
+        ...defaultOptions,
+        columnMap: { date: 'Date', amount: 'Amount' },
+        amountSignConvention: 'debit_negative',
+      }
+      const result = parseCsv(negCsv, opts)
+      expect(result.transactions[0].amount).toBe('-45.5')
+      expect(result.transactions[1].amount).toBe('100')
+    })
+  })
+
+  describe('dedup', () => {
+    it('should mark known external_ids as duplicates', () => {
+      const result1 = parseCsv(SAMPLE_CSV, defaultOptions)
+      const existingIds = new Set(
+        result1.transactions.slice(0, 2).map((t) => t.external_id!)
+      )
+
+      const opts: CsvParseOptions = {
+        ...defaultOptions,
+        existingExternalIds: existingIds,
+      }
+      const result2 = parseCsv(SAMPLE_CSV, opts)
+      expect(result2.duplicateCount).toBe(2)
+      expect(result2.transactions.filter((t) => t._isDuplicate)).toHaveLength(2)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty content', () => {
+      const result = parseCsv('', defaultOptions)
+      expect(result.transactions).toHaveLength(0)
+    })
+
+    it('should handle header-only', () => {
+      const result = parseCsv('Date,Amount', defaultOptions)
+      expect(result.transactions).toHaveLength(0)
+    })
+
+    it('should skip rows with invalid dates', () => {
+      const csv = 'Date,Amount\nbaddate,100\n2026-07-01,200'
+      const opts: CsvParseOptions = {
+        ...defaultOptions,
+        columnMap: { date: 'Date', amount: 'Amount' },
+      }
+      const result = parseCsv(csv, opts)
+      expect(result.transactions).toHaveLength(1)
+    })
+
+    it('should handle currency symbols in amounts', () => {
+      const csv = 'Date,Amount\n2026-07-01,"$1,234.56"'
+      const opts: CsvParseOptions = {
+        ...defaultOptions,
+        columnMap: { date: 'Date', amount: 'Amount' },
+      }
+      const result = parseCsv(csv, opts)
+      expect(result.transactions[0].amount).toBe('1234.56')
+    })
+
+    it('should skip custom header rows', () => {
+      const csv = 'Bank Statement\nDate,Amount\n2026-07-01,100\n2026-07-02,200'
+      const opts: CsvParseOptions = {
+        ...defaultOptions,
+        columnMap: { date: 'Date', amount: 'Amount' },
+        skipHeaderRows: 2,
+      }
+      const result = parseCsv(csv, opts)
+      expect(result.transactions).toHaveLength(2)
+    })
+
+    it('should handle Windows line endings', () => {
+      const csv = 'Date,Amount\r\n2026-07-01,100\r\n2026-07-02,200'
+      const opts: CsvParseOptions = {
+        ...defaultOptions,
+        columnMap: { date: 'Date', amount: 'Amount' },
+      }
+      const result = parseCsv(csv, opts)
+      expect(result.transactions).toHaveLength(2)
+    })
+  })
+})

--- a/src/services/parsers/__tests__/csvParser.test.ts
+++ b/src/services/parsers/__tests__/csvParser.test.ts
@@ -105,8 +105,9 @@ describe('parseCsv', () => {
   it('should compute date range', () => {
     const result = parseCsv(SAMPLE_CSV, defaultOptions)
     expect(result.dateRange).toBeDefined()
-    const start = new Date(result.dateRange!.start)
-    const end = new Date(result.dateRange!.end)
+    if (!result.dateRange) return
+    const start = new Date(result.dateRange.start)
+    const end = new Date(result.dateRange.end)
     expect(start.getUTCDate()).toBe(1)
     expect(end.getUTCDate()).toBe(10)
   })

--- a/src/services/parsers/__tests__/csvParser.test.ts
+++ b/src/services/parsers/__tests__/csvParser.test.ts
@@ -183,9 +183,9 @@ describe('parseCsv', () => {
       const opts = makeOpts('MM/DD/YYYY')
       opts.columnMap = { date: 'Date', amount: 'Amount' }
       const result = parseCsv(csv, opts)
-      const d = new Date(result.transactions[0].posted_date)
-      expect(d.getUTCMonth()).toBe(6)
-      expect(d.getUTCDate()).toBe(15)
+      const date = new Date(result.transactions[0].posted_date)
+      expect(date.getUTCMonth()).toBe(6)
+      expect(date.getUTCDate()).toBe(15)
     })
 
     it('should parse DD/MM/YYYY', () => {
@@ -193,9 +193,9 @@ describe('parseCsv', () => {
       const opts = makeOpts('DD/MM/YYYY')
       opts.columnMap = { date: 'Date', amount: 'Amount' }
       const result = parseCsv(csv, opts)
-      const d = new Date(result.transactions[0].posted_date)
-      expect(d.getUTCMonth()).toBe(6)
-      expect(d.getUTCDate()).toBe(15)
+      const date = new Date(result.transactions[0].posted_date)
+      expect(date.getUTCMonth()).toBe(6)
+      expect(date.getUTCDate()).toBe(15)
     })
 
     it('should parse DD.MM.YYYY', () => {
@@ -203,8 +203,8 @@ describe('parseCsv', () => {
       const opts = makeOpts('DD.MM.YYYY')
       opts.columnMap = { date: 'Date', amount: 'Amount' }
       const result = parseCsv(csv, opts)
-      const d = new Date(result.transactions[0].posted_date)
-      expect(d.getUTCMonth()).toBe(6)
+      const date = new Date(result.transactions[0].posted_date)
+      expect(date.getUTCMonth()).toBe(6)
     })
   })
 
@@ -250,7 +250,7 @@ describe('parseCsv', () => {
     it('should mark known external_ids as duplicates', () => {
       const result1 = parseCsv(SAMPLE_CSV, defaultOptions)
       const existingIds = new Set(
-        result1.transactions.slice(0, 2).map(t => t.external_id!)
+        result1.transactions.slice(0, 2).map(t => t.external_id ?? '')
       )
 
       const opts: CsvParseOptions = {

--- a/src/services/parsers/__tests__/dedup.test.ts
+++ b/src/services/parsers/__tests__/dedup.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import { dedup, buildExternalIdSet } from '../dedup'
+import type { ParsedTransaction } from '../types'
+import type { BankTransaction } from '../../persistence/types'
+
+function makeParsed(
+  overrides: Partial<ParsedTransaction> = {}
+): ParsedTransaction {
+  return {
+    bank_account_id: 'acct-1',
+    posted_date: Date.UTC(2026, 6, 1),
+    amount: '100',
+    currency: 'USD',
+    classification_status: 'unclassified',
+    ...overrides,
+  }
+}
+
+function makeExisting(
+  overrides: Partial<BankTransaction> = {}
+): BankTransaction {
+  return {
+    id: 'tx-1',
+    bank_account_id: 'acct-1',
+    posted_date: Date.UTC(2026, 6, 1),
+    amount: '100',
+    currency: 'USD',
+    classification_status: 'unclassified',
+    created_at: Date.now(),
+    updated_at: Date.now(),
+    ...overrides,
+  }
+}
+
+describe('dedup', () => {
+  it('should pass through all when no existing', () => {
+    const parsed = [
+      makeParsed({ external_id: 'A' }),
+      makeParsed({ external_id: 'B' }),
+    ]
+    const result = dedup(parsed, [])
+    expect(result.unique).toHaveLength(2)
+    expect(result.duplicates).toHaveLength(0)
+    expect(result.duplicateCount).toBe(0)
+  })
+
+  it('should detect duplicates by composite key', () => {
+    const parsed = [
+      makeParsed({ external_id: 'FITID-001' }),
+      makeParsed({ external_id: 'FITID-002' }),
+      makeParsed({ external_id: 'FITID-003' }),
+    ]
+    const existing = [
+      makeExisting({ external_id: 'FITID-001' }),
+      makeExisting({ external_id: 'FITID-003' }),
+    ]
+    const result = dedup(parsed, existing)
+    expect(result.unique).toHaveLength(1)
+    expect(result.unique[0].external_id).toBe('FITID-002')
+    expect(result.duplicates).toHaveLength(2)
+    expect(result.duplicateCount).toBe(2)
+  })
+
+  it('should detect intra-batch duplicates', () => {
+    const parsed = [
+      makeParsed({ external_id: 'SAME-ID' }),
+      makeParsed({ external_id: 'SAME-ID' }),
+      makeParsed({ external_id: 'DIFFERENT' }),
+    ]
+    const result = dedup(parsed, [])
+    expect(result.unique).toHaveLength(2)
+    expect(result.duplicates).toHaveLength(1)
+    expect(result.duplicates[0]._isDuplicate).toBe(true)
+  })
+
+  it('should not dedup transactions without external_id', () => {
+    const parsed = [
+      makeParsed({ external_id: undefined }),
+      makeParsed({ external_id: undefined }),
+    ]
+    const result = dedup(parsed, [])
+    expect(result.unique).toHaveLength(2)
+    expect(result.duplicates).toHaveLength(0)
+  })
+
+  it('should scope dedup to bank_account_id', () => {
+    const parsed = [
+      makeParsed({ bank_account_id: 'acct-1', external_id: 'X' }),
+      makeParsed({ bank_account_id: 'acct-2', external_id: 'X' }),
+    ]
+    const existing = [
+      makeExisting({ bank_account_id: 'acct-1', external_id: 'X' }),
+    ]
+    const result = dedup(parsed, existing)
+    expect(result.unique).toHaveLength(1)
+    expect(result.unique[0].bank_account_id).toBe('acct-2')
+    expect(result.duplicates).toHaveLength(1)
+  })
+
+  it('should preserve _isDuplicate flag on duplicates', () => {
+    const parsed = [makeParsed({ external_id: 'DUP' })]
+    const existing = [makeExisting({ external_id: 'DUP' })]
+    const result = dedup(parsed, existing)
+    expect(result.duplicates[0]._isDuplicate).toBe(true)
+    expect(result.duplicates[0]._duplicateOf).toBe('DUP')
+  })
+
+  it('should clear _isDuplicate on unique items', () => {
+    const parsed = [makeParsed({ external_id: 'NEW' })]
+    const result = dedup(parsed, [])
+    expect(result.unique[0]._isDuplicate).toBe(false)
+  })
+})
+
+describe('buildExternalIdSet', () => {
+  it('should collect external_ids', () => {
+    const existing = [
+      makeExisting({ external_id: 'A' }),
+      makeExisting({ external_id: 'B' }),
+      makeExisting({ external_id: null }),
+    ]
+    const set = buildExternalIdSet(existing)
+    expect(set.size).toBe(2)
+    expect(set.has('A')).toBe(true)
+    expect(set.has('B')).toBe(true)
+  })
+
+  it('should return empty set for no transactions', () => {
+    expect(buildExternalIdSet([]).size).toBe(0)
+  })
+})

--- a/src/services/parsers/__tests__/index.test.ts
+++ b/src/services/parsers/__tests__/index.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { detectFormat, parseStatement, BANK_IMPORT_FLAG } from '../index'
+
+describe('detectFormat', () => {
+  it('should detect OFX by content', () => {
+    expect(detectFormat('OFXHEADER:100\n<OFX>')).toBe('ofx')
+  })
+
+  it('should detect QFX by extension', () => {
+    expect(detectFormat('OFXHEADER:100\n<OFX>', 'statement.qfx')).toBe('qfx')
+  })
+
+  it('should detect QBO by extension', () => {
+    expect(detectFormat('OFXHEADER:100\n<OFX>', 'data.qbo')).toBe('qbo')
+  })
+
+  it('should detect OFX by extension', () => {
+    expect(detectFormat('some content', 'file.ofx')).toBe('ofx')
+  })
+
+  it('should detect CSV by extension', () => {
+    expect(detectFormat('Date,Amount\n1,2', 'stmt.csv')).toBe('csv')
+  })
+
+  it('should detect CSV by content', () => {
+    expect(
+      detectFormat('Date,Description,Amount\n2026-07-01,Test,100')
+    ).toBe('csv')
+  })
+
+  it('should return null for unknown format', () => {
+    expect(detectFormat('random binary data')).toBeNull()
+  })
+
+  it('should prefer extension over content detection', () => {
+    expect(
+      detectFormat('Date,Amount\n1,2', 'transactions.qfx')
+    ).toBe('qfx')
+  })
+})
+
+describe('parseStatement', () => {
+  it('should parse OFX format', () => {
+    const ofx = `OFXHEADER:100
+<OFX>
+<BANKTRANLIST>
+<STMTTRN>
+<TRNTYPE>DEBIT
+<DTPOSTED>20260701
+<TRNAMT>-50
+<FITID>TEST001
+<NAME>Test Payee
+</STMTTRN>
+</BANKTRANLIST>
+</OFX>`
+    const result = parseStatement(ofx, 'ofx', { bankAccountId: 'acct-1' })
+    expect(result.transactions).toHaveLength(1)
+    expect(result.format).toBe('ofx')
+    expect(result.transactions[0].amount).toBe('-50')
+  })
+
+  it('should parse CSV format', () => {
+    const csv = 'Date,Amount\n2026-07-01,100'
+    const result = parseStatement(csv, 'csv', {
+      bankAccountId: 'acct-1',
+      columnMap: { date: 'Date', amount: 'Amount' },
+      dateFormat: 'YYYY-MM-DD',
+      amountSignConvention: 'signed',
+      currencyDefault: 'USD',
+    })
+    expect(result.transactions).toHaveLength(1)
+    expect(result.format).toBe('csv')
+  })
+
+  it('should route QFX to OFX parser', () => {
+    const qfx = '<OFX><BANKTRANLIST><STMTTRN><TRNTYPE>DEBIT<DTPOSTED>20260701<TRNAMT>-10<FITID>Q1<NAME>QFX Test</STMTTRN></BANKTRANLIST></OFX>'
+    const result = parseStatement(qfx, 'qfx', { bankAccountId: 'acct-1' })
+    expect(result.transactions).toHaveLength(1)
+  })
+
+  it('should route QBO to OFX parser', () => {
+    const qbo = '<OFX><BANKTRANLIST><STMTTRN><TRNTYPE>CREDIT<DTPOSTED>20260701<TRNAMT>500<FITID>QB1<NAME>QBO Test</STMTTRN></BANKTRANLIST></OFX>'
+    const result = parseStatement(qbo, 'qbo', { bankAccountId: 'acct-1' })
+    expect(result.transactions).toHaveLength(1)
+  })
+
+  it('should throw for unsupported format', () => {
+    expect(() =>
+      parseStatement('data', 'xml' as never, { bankAccountId: 'acct-1' })
+    ).toThrow('Unsupported format')
+  })
+})
+
+describe('BANK_IMPORT_FLAG', () => {
+  it('should export the feature flag key', () => {
+    expect(BANK_IMPORT_FLAG).toBe('bank_import_v1')
+  })
+})

--- a/src/services/parsers/__tests__/index.test.ts
+++ b/src/services/parsers/__tests__/index.test.ts
@@ -23,9 +23,9 @@ describe('detectFormat', () => {
   })
 
   it('should detect CSV by content', () => {
-    expect(
-      detectFormat('Date,Description,Amount\n2026-07-01,Test,100')
-    ).toBe('csv')
+    expect(detectFormat('Date,Description,Amount\n2026-07-01,Test,100')).toBe(
+      'csv'
+    )
   })
 
   it('should return null for unknown format', () => {
@@ -33,9 +33,7 @@ describe('detectFormat', () => {
   })
 
   it('should prefer extension over content detection', () => {
-    expect(
-      detectFormat('Date,Amount\n1,2', 'transactions.qfx')
-    ).toBe('qfx')
+    expect(detectFormat('Date,Amount\n1,2', 'transactions.qfx')).toBe('qfx')
   })
 })
 
@@ -73,13 +71,15 @@ describe('parseStatement', () => {
   })
 
   it('should route QFX to OFX parser', () => {
-    const qfx = '<OFX><BANKTRANLIST><STMTTRN><TRNTYPE>DEBIT<DTPOSTED>20260701<TRNAMT>-10<FITID>Q1<NAME>QFX Test</STMTTRN></BANKTRANLIST></OFX>'
+    const qfx =
+      '<OFX><BANKTRANLIST><STMTTRN><TRNTYPE>DEBIT<DTPOSTED>20260701<TRNAMT>-10<FITID>Q1<NAME>QFX Test</STMTTRN></BANKTRANLIST></OFX>'
     const result = parseStatement(qfx, 'qfx', { bankAccountId: 'acct-1' })
     expect(result.transactions).toHaveLength(1)
   })
 
   it('should route QBO to OFX parser', () => {
-    const qbo = '<OFX><BANKTRANLIST><STMTTRN><TRNTYPE>CREDIT<DTPOSTED>20260701<TRNAMT>500<FITID>QB1<NAME>QBO Test</STMTTRN></BANKTRANLIST></OFX>'
+    const qbo =
+      '<OFX><BANKTRANLIST><STMTTRN><TRNTYPE>CREDIT<DTPOSTED>20260701<TRNAMT>500<FITID>QB1<NAME>QBO Test</STMTTRN></BANKTRANLIST></OFX>'
     const result = parseStatement(qbo, 'qbo', { bankAccountId: 'acct-1' })
     expect(result.transactions).toHaveLength(1)
   })

--- a/src/services/parsers/__tests__/ofxParser.test.ts
+++ b/src/services/parsers/__tests__/ofxParser.test.ts
@@ -170,7 +170,8 @@ describe('parseOfx', () => {
     it('should extract date range', () => {
       const result = parseOfx(OFX_V1_SAMPLE, defaultOptions)
       expect(result.dateRange).toBeDefined()
-      const startDate = new Date(result.dateRange!.start)
+      if (!result.dateRange) return
+      const startDate = new Date(result.dateRange.start)
       expect(startDate.getUTCFullYear()).toBe(2026)
       expect(startDate.getUTCMonth()).toBe(6)
       expect(startDate.getUTCDate()).toBe(1)

--- a/src/services/parsers/__tests__/ofxParser.test.ts
+++ b/src/services/parsers/__tests__/ofxParser.test.ts
@@ -135,7 +135,9 @@ describe('detectOfxFormat', () => {
   })
 
   it('should return null for non-OFX content', () => {
-    expect(detectOfxFormat('Date,Amount,Description\n2026-07-01,100,Test')).toBeNull()
+    expect(
+      detectOfxFormat('Date,Amount,Description\n2026-07-01,100,Test')
+    ).toBeNull()
   })
 
   it('should detect by <OFX> tag alone', () => {
@@ -248,7 +250,7 @@ describe('parseOfx', () => {
       const result = parseOfx(OFX_V1_SAMPLE, opts)
       expect(result.duplicateCount).toBe(2)
 
-      const dupes = result.transactions.filter((t) => t._isDuplicate)
+      const dupes = result.transactions.filter(t => t._isDuplicate)
       expect(dupes).toHaveLength(2)
       expect(dupes[0].external_id).toBe('20260702001')
       expect(dupes[1].external_id).toBe('20260710001')
@@ -299,9 +301,24 @@ DATA:OFXSGML
 
     it('should map all known OFX transaction types', () => {
       const types = [
-        'CREDIT', 'DEBIT', 'INT', 'DIV', 'FEE', 'SRVCHG',
-        'DEP', 'ATM', 'POS', 'XFER', 'CHECK', 'PAYMENT',
-        'CASH', 'DIRECTDEP', 'DIRECTDEBIT', 'REPEATPMT', 'HOLD', 'OTHER',
+        'CREDIT',
+        'DEBIT',
+        'INT',
+        'DIV',
+        'FEE',
+        'SRVCHG',
+        'DEP',
+        'ATM',
+        'POS',
+        'XFER',
+        'CHECK',
+        'PAYMENT',
+        'CASH',
+        'DIRECTDEP',
+        'DIRECTDEBIT',
+        'REPEATPMT',
+        'HOLD',
+        'OTHER',
       ]
       for (const t of types) {
         const ofx = `<OFX><BANKTRANLIST><STMTTRN><TRNTYPE>${t}<DTPOSTED>20260701<TRNAMT>100<FITID>test_${t}<NAME>Test</STMTTRN></BANKTRANLIST></OFX>`

--- a/src/services/parsers/__tests__/ofxParser.test.ts
+++ b/src/services/parsers/__tests__/ofxParser.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect } from 'vitest'
+import { parseOfx, detectOfxFormat } from '../ofxParser'
+import type { OfxParseOptions } from '../types'
+
+const OFX_V1_SAMPLE = `OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:USASCII
+CHARSET:1252
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+
+<OFX>
+<SIGNONMSGSRSV1>
+<SONRS>
+<STATUS>
+<CODE>0
+<SEVERITY>INFO
+</STATUS>
+<DTSERVER>20260715120000
+<LANGUAGE>ENG
+<FI>
+<ORG>Test Bank
+<FID>12345
+</FI>
+</SONRS>
+</SIGNONMSGSRSV1>
+<BANKMSGSRSV1>
+<STMTTRNRS>
+<TRNUID>1001
+<STATUS>
+<CODE>0
+<SEVERITY>INFO
+</STATUS>
+<STMTRS>
+<CURDEF>USD
+<BANKACCTFROM>
+<BANKID>071000013
+<ACCTID>123456789
+<ACCTTYPE>CHECKING
+</BANKACCTFROM>
+<BANKTRANLIST>
+<DTSTART>20260701
+<DTEND>20260715
+<STMTTRN>
+<TRNTYPE>DEBIT
+<DTPOSTED>20260702
+<TRNAMT>-45.50
+<FITID>20260702001
+<NAME>GROCERY STORE
+<MEMO>Purchase at grocery
+</STMTTRN>
+<STMTTRN>
+<TRNTYPE>CREDIT
+<DTPOSTED>20260705
+<TRNAMT>2500.00
+<FITID>20260705001
+<NAME>EMPLOYER INC
+<MEMO>Direct deposit payroll
+</STMTTRN>
+<STMTTRN>
+<TRNTYPE>CHECK
+<DTPOSTED>20260710
+<TRNAMT>-150.00
+<FITID>20260710001
+<NAME>LANDLORD
+<CHECKNUM>1042
+</STMTTRN>
+</BANKTRANLIST>
+<LEDGERBAL>
+<BALAMT>5234.50
+<DTASOF>20260715
+</LEDGERBAL>
+</STMTRS>
+</STMTTRNRS>
+</BANKMSGSRSV1>
+</OFX>`
+
+const OFX_V2_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<?OFX OFXHEADER="200" VERSION="220" SECURITY="NONE" OLDFILEUID="NONE" NEWFILEUID="NONE"?>
+<OFX>
+<SIGNONMSGSRSV1>
+<SONRS>
+<STATUS><CODE>0</CODE><SEVERITY>INFO</SEVERITY></STATUS>
+<DTSERVER>20260715120000</DTSERVER>
+<LANGUAGE>ENG</LANGUAGE>
+</SONRS>
+</SIGNONMSGSRSV1>
+<CREDITCARDMSGSRSV1>
+<CCSTMTTRNRS>
+<TRNUID>2001</TRNUID>
+<STATUS><CODE>0</CODE><SEVERITY>INFO</SEVERITY></STATUS>
+<CCSTMTRS>
+<CURDEF>EUR</CURDEF>
+<CCACCTFROM>
+<ACCTID>4111111111111111</ACCTID>
+</CCACCTFROM>
+<BANKTRANLIST>
+<DTSTART>20260701</DTSTART>
+<DTEND>20260715</DTEND>
+<STMTTRN>
+<TRNTYPE>DEBIT</TRNTYPE>
+<DTPOSTED>20260703120000</DTPOSTED>
+<TRNAMT>-29.99</TRNAMT>
+<FITID>CC20260703001</FITID>
+<NAME>STREAMING SERVICE</NAME>
+<MEMO>Monthly subscription</MEMO>
+</STMTTRN>
+<STMTTRN>
+<TRNTYPE>PAYMENT</TRNTYPE>
+<DTPOSTED>20260710</DTPOSTED>
+<TRNAMT>500.00</TRNAMT>
+<FITID>CC20260710001</FITID>
+<NAME>PAYMENT RECEIVED</NAME>
+</STMTTRN>
+</BANKTRANLIST>
+</CCSTMTRS>
+</CCSTMTTRNRS>
+</CREDITCARDMSGSRSV1>
+</OFX>`
+
+const defaultOptions: OfxParseOptions = {
+  bankAccountId: 'test-bank-acct-1',
+}
+
+describe('detectOfxFormat', () => {
+  it('should detect OFX v1 by header', () => {
+    expect(detectOfxFormat(OFX_V1_SAMPLE)).toBe('ofx')
+  })
+
+  it('should detect OFX v2 by XML processing instruction', () => {
+    expect(detectOfxFormat(OFX_V2_XML)).toBe('ofx')
+  })
+
+  it('should return null for non-OFX content', () => {
+    expect(detectOfxFormat('Date,Amount,Description\n2026-07-01,100,Test')).toBeNull()
+  })
+
+  it('should detect by <OFX> tag alone', () => {
+    expect(detectOfxFormat('some preamble\n<OFX>\n')).toBe('ofx')
+  })
+})
+
+describe('parseOfx', () => {
+  describe('OFX v1 (SGML)', () => {
+    it('should parse all 3 transactions', () => {
+      const result = parseOfx(OFX_V1_SAMPLE, defaultOptions)
+      expect(result.transactions).toHaveLength(3)
+      expect(result.format).toBe('ofx')
+      expect(result.totalCount).toBe(3)
+    })
+
+    it('should extract currency', () => {
+      const result = parseOfx(OFX_V1_SAMPLE, defaultOptions)
+      expect(result.currency).toBe('USD')
+    })
+
+    it('should extract account info', () => {
+      const result = parseOfx(OFX_V1_SAMPLE, defaultOptions)
+      expect(result.accountInfo?.bankId).toBe('071000013')
+      expect(result.accountInfo?.accountId).toBe('123456789')
+      expect(result.accountInfo?.accountType).toBe('CHECKING')
+      expect(result.accountInfo?.institutionName).toBe('Test Bank')
+    })
+
+    it('should extract date range', () => {
+      const result = parseOfx(OFX_V1_SAMPLE, defaultOptions)
+      expect(result.dateRange).toBeDefined()
+      const startDate = new Date(result.dateRange!.start)
+      expect(startDate.getUTCFullYear()).toBe(2026)
+      expect(startDate.getUTCMonth()).toBe(6)
+      expect(startDate.getUTCDate()).toBe(1)
+    })
+
+    it('should parse debit transaction correctly', () => {
+      const result = parseOfx(OFX_V1_SAMPLE, defaultOptions)
+      const debit = result.transactions[0]
+      expect(debit.amount).toBe('-45.50')
+      expect(debit.external_id).toBe('20260702001')
+      expect(debit.payee).toBe('GROCERY STORE')
+      expect(debit.memo).toBe('Purchase at grocery')
+      expect(debit.tx_type).toBe('debit')
+      expect(debit.bank_account_id).toBe('test-bank-acct-1')
+    })
+
+    it('should parse credit transaction correctly', () => {
+      const result = parseOfx(OFX_V1_SAMPLE, defaultOptions)
+      const credit = result.transactions[1]
+      expect(credit.amount).toBe('2500.00')
+      expect(credit.external_id).toBe('20260705001')
+      expect(credit.payee).toBe('EMPLOYER INC')
+      expect(credit.tx_type).toBe('credit')
+    })
+
+    it('should parse check with CHECKNUM', () => {
+      const result = parseOfx(OFX_V1_SAMPLE, defaultOptions)
+      const check = result.transactions[2]
+      expect(check.amount).toBe('-150.00')
+      expect(check.reference_number).toBe('1042')
+      expect(check.tx_type).toBe('check')
+    })
+
+    it('should parse dates as UTC timestamps', () => {
+      const result = parseOfx(OFX_V1_SAMPLE, defaultOptions)
+      const tx = result.transactions[0]
+      const date = new Date(tx.posted_date)
+      expect(date.getUTCFullYear()).toBe(2026)
+      expect(date.getUTCMonth()).toBe(6)
+      expect(date.getUTCDate()).toBe(2)
+    })
+
+    it('should set classification_status to unclassified', () => {
+      const result = parseOfx(OFX_V1_SAMPLE, defaultOptions)
+      for (const tx of result.transactions) {
+        expect(tx.classification_status).toBe('unclassified')
+      }
+    })
+  })
+
+  describe('OFX v2 (XML)', () => {
+    it('should parse credit card statement', () => {
+      const result = parseOfx(OFX_V2_XML, defaultOptions)
+      expect(result.transactions).toHaveLength(2)
+      expect(result.currency).toBe('EUR')
+    })
+
+    it('should extract CC account info', () => {
+      const result = parseOfx(OFX_V2_XML, defaultOptions)
+      expect(result.accountInfo?.accountId).toBe('4111111111111111')
+    })
+
+    it('should parse datetime with hours/minutes/seconds', () => {
+      const result = parseOfx(OFX_V2_XML, defaultOptions)
+      const tx = result.transactions[0]
+      const date = new Date(tx.posted_date)
+      expect(date.getUTCHours()).toBe(12)
+    })
+  })
+
+  describe('dedup', () => {
+    it('should mark known FITIDs as duplicates', () => {
+      const opts: OfxParseOptions = {
+        bankAccountId: 'test-bank-acct-1',
+        existingExternalIds: new Set(['20260702001', '20260710001']),
+      }
+      const result = parseOfx(OFX_V1_SAMPLE, opts)
+      expect(result.duplicateCount).toBe(2)
+
+      const dupes = result.transactions.filter((t) => t._isDuplicate)
+      expect(dupes).toHaveLength(2)
+      expect(dupes[0].external_id).toBe('20260702001')
+      expect(dupes[1].external_id).toBe('20260710001')
+    })
+
+    it('should not mark unknown FITIDs as duplicates', () => {
+      const opts: OfxParseOptions = {
+        bankAccountId: 'test-bank-acct-1',
+        existingExternalIds: new Set(['nonexistent']),
+      }
+      const result = parseOfx(OFX_V1_SAMPLE, opts)
+      expect(result.duplicateCount).toBe(0)
+    })
+
+    it('should report zero duplicates with no existing IDs', () => {
+      const result = parseOfx(OFX_V1_SAMPLE, defaultOptions)
+      expect(result.duplicateCount).toBe(0)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle empty content', () => {
+      const result = parseOfx('', defaultOptions)
+      expect(result.transactions).toHaveLength(0)
+      expect(result.totalCount).toBe(0)
+    })
+
+    it('should handle OFX with no transactions', () => {
+      const noTx = `OFXHEADER:100
+DATA:OFXSGML
+<OFX>
+<BANKMSGSRSV1>
+<STMTTRNRS>
+<STMTRS>
+<CURDEF>USD
+<BANKTRANLIST>
+<DTSTART>20260701
+<DTEND>20260715
+</BANKTRANLIST>
+</STMTRS>
+</STMTTRNRS>
+</BANKMSGSRSV1>
+</OFX>`
+      const result = parseOfx(noTx, defaultOptions)
+      expect(result.transactions).toHaveLength(0)
+      expect(result.currency).toBe('USD')
+    })
+
+    it('should map all known OFX transaction types', () => {
+      const types = [
+        'CREDIT', 'DEBIT', 'INT', 'DIV', 'FEE', 'SRVCHG',
+        'DEP', 'ATM', 'POS', 'XFER', 'CHECK', 'PAYMENT',
+        'CASH', 'DIRECTDEP', 'DIRECTDEBIT', 'REPEATPMT', 'HOLD', 'OTHER',
+      ]
+      for (const t of types) {
+        const ofx = `<OFX><BANKTRANLIST><STMTTRN><TRNTYPE>${t}<DTPOSTED>20260701<TRNAMT>100<FITID>test_${t}<NAME>Test</STMTTRN></BANKTRANLIST></OFX>`
+        const result = parseOfx(ofx, defaultOptions)
+        expect(result.transactions).toHaveLength(1)
+        expect(result.transactions[0].tx_type).toBeTruthy()
+      }
+    })
+  })
+})

--- a/src/services/parsers/csvParser.ts
+++ b/src/services/parsers/csvParser.ts
@@ -1,0 +1,327 @@
+import type {
+  CsvParseOptions,
+  ParseResult,
+  ParsedTransaction,
+} from './types'
+
+function splitCsvLine(line: string): string[] {
+  const fields: string[] = []
+  let current = ''
+  let inQuotes = false
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]
+    if (inQuotes) {
+      if (ch === '"') {
+        if (i + 1 < line.length && line[i + 1] === '"') {
+          current += '"'
+          i++
+        } else {
+          inQuotes = false
+        }
+      } else {
+        current += ch
+      }
+    } else if (ch === '"') {
+      inQuotes = true
+    } else if (ch === ',') {
+      fields.push(current.trim())
+      current = ''
+    } else {
+      current += ch
+    }
+  }
+  fields.push(current.trim())
+  return fields
+}
+
+const DATE_FORMATS: Record<string, RegExp> = {
+  'YYYY-MM-DD': /^(\d{4})-(\d{1,2})-(\d{1,2})/,
+  'MM/DD/YYYY': /^(\d{1,2})\/(\d{1,2})\/(\d{4})/,
+  'DD/MM/YYYY': /^(\d{1,2})\/(\d{1,2})\/(\d{4})/,
+  'YYYY/MM/DD': /^(\d{4})\/(\d{1,2})\/(\d{1,2})/,
+  'MM-DD-YYYY': /^(\d{1,2})-(\d{1,2})-(\d{4})/,
+  'DD-MM-YYYY': /^(\d{1,2})-(\d{1,2})-(\d{4})/,
+  'DD.MM.YYYY': /^(\d{1,2})\.(\d{1,2})\.(\d{4})/,
+}
+
+function parseDateWithFormat(raw: string, format: string): number {
+  const re = DATE_FORMATS[format]
+  if (!re) return 0
+  const m = re.exec(raw.trim())
+  if (!m) return 0
+
+  let year: number, month: number, day: number
+
+  if (format.startsWith('YYYY')) {
+    year = Number.parseInt(m[1], 10)
+    month = Number.parseInt(m[2], 10) - 1
+    day = Number.parseInt(m[3], 10)
+  } else if (format.startsWith('MM')) {
+    month = Number.parseInt(m[1], 10) - 1
+    day = Number.parseInt(m[2], 10)
+    year = Number.parseInt(m[3], 10)
+  } else {
+    day = Number.parseInt(m[1], 10)
+    month = Number.parseInt(m[2], 10) - 1
+    year = Number.parseInt(m[3], 10)
+  }
+
+  return Date.UTC(year, month, day)
+}
+
+function parseAmount(
+  raw: string,
+  convention: string,
+  txType?: string
+): string {
+  const cleaned = raw.replace(/[^0-9.\-+]/g, '')
+  if (!cleaned) return '0'
+
+  const num = Number.parseFloat(cleaned)
+  if (Number.isNaN(num)) return '0'
+
+  if (convention === 'signed') {
+    return num.toString()
+  }
+
+  if (convention === 'debit_positive') {
+    const isDebit =
+      txType?.toLowerCase().includes('debit') ||
+      txType?.toLowerCase().includes('withdrawal') ||
+      txType?.toLowerCase().includes('payment')
+    return isDebit ? (-Math.abs(num)).toString() : Math.abs(num).toString()
+  }
+
+  if (convention === 'debit_negative') {
+    return num.toString()
+  }
+
+  return num.toString()
+}
+
+function computeExternalId(
+  row: Record<string, string>,
+  lineNum: number
+): string {
+  const parts = [
+    row.date ?? '',
+    row.amount ?? '',
+    row.payee ?? row.memo ?? '',
+    String(lineNum),
+  ]
+  return `csv_${hashString(parts.join('|'))}`
+}
+
+function hashString(str: string): string {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    const ch = str.charCodeAt(i)
+    hash = ((hash << 5) - hash + ch) | 0
+  }
+  return Math.abs(hash).toString(36)
+}
+
+export function detectCsvFormat(content: string): boolean {
+  const lines = content.split('\n').filter((l) => l.trim().length > 0)
+  if (lines.length < 2) return false
+
+  const firstLine = lines[0]
+  const commaCount = (firstLine.match(/,/g) ?? []).length
+  if (commaCount < 1) return false
+
+  const headerLower = firstLine.toLowerCase()
+  const bankKeywords = [
+    'date',
+    'amount',
+    'description',
+    'memo',
+    'payee',
+    'debit',
+    'credit',
+    'balance',
+    'transaction',
+    'reference',
+    'check',
+  ]
+  return bankKeywords.some((kw) => headerLower.includes(kw))
+}
+
+export function inferColumnMap(
+  headers: string[]
+): Partial<Record<string, string>> {
+  const map: Record<string, string> = {}
+  const lower = headers.map((h) => h.toLowerCase().trim())
+
+  const datePatterns = [
+    'date',
+    'posted date',
+    'transaction date',
+    'posting date',
+    'trans date',
+  ]
+  const amountPatterns = ['amount', 'debit', 'credit', 'value', 'sum']
+  const payeePatterns = [
+    'payee',
+    'description',
+    'name',
+    'merchant',
+    'vendor',
+    'details',
+  ]
+  const memoPatterns = ['memo', 'note', 'notes', 'additional info']
+  const refPatterns = [
+    'reference',
+    'ref',
+    'check',
+    'check number',
+    'confirmation',
+    'id',
+  ]
+  const typePatterns = ['type', 'transaction type', 'category', 'trans type']
+  const balancePatterns = ['balance', 'running balance', 'ending balance']
+
+  for (const patterns of [
+    { key: 'date', list: datePatterns },
+    { key: 'amount', list: amountPatterns },
+    { key: 'payee', list: payeePatterns },
+    { key: 'memo', list: memoPatterns },
+    { key: 'referenceNumber', list: refPatterns },
+    { key: 'type', list: typePatterns },
+    { key: 'balance', list: balancePatterns },
+  ]) {
+    for (const pattern of patterns.list) {
+      const idx = lower.indexOf(pattern)
+      if (idx !== -1 && !map[patterns.key]) {
+        map[patterns.key] = headers[idx]
+        break
+      }
+    }
+  }
+
+  return map
+}
+
+export function parseCsv(
+  content: string,
+  options: CsvParseOptions
+): ParseResult {
+  const lines = content.split(/\r?\n/).filter((l) => l.trim().length > 0)
+  const skipRows = options.skipHeaderRows ?? 1
+  if (lines.length <= skipRows) {
+    return {
+      transactions: [],
+      format: 'csv',
+      duplicateCount: 0,
+      totalCount: 0,
+      currency: options.currencyDefault,
+    }
+  }
+
+  const headerRowIdx = Math.max(0, skipRows - 1)
+  const headers = splitCsvLine(lines[headerRowIdx])
+  const colMap = options.columnMap
+  const dataLines = lines.slice(skipRows)
+
+  const getColIndex = (colName: string | undefined): number => {
+    if (!colName) return -1
+    return headers.findIndex(
+      (h) => h.trim().toLowerCase() === colName.trim().toLowerCase()
+    )
+  }
+
+  const dateIdx = getColIndex(colMap.date)
+  const amountIdx = getColIndex(colMap.amount)
+  const payeeIdx = getColIndex(colMap.payee)
+  const memoIdx = getColIndex(colMap.memo)
+  const refIdx = getColIndex(colMap.referenceNumber)
+  const typeIdx = getColIndex(colMap.type)
+  const balanceIdx = getColIndex(colMap.balance)
+
+  if (dateIdx === -1 || amountIdx === -1) {
+    return {
+      transactions: [],
+      format: 'csv',
+      duplicateCount: 0,
+      totalCount: 0,
+      currency: options.currencyDefault,
+    }
+  }
+
+  const transactions: ParsedTransaction[] = []
+  let duplicateCount = 0
+
+  for (let i = 0; i < dataLines.length; i++) {
+    const fields = splitCsvLine(dataLines[i])
+    if (fields.length <= Math.max(dateIdx, amountIdx)) continue
+
+    const dateRaw = fields[dateIdx] ?? ''
+    const amountRaw = fields[amountIdx] ?? ''
+    const typeRaw = typeIdx >= 0 ? fields[typeIdx] : undefined
+
+    const postedDate = parseDateWithFormat(dateRaw, options.dateFormat)
+    if (!postedDate) continue
+
+    const amount = parseAmount(
+      amountRaw,
+      options.amountSignConvention,
+      typeRaw
+    )
+
+    const rowData: Record<string, string> = {
+      date: dateRaw,
+      amount: amountRaw,
+      payee: payeeIdx >= 0 ? (fields[payeeIdx] ?? '') : '',
+      memo: memoIdx >= 0 ? (fields[memoIdx] ?? '') : '',
+    }
+
+    const externalId = computeExternalId(rowData, i + skipRows)
+    const isDuplicate = Boolean(
+      options.existingExternalIds?.has(externalId)
+    )
+    if (isDuplicate) duplicateCount++
+
+    const tx: ParsedTransaction = {
+      bank_account_id: options.bankAccountId,
+      external_id: externalId,
+      posted_date: postedDate,
+      amount,
+      currency: options.currencyDefault,
+      payee: payeeIdx >= 0 ? (fields[payeeIdx] || undefined) : undefined,
+      memo: memoIdx >= 0 ? (fields[memoIdx] || undefined) : undefined,
+      reference_number:
+        refIdx >= 0 ? (fields[refIdx] || undefined) : undefined,
+      tx_type: typeRaw?.toLowerCase() ?? undefined,
+      running_balance:
+        balanceIdx >= 0 ? (fields[balanceIdx] || undefined) : undefined,
+      classification_status: 'unclassified',
+      raw_data: dataLines[i],
+      _isDuplicate: isDuplicate,
+      _duplicateOf: isDuplicate ? externalId : undefined,
+      _rawLine: i + skipRows,
+    }
+
+    transactions.push(tx)
+  }
+
+  let startDate = Number.POSITIVE_INFINITY
+  let endDate = 0
+  for (const tx of transactions) {
+    if (tx.posted_date < startDate) startDate = tx.posted_date
+    if (tx.posted_date > endDate) endDate = tx.posted_date
+  }
+
+  return {
+    transactions,
+    format: 'csv',
+    dateRange:
+      transactions.length > 0
+        ? {
+            start: startDate === Number.POSITIVE_INFINITY ? 0 : startDate,
+            end: endDate,
+          }
+        : undefined,
+    currency: options.currencyDefault,
+    duplicateCount,
+    totalCount: transactions.length,
+  }
+}

--- a/src/services/parsers/csvParser.ts
+++ b/src/services/parsers/csvParser.ts
@@ -1,8 +1,4 @@
-import type {
-  CsvParseOptions,
-  ParseResult,
-  ParsedTransaction,
-} from './types'
+import type { CsvParseOptions, ParseResult, ParsedTransaction } from './types'
 
 function splitCsvLine(line: string): string[] {
   const fields: string[] = []
@@ -69,11 +65,7 @@ function parseDateWithFormat(raw: string, format: string): number {
   return Date.UTC(year, month, day)
 }
 
-function parseAmount(
-  raw: string,
-  convention: string,
-  txType?: string
-): string {
+function parseAmount(raw: string, convention: string, txType?: string): string {
   const cleaned = raw.replace(/[^0-9.\-+]/g, '')
   if (!cleaned) return '0'
 
@@ -122,7 +114,7 @@ function hashString(str: string): string {
 }
 
 export function detectCsvFormat(content: string): boolean {
-  const lines = content.split('\n').filter((l) => l.trim().length > 0)
+  const lines = content.split('\n').filter(l => l.trim().length > 0)
   if (lines.length < 2) return false
 
   const firstLine = lines[0]
@@ -143,14 +135,14 @@ export function detectCsvFormat(content: string): boolean {
     'reference',
     'check',
   ]
-  return bankKeywords.some((kw) => headerLower.includes(kw))
+  return bankKeywords.some(kw => headerLower.includes(kw))
 }
 
 export function inferColumnMap(
   headers: string[]
 ): Partial<Record<string, string>> {
   const map: Record<string, string> = {}
-  const lower = headers.map((h) => h.toLowerCase().trim())
+  const lower = headers.map(h => h.toLowerCase().trim())
 
   const datePatterns = [
     'date',
@@ -205,7 +197,7 @@ export function parseCsv(
   content: string,
   options: CsvParseOptions
 ): ParseResult {
-  const lines = content.split(/\r?\n/).filter((l) => l.trim().length > 0)
+  const lines = content.split(/\r?\n/).filter(l => l.trim().length > 0)
   const skipRows = options.skipHeaderRows ?? 1
   if (lines.length <= skipRows) {
     return {
@@ -225,7 +217,7 @@ export function parseCsv(
   const getColIndex = (colName: string | undefined): number => {
     if (!colName) return -1
     return headers.findIndex(
-      (h) => h.trim().toLowerCase() === colName.trim().toLowerCase()
+      h => h.trim().toLowerCase() === colName.trim().toLowerCase()
     )
   }
 
@@ -261,11 +253,7 @@ export function parseCsv(
     const postedDate = parseDateWithFormat(dateRaw, options.dateFormat)
     if (!postedDate) continue
 
-    const amount = parseAmount(
-      amountRaw,
-      options.amountSignConvention,
-      typeRaw
-    )
+    const amount = parseAmount(amountRaw, options.amountSignConvention, typeRaw)
 
     const rowData: Record<string, string> = {
       date: dateRaw,
@@ -275,9 +263,7 @@ export function parseCsv(
     }
 
     const externalId = computeExternalId(rowData, i + skipRows)
-    const isDuplicate = Boolean(
-      options.existingExternalIds?.has(externalId)
-    )
+    const isDuplicate = Boolean(options.existingExternalIds?.has(externalId))
     if (isDuplicate) duplicateCount++
 
     const tx: ParsedTransaction = {
@@ -286,13 +272,12 @@ export function parseCsv(
       posted_date: postedDate,
       amount,
       currency: options.currencyDefault,
-      payee: payeeIdx >= 0 ? (fields[payeeIdx] || undefined) : undefined,
-      memo: memoIdx >= 0 ? (fields[memoIdx] || undefined) : undefined,
-      reference_number:
-        refIdx >= 0 ? (fields[refIdx] || undefined) : undefined,
+      payee: payeeIdx >= 0 ? fields[payeeIdx] || undefined : undefined,
+      memo: memoIdx >= 0 ? fields[memoIdx] || undefined : undefined,
+      reference_number: refIdx >= 0 ? fields[refIdx] || undefined : undefined,
       tx_type: typeRaw?.toLowerCase() ?? undefined,
       running_balance:
-        balanceIdx >= 0 ? (fields[balanceIdx] || undefined) : undefined,
+        balanceIdx >= 0 ? fields[balanceIdx] || undefined : undefined,
       classification_status: 'unclassified',
       raw_data: dataLines[i],
       _isDuplicate: isDuplicate,

--- a/src/services/parsers/csvParser.ts
+++ b/src/services/parsers/csvParser.ts
@@ -224,6 +224,7 @@ function resolveColumns(
   headers: string[],
   colMap: CsvColumnMap
 ): ColumnIndices {
+  /** Finds a column index by case-insensitive name match. */
   const resolve = (colName: string | undefined): number => {
     if (!colName) return -1
     return headers.findIndex(

--- a/src/services/parsers/csvParser.ts
+++ b/src/services/parsers/csvParser.ts
@@ -1,5 +1,11 @@
-import type { CsvParseOptions, ParseResult, ParsedTransaction } from './types'
+import type {
+  CsvColumnMap,
+  CsvParseOptions,
+  ParseResult,
+  ParsedTransaction,
+} from './types'
 
+/** Splits a CSV line into fields, respecting quoted values. */
 function splitCsvLine(line: string): string[] {
   const fields: string[] = []
   let current = ''
@@ -30,6 +36,7 @@ function splitCsvLine(line: string): string[] {
   return fields
 }
 
+// Shared regex for MM/DD and DD/MM — groups are positional; parseDateWithFormat resolves semantics via the format key.
 const SLASH_DMY_RE = /^(\d{1,2})\/(\d{1,2})\/(\d{4})/
 const DASH_DMY_RE = /^(\d{1,2})-(\d{1,2})-(\d{4})/
 
@@ -43,31 +50,33 @@ const DATE_FORMATS: Record<string, RegExp> = {
   'DD.MM.YYYY': /^(\d{1,2})\.(\d{1,2})\.(\d{4})/,
 }
 
+/** Parses a date string using the given format key and returns a UTC timestamp. */
 function parseDateWithFormat(raw: string, format: string): number {
   const re = DATE_FORMATS[format]
   if (!re) return 0
-  const m = re.exec(raw.trim())
-  if (!m) return 0
+  const match = re.exec(raw.trim())
+  if (!match) return 0
 
   let year: number, month: number, day: number
 
   if (format.startsWith('YYYY')) {
-    year = Number.parseInt(m[1], 10)
-    month = Number.parseInt(m[2], 10) - 1
-    day = Number.parseInt(m[3], 10)
+    year = Number.parseInt(match[1], 10)
+    month = Number.parseInt(match[2], 10) - 1
+    day = Number.parseInt(match[3], 10)
   } else if (format.startsWith('MM')) {
-    month = Number.parseInt(m[1], 10) - 1
-    day = Number.parseInt(m[2], 10)
-    year = Number.parseInt(m[3], 10)
+    month = Number.parseInt(match[1], 10) - 1
+    day = Number.parseInt(match[2], 10)
+    year = Number.parseInt(match[3], 10)
   } else {
-    day = Number.parseInt(m[1], 10)
-    month = Number.parseInt(m[2], 10) - 1
-    year = Number.parseInt(m[3], 10)
+    day = Number.parseInt(match[1], 10)
+    month = Number.parseInt(match[2], 10) - 1
+    year = Number.parseInt(match[3], 10)
   }
 
   return Date.UTC(year, month, day)
 }
 
+/** Strips non-numeric characters and applies the sign convention to produce a numeric string. */
 function parseAmount(raw: string, convention: string, txType?: string): string {
   const cleaned = raw.replace(/[^0-9.+-]/g, '')
   if (!cleaned) return '0'
@@ -94,6 +103,7 @@ function parseAmount(raw: string, convention: string, txType?: string): string {
   return num.toString()
 }
 
+/** Computes a deterministic external ID from row values and line number. */
 function computeExternalId(
   row: Record<string, string>,
   lineNum: number
@@ -107,6 +117,7 @@ function computeExternalId(
   return `csv_${hashString(parts.join('|'))}`
 }
 
+/** Produces a simple numeric hash of a string, returned in base-36. */
 function hashString(str: string): string {
   let hash = 0
   for (let i = 0; i < str.length; i++) {
@@ -116,6 +127,7 @@ function hashString(str: string): string {
   return Math.abs(hash).toString(36)
 }
 
+/** Checks whether file content looks like a bank-statement CSV based on header keywords. */
 export function detectCsvFormat(content: string): boolean {
   const lines = content.split('\n').filter(l => l.trim().length > 0)
   if (lines.length < 2) return false
@@ -141,6 +153,7 @@ export function detectCsvFormat(content: string): boolean {
   return bankKeywords.some(kw => headerLower.includes(kw))
 }
 
+/** Maps common bank-statement header names to semantic column roles. */
 export function inferColumnMap(
   headers: string[]
 ): Partial<Record<string, string>> {
@@ -196,118 +209,148 @@ export function inferColumnMap(
   return map
 }
 
+interface ColumnIndices {
+  date: number
+  amount: number
+  payee: number
+  memo: number
+  ref: number
+  type: number
+  balance: number
+}
+
+/** Resolves column indices from header names using case-insensitive matching. */
+function resolveColumns(
+  headers: string[],
+  colMap: CsvColumnMap
+): ColumnIndices {
+  const resolve = (colName: string | undefined): number => {
+    if (!colName) return -1
+    return headers.findIndex(
+      h => h.trim().toLowerCase() === colName.trim().toLowerCase()
+    )
+  }
+  return {
+    date: resolve(colMap.date),
+    amount: resolve(colMap.amount),
+    payee: resolve(colMap.payee),
+    memo: resolve(colMap.memo),
+    ref: resolve(colMap.referenceNumber),
+    type: resolve(colMap.type),
+    balance: resolve(colMap.balance),
+  }
+}
+
+/** Returns the field at the given index, or undefined if the index is negative or the field is empty. */
+function optionalField(fields: string[], idx: number): string | undefined {
+  if (idx < 0) return undefined
+  return fields[idx] || undefined
+}
+
+/** Parses a single CSV data row into a ParsedTransaction, or null if the row is invalid. */
+function parseCsvRow(
+  rawLine: string,
+  fields: string[],
+  lineNum: number,
+  cols: ColumnIndices,
+  options: CsvParseOptions
+): ParsedTransaction | null {
+  if (fields.length <= Math.max(cols.date, cols.amount)) return null
+
+  const dateRaw = fields[cols.date] ?? ''
+  const amountRaw = fields[cols.amount] ?? ''
+  const typeRaw = optionalField(fields, cols.type)
+
+  const postedDate = parseDateWithFormat(dateRaw, options.dateFormat)
+  if (!postedDate) return null
+
+  const amount = parseAmount(amountRaw, options.amountSignConvention, typeRaw)
+
+  const rowData: Record<string, string> = {
+    date: dateRaw,
+    amount: amountRaw,
+    payee: cols.payee >= 0 ? (fields[cols.payee] ?? '') : '',
+    memo: cols.memo >= 0 ? (fields[cols.memo] ?? '') : '',
+  }
+
+  const externalId = computeExternalId(rowData, lineNum)
+  const isDuplicate = Boolean(options.existingExternalIds?.has(externalId))
+
+  return {
+    bank_account_id: options.bankAccountId,
+    external_id: externalId,
+    posted_date: postedDate,
+    amount,
+    currency: options.currencyDefault,
+    payee: optionalField(fields, cols.payee),
+    memo: optionalField(fields, cols.memo),
+    reference_number: optionalField(fields, cols.ref),
+    tx_type: typeRaw?.toLowerCase() ?? undefined,
+    running_balance: optionalField(fields, cols.balance),
+    classification_status: 'unclassified',
+    raw_data: rawLine,
+    _isDuplicate: isDuplicate,
+    _duplicateOf: isDuplicate ? externalId : undefined,
+    _rawLine: lineNum,
+  }
+}
+
+/** Computes the earliest and latest posted_date across a transaction list. */
+function computeDateRange(
+  transactions: ParsedTransaction[]
+): { start: number; end: number } | undefined {
+  if (transactions.length === 0) return undefined
+  let start = Number.POSITIVE_INFINITY
+  let end = 0
+  for (const tx of transactions) {
+    if (tx.posted_date < start) start = tx.posted_date
+    if (tx.posted_date > end) end = tx.posted_date
+  }
+  return {
+    start: start === Number.POSITIVE_INFINITY ? 0 : start,
+    end,
+  }
+}
+
+/** Parses a CSV bank statement into structured transactions. */
 export function parseCsv(
   content: string,
   options: CsvParseOptions
 ): ParseResult {
   const lines = content.split(/\r?\n/).filter(l => l.trim().length > 0)
   const skipRows = options.skipHeaderRows ?? 1
-  if (lines.length <= skipRows) {
-    return {
-      transactions: [],
-      format: 'csv',
-      duplicateCount: 0,
-      totalCount: 0,
-      currency: options.currencyDefault,
-    }
+  const emptyResult: ParseResult = {
+    transactions: [],
+    format: 'csv',
+    duplicateCount: 0,
+    totalCount: 0,
+    currency: options.currencyDefault,
   }
+
+  if (lines.length <= skipRows) return emptyResult
 
   const headerRowIdx = Math.max(0, skipRows - 1)
   const headers = splitCsvLine(lines[headerRowIdx])
-  const colMap = options.columnMap
+  const cols = resolveColumns(headers, options.columnMap)
   const dataLines = lines.slice(skipRows)
 
-  const getColIndex = (colName: string | undefined): number => {
-    if (!colName) return -1
-    return headers.findIndex(
-      h => h.trim().toLowerCase() === colName.trim().toLowerCase()
-    )
-  }
-
-  const dateIdx = getColIndex(colMap.date)
-  const amountIdx = getColIndex(colMap.amount)
-  const payeeIdx = getColIndex(colMap.payee)
-  const memoIdx = getColIndex(colMap.memo)
-  const refIdx = getColIndex(colMap.referenceNumber)
-  const typeIdx = getColIndex(colMap.type)
-  const balanceIdx = getColIndex(colMap.balance)
-
-  if (dateIdx === -1 || amountIdx === -1) {
-    return {
-      transactions: [],
-      format: 'csv',
-      duplicateCount: 0,
-      totalCount: 0,
-      currency: options.currencyDefault,
-    }
-  }
+  if (cols.date === -1 || cols.amount === -1) return emptyResult
 
   const transactions: ParsedTransaction[] = []
   let duplicateCount = 0
 
   for (let i = 0; i < dataLines.length; i++) {
     const fields = splitCsvLine(dataLines[i])
-    if (fields.length <= Math.max(dateIdx, amountIdx)) continue
-
-    const dateRaw = fields[dateIdx] ?? ''
-    const amountRaw = fields[amountIdx] ?? ''
-    const typeRaw = typeIdx >= 0 ? fields[typeIdx] : undefined
-
-    const postedDate = parseDateWithFormat(dateRaw, options.dateFormat)
-    if (!postedDate) continue
-
-    const amount = parseAmount(amountRaw, options.amountSignConvention, typeRaw)
-
-    const rowData: Record<string, string> = {
-      date: dateRaw,
-      amount: amountRaw,
-      payee: payeeIdx >= 0 ? (fields[payeeIdx] ?? '') : '',
-      memo: memoIdx >= 0 ? (fields[memoIdx] ?? '') : '',
-    }
-
-    const externalId = computeExternalId(rowData, i + skipRows)
-    const isDuplicate = Boolean(options.existingExternalIds?.has(externalId))
-    if (isDuplicate) duplicateCount++
-
-    const tx: ParsedTransaction = {
-      bank_account_id: options.bankAccountId,
-      external_id: externalId,
-      posted_date: postedDate,
-      amount,
-      currency: options.currencyDefault,
-      payee: payeeIdx >= 0 ? fields[payeeIdx] || undefined : undefined,
-      memo: memoIdx >= 0 ? fields[memoIdx] || undefined : undefined,
-      reference_number: refIdx >= 0 ? fields[refIdx] || undefined : undefined,
-      tx_type: typeRaw?.toLowerCase() ?? undefined,
-      running_balance:
-        balanceIdx >= 0 ? fields[balanceIdx] || undefined : undefined,
-      classification_status: 'unclassified',
-      raw_data: dataLines[i],
-      _isDuplicate: isDuplicate,
-      _duplicateOf: isDuplicate ? externalId : undefined,
-      _rawLine: i + skipRows,
-    }
-
+    const tx = parseCsvRow(dataLines[i], fields, i + skipRows, cols, options)
+    if (!tx) continue
+    if (tx._isDuplicate) duplicateCount++
     transactions.push(tx)
-  }
-
-  let startDate = Number.POSITIVE_INFINITY
-  let endDate = 0
-  for (const tx of transactions) {
-    if (tx.posted_date < startDate) startDate = tx.posted_date
-    if (tx.posted_date > endDate) endDate = tx.posted_date
   }
 
   return {
     transactions,
     format: 'csv',
-    dateRange:
-      transactions.length > 0
-        ? {
-            start: startDate === Number.POSITIVE_INFINITY ? 0 : startDate,
-            end: endDate,
-          }
-        : undefined,
+    dateRange: computeDateRange(transactions),
     currency: options.currencyDefault,
     duplicateCount,
     totalCount: transactions.length,

--- a/src/services/parsers/csvParser.ts
+++ b/src/services/parsers/csvParser.ts
@@ -30,13 +30,16 @@ function splitCsvLine(line: string): string[] {
   return fields
 }
 
+const SLASH_DMY_RE = /^(\d{1,2})\/(\d{1,2})\/(\d{4})/
+const DASH_DMY_RE = /^(\d{1,2})-(\d{1,2})-(\d{4})/
+
 const DATE_FORMATS: Record<string, RegExp> = {
   'YYYY-MM-DD': /^(\d{4})-(\d{1,2})-(\d{1,2})/,
-  'MM/DD/YYYY': /^(\d{1,2})\/(\d{1,2})\/(\d{4})/,
-  'DD/MM/YYYY': /^(\d{1,2})\/(\d{1,2})\/(\d{4})/,
+  'MM/DD/YYYY': SLASH_DMY_RE,
+  'DD/MM/YYYY': SLASH_DMY_RE,
   'YYYY/MM/DD': /^(\d{4})\/(\d{1,2})\/(\d{1,2})/,
-  'MM-DD-YYYY': /^(\d{1,2})-(\d{1,2})-(\d{4})/,
-  'DD-MM-YYYY': /^(\d{1,2})-(\d{1,2})-(\d{4})/,
+  'MM-DD-YYYY': DASH_DMY_RE,
+  'DD-MM-YYYY': DASH_DMY_RE,
   'DD.MM.YYYY': /^(\d{1,2})\.(\d{1,2})\.(\d{4})/,
 }
 
@@ -66,7 +69,7 @@ function parseDateWithFormat(raw: string, format: string): number {
 }
 
 function parseAmount(raw: string, convention: string, txType?: string): string {
-  const cleaned = raw.replace(/[^0-9.\-+]/g, '')
+  const cleaned = raw.replace(/[^0-9.+-]/g, '')
   if (!cleaned) return '0'
 
   const num = Number.parseFloat(cleaned)

--- a/src/services/parsers/dedup.ts
+++ b/src/services/parsers/dedup.ts
@@ -42,9 +42,7 @@ export function dedup(
   return { unique, duplicates, duplicateCount: duplicates.length }
 }
 
-export function buildExternalIdSet(
-  existing: BankTransaction[]
-): Set<string> {
+export function buildExternalIdSet(existing: BankTransaction[]): Set<string> {
   const ids = new Set<string>()
   for (const tx of existing) {
     if (tx.external_id) {

--- a/src/services/parsers/dedup.ts
+++ b/src/services/parsers/dedup.ts
@@ -1,0 +1,55 @@
+import type { BankTransaction } from '../persistence/types'
+import type { ParsedTransaction } from './types'
+
+export interface DedupResult {
+  unique: ParsedTransaction[]
+  duplicates: ParsedTransaction[]
+  duplicateCount: number
+}
+
+export function dedup(
+  parsed: ParsedTransaction[],
+  existing: BankTransaction[]
+): DedupResult {
+  const existingKeys = new Set<string>()
+  for (const tx of existing) {
+    if (tx.external_id) {
+      existingKeys.add(`${tx.bank_account_id}_${tx.external_id}`)
+    }
+  }
+
+  const batchKeys = new Set<string>()
+  const unique: ParsedTransaction[] = []
+  const duplicates: ParsedTransaction[] = []
+
+  for (const tx of parsed) {
+    const key = tx.external_id
+      ? `${tx.bank_account_id}_${tx.external_id}`
+      : null
+
+    if (key && (existingKeys.has(key) || batchKeys.has(key))) {
+      duplicates.push({
+        ...tx,
+        _isDuplicate: true,
+        _duplicateOf: tx.external_id,
+      })
+    } else {
+      if (key) batchKeys.add(key)
+      unique.push({ ...tx, _isDuplicate: false })
+    }
+  }
+
+  return { unique, duplicates, duplicateCount: duplicates.length }
+}
+
+export function buildExternalIdSet(
+  existing: BankTransaction[]
+): Set<string> {
+  const ids = new Set<string>()
+  for (const tx of existing) {
+    if (tx.external_id) {
+      ids.add(tx.external_id)
+    }
+  }
+  return ids
+}

--- a/src/services/parsers/dedup.ts
+++ b/src/services/parsers/dedup.ts
@@ -7,6 +7,7 @@ export interface DedupResult {
   duplicateCount: number
 }
 
+/** Separates parsed transactions into unique and duplicate sets against existing records. */
 export function dedup(
   parsed: ParsedTransaction[],
   existing: BankTransaction[]
@@ -42,6 +43,7 @@ export function dedup(
   return { unique, duplicates, duplicateCount: duplicates.length }
 }
 
+/** Collects all external IDs from existing bank transactions into a Set for fast lookup. */
 export function buildExternalIdSet(existing: BankTransaction[]): Set<string> {
   const ids = new Set<string>()
   for (const tx of existing) {

--- a/src/services/parsers/index.ts
+++ b/src/services/parsers/index.ts
@@ -19,6 +19,7 @@ export { columnMapFromProfile } from './types'
 export { inferColumnMap } from './csvParser'
 export { dedup, buildExternalIdSet }
 
+/** Detects the statement format from file content and optional filename extension. */
 export function detectFormat(
   content: string,
   filename?: string
@@ -36,6 +37,7 @@ export function detectFormat(
   return null
 }
 
+/** Parses a bank statement string into structured transactions using the appropriate format parser. */
 export function parseStatement(
   content: string,
   format: StatementFormat,

--- a/src/services/parsers/index.ts
+++ b/src/services/parsers/index.ts
@@ -1,0 +1,55 @@
+import { parseOfx, detectOfxFormat } from './ofxParser'
+import { parseCsv, detectCsvFormat } from './csvParser'
+import { dedup, buildExternalIdSet } from './dedup'
+import type {
+  StatementFormat,
+  ParseResult,
+  OfxParseOptions,
+  CsvParseOptions,
+} from './types'
+
+export type { StatementFormat, ParseResult, OfxParseOptions, CsvParseOptions }
+export type {
+  ParsedTransaction,
+  CsvColumnMap,
+  AmountSignConvention,
+  ParsedAccountInfo,
+} from './types'
+export { columnMapFromProfile } from './types'
+export { inferColumnMap } from './csvParser'
+export { dedup, buildExternalIdSet }
+
+export function detectFormat(
+  content: string,
+  filename?: string
+): StatementFormat | null {
+  const ext = filename?.split('.').pop()?.toLowerCase()
+  if (ext === 'qfx') return 'qfx'
+  if (ext === 'qbo') return 'qbo'
+  if (ext === 'ofx') return 'ofx'
+
+  const ofxFormat = detectOfxFormat(content)
+  if (ofxFormat) return ofxFormat
+
+  if (ext === 'csv' || detectCsvFormat(content)) return 'csv'
+
+  return null
+}
+
+export function parseStatement(
+  content: string,
+  format: StatementFormat,
+  options: OfxParseOptions | CsvParseOptions
+): ParseResult {
+  if (format === 'ofx' || format === 'qfx' || format === 'qbo') {
+    return parseOfx(content, options as OfxParseOptions)
+  }
+
+  if (format === 'csv') {
+    return parseCsv(content, options as CsvParseOptions)
+  }
+
+  throw new Error(`Unsupported format: ${format}`)
+}
+
+export const BANK_IMPORT_FLAG = 'bank_import_v1'

--- a/src/services/parsers/ofxParser.ts
+++ b/src/services/parsers/ofxParser.ts
@@ -25,13 +25,16 @@ function normalizeOfxToXml(raw: string): string {
   if (bodyStart === -1) return raw
   let body = raw.slice(bodyStart)
 
-  body = body.replace(/<(\w+)[^/>]*>([^<]*)\n/g, (_match, tag: string, val: string) => {
-    const trimmed = val.trim()
-    if (trimmed.length > 0) {
-      return `<${tag}>${trimmed}</${tag}>\n`
+  body = body.replace(
+    /<(\w+)[^/>]*>([^<]*)\n/g,
+    (_match, tag: string, val: string) => {
+      const trimmed = val.trim()
+      if (trimmed.length > 0) {
+        return `<${tag}>${trimmed}</${tag}>\n`
+      }
+      return `<${tag}>\n`
     }
-    return `<${tag}>\n`
-  })
+  )
 
   return body
 }
@@ -128,9 +131,7 @@ function parseTransactionBlock(
   const refNum = extractTagValue(block, 'REFNUM')
   const trnType = extractTagValue(block, 'TRNTYPE')
 
-  const isDuplicate = Boolean(
-    fitid && options.existingExternalIds?.has(fitid)
-  )
+  const isDuplicate = Boolean(fitid && options.existingExternalIds?.has(fitid))
 
   const tx: ParsedTransaction = {
     bank_account_id: options.bankAccountId,
@@ -175,19 +176,15 @@ export function parseOfx(
 
   const accountInfo = parseAccountInfo(xml)
 
-  const stmtrs =
-    extractTag(xml, 'STMTTRNRS') || extractTag(xml, 'CCSTMTTRNRS')
+  const stmtrs = extractTag(xml, 'STMTTRNRS') || extractTag(xml, 'CCSTMTTRNRS')
 
   const tranList = stmtrs
     ? extractTag(stmtrs, 'BANKTRANLIST')
     : extractTag(xml, 'BANKTRANLIST')
 
-  const txBlocks = extractAllBlocks(
-    tranList || stmtrs || xml,
-    'STMTTRN'
-  )
+  const txBlocks = extractAllBlocks(tranList || stmtrs || xml, 'STMTTRN')
 
-  const transactions: ParsedTransaction[] = txBlocks.map((block) =>
+  const transactions: ParsedTransaction[] = txBlocks.map(block =>
     parseTransactionBlock(block, options, currency)
   )
 
@@ -200,7 +197,7 @@ export function parseOfx(
     if (dtEnd) endDate = parseOfxDate(dtEnd)
   }
 
-  const duplicateCount = transactions.filter((t) => t._isDuplicate).length
+  const duplicateCount = transactions.filter(t => t._isDuplicate).length
 
   return {
     transactions,

--- a/src/services/parsers/ofxParser.ts
+++ b/src/services/parsers/ofxParser.ts
@@ -1,0 +1,215 @@
+import type {
+  OfxParseOptions,
+  ParseResult,
+  ParsedAccountInfo,
+  ParsedTransaction,
+  StatementFormat,
+} from './types'
+
+const OFX_DATE_RE = /^(\d{4})(\d{2})(\d{2})(?:(\d{2})(\d{2})(\d{2}))?/
+
+function parseOfxDate(raw: string): number {
+  const m = OFX_DATE_RE.exec(raw.trim())
+  if (!m) return 0
+  const year = Number.parseInt(m[1], 10)
+  const month = Number.parseInt(m[2], 10) - 1
+  const day = Number.parseInt(m[3], 10)
+  const hour = m[4] ? Number.parseInt(m[4], 10) : 0
+  const min = m[5] ? Number.parseInt(m[5], 10) : 0
+  const sec = m[6] ? Number.parseInt(m[6], 10) : 0
+  return new Date(Date.UTC(year, month, day, hour, min, sec)).getTime()
+}
+
+function normalizeOfxToXml(raw: string): string {
+  const bodyStart = raw.indexOf('<OFX>')
+  if (bodyStart === -1) return raw
+  let body = raw.slice(bodyStart)
+
+  body = body.replace(/<(\w+)[^/>]*>([^<]*)\n/g, (_match, tag: string, val: string) => {
+    const trimmed = val.trim()
+    if (trimmed.length > 0) {
+      return `<${tag}>${trimmed}</${tag}>\n`
+    }
+    return `<${tag}>\n`
+  })
+
+  return body
+}
+
+function extractTag(xml: string, tag: string): string {
+  const openRe = new RegExp(`<${tag}>`, 'i')
+  const closeRe = new RegExp(`</${tag}>`, 'i')
+  const openMatch = openRe.exec(xml)
+  if (!openMatch) return ''
+  const start = openMatch.index + openMatch[0].length
+  const closeMatch = closeRe.exec(xml.slice(start))
+  if (!closeMatch) {
+    const nl = xml.indexOf('\n', start)
+    return nl === -1 ? xml.slice(start).trim() : xml.slice(start, nl).trim()
+  }
+  return xml.slice(start, start + closeMatch.index).trim()
+}
+
+function extractTagValue(xml: string, tag: string): string {
+  const re = new RegExp(`<${tag}>\\s*([^<\\n]+)`, 'i')
+  const m = re.exec(xml)
+  return m ? m[1].trim() : ''
+}
+
+function extractAllBlocks(xml: string, tag: string): string[] {
+  const results: string[] = []
+  const openTag = `<${tag}>`
+  const closeTag = `</${tag}>`
+  let pos = 0
+  while (pos < xml.length) {
+    const start = xml.indexOf(openTag, pos)
+    if (start === -1) break
+    const contentStart = start + openTag.length
+    const end = xml.indexOf(closeTag, contentStart)
+    if (end === -1) break
+    results.push(xml.slice(contentStart, end))
+    pos = end + closeTag.length
+  }
+  return results
+}
+
+function parseAccountInfo(xml: string): ParsedAccountInfo {
+  const info: ParsedAccountInfo = {}
+  const bankAcct =
+    extractTag(xml, 'BANKACCTFROM') || extractTag(xml, 'CCACCTFROM')
+  if (bankAcct) {
+    info.bankId = extractTagValue(bankAcct, 'BANKID')
+    info.accountId = extractTagValue(bankAcct, 'ACCTID')
+    info.accountType = extractTagValue(bankAcct, 'ACCTTYPE')
+  }
+  const fi = extractTag(xml, 'FI')
+  if (fi) {
+    info.institutionName = extractTagValue(fi, 'ORG')
+  }
+  return info
+}
+
+function mapOfxTxType(ofxType: string): string {
+  const map: Record<string, string> = {
+    CREDIT: 'credit',
+    DEBIT: 'debit',
+    INT: 'interest',
+    DIV: 'dividend',
+    FEE: 'fee',
+    SRVCHG: 'service_charge',
+    DEP: 'deposit',
+    ATM: 'atm',
+    POS: 'pos',
+    XFER: 'transfer',
+    CHECK: 'check',
+    PAYMENT: 'payment',
+    CASH: 'cash',
+    DIRECTDEP: 'direct_deposit',
+    DIRECTDEBIT: 'direct_debit',
+    REPEATPMT: 'recurring_payment',
+    HOLD: 'hold',
+    OTHER: 'other',
+  }
+  return map[ofxType.toUpperCase()] ?? 'other'
+}
+
+function parseTransactionBlock(
+  block: string,
+  options: OfxParseOptions,
+  currency: string
+): ParsedTransaction {
+  const fitid = extractTagValue(block, 'FITID')
+  const dtPosted = extractTagValue(block, 'DTPOSTED')
+  const dtUser = extractTagValue(block, 'DTUSER')
+  const amount = extractTagValue(block, 'TRNAMT')
+  const name = extractTagValue(block, 'NAME')
+  const memo = extractTagValue(block, 'MEMO')
+  const checkNum = extractTagValue(block, 'CHECKNUM')
+  const refNum = extractTagValue(block, 'REFNUM')
+  const trnType = extractTagValue(block, 'TRNTYPE')
+
+  const isDuplicate = Boolean(
+    fitid && options.existingExternalIds?.has(fitid)
+  )
+
+  const tx: ParsedTransaction = {
+    bank_account_id: options.bankAccountId,
+    external_id: fitid || undefined,
+    posted_date: parseOfxDate(dtPosted),
+    transaction_date: dtUser ? parseOfxDate(dtUser) : undefined,
+    amount,
+    currency,
+    payee: name || undefined,
+    memo: memo || undefined,
+    reference_number: checkNum || refNum || undefined,
+    tx_type: trnType ? mapOfxTxType(trnType) : undefined,
+    classification_status: 'unclassified',
+    raw_data: block,
+    _isDuplicate: isDuplicate,
+    _duplicateOf: isDuplicate ? fitid : undefined,
+  }
+
+  return tx
+}
+
+export function detectOfxFormat(content: string): StatementFormat | null {
+  const upper = content.slice(0, 2000).toUpperCase()
+  if (
+    upper.includes('OFXHEADER:') ||
+    upper.includes('<OFX>') ||
+    upper.includes('<?OFX')
+  ) {
+    return 'ofx'
+  }
+  return null
+}
+
+export function parseOfx(
+  content: string,
+  options: OfxParseOptions
+): ParseResult {
+  const xml = normalizeOfxToXml(content)
+
+  const currency =
+    extractTagValue(xml, 'CURDEF') || extractTagValue(xml, 'CURRENCY') || 'USD'
+
+  const accountInfo = parseAccountInfo(xml)
+
+  const stmtrs =
+    extractTag(xml, 'STMTTRNRS') || extractTag(xml, 'CCSTMTTRNRS')
+
+  const tranList = stmtrs
+    ? extractTag(stmtrs, 'BANKTRANLIST')
+    : extractTag(xml, 'BANKTRANLIST')
+
+  const txBlocks = extractAllBlocks(
+    tranList || stmtrs || xml,
+    'STMTTRN'
+  )
+
+  const transactions: ParsedTransaction[] = txBlocks.map((block) =>
+    parseTransactionBlock(block, options, currency)
+  )
+
+  let startDate = 0
+  let endDate = 0
+  if (tranList) {
+    const dtStart = extractTagValue(tranList, 'DTSTART')
+    const dtEnd = extractTagValue(tranList, 'DTEND')
+    if (dtStart) startDate = parseOfxDate(dtStart)
+    if (dtEnd) endDate = parseOfxDate(dtEnd)
+  }
+
+  const duplicateCount = transactions.filter((t) => t._isDuplicate).length
+
+  return {
+    transactions,
+    format: 'ofx',
+    accountInfo,
+    dateRange:
+      startDate || endDate ? { start: startDate, end: endDate } : undefined,
+    currency,
+    duplicateCount,
+    totalCount: transactions.length,
+  }
+}

--- a/src/services/parsers/ofxParser.ts
+++ b/src/services/parsers/ofxParser.ts
@@ -39,9 +39,14 @@ function normalizeOfxToXml(raw: string): string {
   return body
 }
 
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 function extractTag(xml: string, tag: string): string {
-  const openRe = new RegExp(`<${tag}>`, 'i')
-  const closeRe = new RegExp(`</${tag}>`, 'i')
+  const escaped = escapeRegExp(tag)
+  const openRe = new RegExp(`<${escaped}>`, 'i')
+  const closeRe = new RegExp(`</${escaped}>`, 'i')
   const openMatch = openRe.exec(xml)
   if (!openMatch) return ''
   const start = openMatch.index + openMatch[0].length
@@ -54,7 +59,8 @@ function extractTag(xml: string, tag: string): string {
 }
 
 function extractTagValue(xml: string, tag: string): string {
-  const re = new RegExp(`<${tag}>\\s*([^<\\n]+)`, 'i')
+  const escaped = escapeRegExp(tag)
+  const re = new RegExp(`<${escaped}>\\s*([^<\\n]+)`, 'i')
   const m = re.exec(xml)
   return m ? m[1].trim() : ''
 }

--- a/src/services/parsers/ofxParser.ts
+++ b/src/services/parsers/ofxParser.ts
@@ -8,18 +8,20 @@ import type {
 
 const OFX_DATE_RE = /^(\d{4})(\d{2})(\d{2})(?:(\d{2})(\d{2})(\d{2}))?/
 
+/** Parses an OFX date string (YYYYMMDD[HHmmss]) into a UTC timestamp. */
 function parseOfxDate(raw: string): number {
-  const m = OFX_DATE_RE.exec(raw.trim())
-  if (!m) return 0
-  const year = Number.parseInt(m[1], 10)
-  const month = Number.parseInt(m[2], 10) - 1
-  const day = Number.parseInt(m[3], 10)
-  const hour = m[4] ? Number.parseInt(m[4], 10) : 0
-  const min = m[5] ? Number.parseInt(m[5], 10) : 0
-  const sec = m[6] ? Number.parseInt(m[6], 10) : 0
+  const match = OFX_DATE_RE.exec(raw.trim())
+  if (!match) return 0
+  const year = Number.parseInt(match[1], 10)
+  const month = Number.parseInt(match[2], 10) - 1
+  const day = Number.parseInt(match[3], 10)
+  const hour = match[4] ? Number.parseInt(match[4], 10) : 0
+  const min = match[5] ? Number.parseInt(match[5], 10) : 0
+  const sec = match[6] ? Number.parseInt(match[6], 10) : 0
   return new Date(Date.UTC(year, month, day, hour, min, sec)).getTime()
 }
 
+/** Normalizes SGML-style OFX into well-formed XML by closing open value tags. */
 function normalizeOfxToXml(raw: string): string {
   const bodyStart = raw.indexOf('<OFX>')
   if (bodyStart === -1) return raw
@@ -39,10 +41,12 @@ function normalizeOfxToXml(raw: string): string {
   return body
 }
 
+/** Escapes special regex characters in a string for safe use in `new RegExp()`. */
 function escapeRegExp(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+/** Extracts the full content between an opening and closing XML tag. */
 function extractTag(xml: string, tag: string): string {
   const escaped = escapeRegExp(tag)
   const openRe = new RegExp(`<${escaped}>`, 'i')
@@ -58,13 +62,15 @@ function extractTag(xml: string, tag: string): string {
   return xml.slice(start, start + closeMatch.index).trim()
 }
 
+/** Extracts the inline text value immediately following an XML tag. */
 function extractTagValue(xml: string, tag: string): string {
   const escaped = escapeRegExp(tag)
   const re = new RegExp(`<${escaped}>\\s*([^<\\n]+)`, 'i')
-  const m = re.exec(xml)
-  return m ? m[1].trim() : ''
+  const match = re.exec(xml)
+  return match ? match[1].trim() : ''
 }
 
+/** Finds all content blocks between repeated opening/closing tag pairs. */
 function extractAllBlocks(xml: string, tag: string): string[] {
   const results: string[] = []
   const openTag = `<${tag}>`
@@ -82,6 +88,7 @@ function extractAllBlocks(xml: string, tag: string): string[] {
   return results
 }
 
+/** Extracts bank account metadata from the OFX BANKACCTFROM or CCACCTFROM block. */
 function parseAccountInfo(xml: string): ParsedAccountInfo {
   const info: ParsedAccountInfo = {}
   const bankAcct =
@@ -98,6 +105,7 @@ function parseAccountInfo(xml: string): ParsedAccountInfo {
   return info
 }
 
+/** Maps an OFX TRNTYPE code to a normalized lowercase transaction type string. */
 function mapOfxTxType(ofxType: string): string {
   const map: Record<string, string> = {
     CREDIT: 'credit',
@@ -122,6 +130,7 @@ function mapOfxTxType(ofxType: string): string {
   return map[ofxType.toUpperCase()] ?? 'other'
 }
 
+/** Parses a single OFX STMTTRN block into a ParsedTransaction. */
 function parseTransactionBlock(
   block: string,
   options: OfxParseOptions,
@@ -159,6 +168,7 @@ function parseTransactionBlock(
   return tx
 }
 
+/** Detects whether file content is an OFX/QFX/QBO statement by scanning for OFX markers. */
 export function detectOfxFormat(content: string): StatementFormat | null {
   const upper = content.slice(0, 2000).toUpperCase()
   if (
@@ -171,6 +181,7 @@ export function detectOfxFormat(content: string): StatementFormat | null {
   return null
 }
 
+/** Parses an OFX/QFX/QBO file into structured transactions and account metadata. */
 export function parseOfx(
   content: string,
   options: OfxParseOptions

--- a/src/services/parsers/types.ts
+++ b/src/services/parsers/types.ts
@@ -66,6 +66,7 @@ export interface StatementParser {
   detectFormat(content: string): StatementFormat | null
 }
 
+/** Deserializes a StatementProfile's JSON column_map into a typed CsvColumnMap, or null on failure. */
 export function columnMapFromProfile(
   profile: StatementProfile
 ): CsvColumnMap | null {

--- a/src/services/parsers/types.ts
+++ b/src/services/parsers/types.ts
@@ -1,0 +1,69 @@
+import type { BankTransactionInput, StatementProfile } from '../persistence/types'
+
+export type StatementFormat = 'ofx' | 'qfx' | 'qbo' | 'csv'
+
+export type AmountSignConvention = 'signed' | 'debit_positive' | 'debit_negative'
+
+export interface ParsedTransaction extends BankTransactionInput {
+  _isDuplicate?: boolean
+  _duplicateOf?: string
+  _rawLine?: number
+}
+
+export interface ParseResult {
+  transactions: ParsedTransaction[]
+  format: StatementFormat
+  accountInfo?: ParsedAccountInfo
+  dateRange?: { start: number; end: number }
+  currency?: string
+  duplicateCount: number
+  totalCount: number
+}
+
+export interface ParsedAccountInfo {
+  bankId?: string
+  accountId?: string
+  accountType?: string
+  institutionName?: string
+}
+
+export interface CsvColumnMap {
+  date: string
+  amount: string
+  payee?: string
+  memo?: string
+  referenceNumber?: string
+  type?: string
+  balance?: string
+}
+
+export interface CsvParseOptions {
+  bankAccountId: string
+  columnMap: CsvColumnMap
+  dateFormat: string
+  amountSignConvention: AmountSignConvention
+  currencyDefault: string
+  skipHeaderRows?: number
+  existingExternalIds?: Set<string>
+}
+
+export interface OfxParseOptions {
+  bankAccountId: string
+  existingExternalIds?: Set<string>
+}
+
+export interface StatementParser {
+  parse(content: string, options: OfxParseOptions | CsvParseOptions): ParseResult
+  detectFormat(content: string): StatementFormat | null
+}
+
+export function columnMapFromProfile(
+  profile: StatementProfile
+): CsvColumnMap | null {
+  if (!profile.column_map) return null
+  try {
+    return JSON.parse(profile.column_map) as CsvColumnMap
+  } catch {
+    return null
+  }
+}

--- a/src/services/parsers/types.ts
+++ b/src/services/parsers/types.ts
@@ -1,8 +1,14 @@
-import type { BankTransactionInput, StatementProfile } from '../persistence/types'
+import type {
+  BankTransactionInput,
+  StatementProfile,
+} from '../persistence/types'
 
 export type StatementFormat = 'ofx' | 'qfx' | 'qbo' | 'csv'
 
-export type AmountSignConvention = 'signed' | 'debit_positive' | 'debit_negative'
+export type AmountSignConvention =
+  | 'signed'
+  | 'debit_positive'
+  | 'debit_negative'
 
 export interface ParsedTransaction extends BankTransactionInput {
   _isDuplicate?: boolean
@@ -53,7 +59,10 @@ export interface OfxParseOptions {
 }
 
 export interface StatementParser {
-  parse(content: string, options: OfxParseOptions | CsvParseOptions): ParseResult
+  parse(
+    content: string,
+    options: OfxParseOptions | CsvParseOptions
+  ): ParseResult
   detectFormat(content: string): StatementFormat | null
 }
 

--- a/src/services/persistence/index.ts
+++ b/src/services/persistence/index.ts
@@ -34,6 +34,17 @@ export type {
   AddressMatch,
   PostalAddress,
   TaxDocumentationStatus,
+  // Bank types (GIV-825)
+  BankAccount,
+  BankAccountInput,
+  BankAccountType,
+  BankTransaction,
+  BankTransactionInput,
+  BankTransactionFilter,
+  ImportBatch,
+  ImportBatchInput,
+  StatementProfile,
+  StatementProfileInput,
 } from './types'
 
 /**


### PR DESCRIPTION
## Summary

- **OFX/QFX/QBO parser** — handles both v1 (SGML, self-closing tags) and v2 (XML). Extracts FITID for dedup, maps all 18 OFX transaction types, parses account info (bank/CC), date ranges, and currency.
- **CSV parser** — configurable column mapping via `StatementProfile`, supports 7 date formats (YYYY-MM-DD, MM/DD/YYYY, DD/MM/YYYY, etc.), 3 amount sign conventions (signed, debit_positive, debit_negative), quoted fields, escaped quotes, and Windows line endings.
- **Dedup module** — composite key dedup (`bank_account_id + external_id`) against both existing DB transactions and intra-batch duplicates. Exposes deterministic interface for QA property-based testing (GIV-821.6).
- **Format auto-detection** — by file extension (.ofx/.qfx/.qbo/.csv) and content heuristics.
- **Feature flag** — `bank_import_v1` key exported for settings-based dark-shipping.
- **Browser-safe** — pure TypeScript, no native/Rust dependencies. Works in both Tauri and PWA/web builds.
- Re-exports bank types from persistence index.

## Test plan

- [x] 75 tests pass across 4 test files (ofxParser, csvParser, dedup, index)
- [x] OFX v1 SGML parsing (3-tx bank statement with debit/credit/check)
- [x] OFX v2 XML parsing (2-tx credit card statement, EUR currency)
- [x] All 18 OFX transaction type mappings verified
- [x] CSV: 5 date formats, 3 sign conventions, quoted fields, escaped quotes, Windows CRLF
- [x] Dedup: existing-tx detection, intra-batch detection, account-scoped keys, no-external-id passthrough
- [x] `tsc --noEmit` clean
- [x] ESLint clean