### PR TITLE
feat(bank): BankAccountManager UI + statement upload + preview grid (GIV-827)

### DIFF
--- a/src-tauri/src/api/bank.rs
+++ b/src-tauri/src/api/bank.rs
@@ -282,6 +282,20 @@ pub async fn save_bank_account(
         .map_err(|e| e.to_string())
 }
 
+/// Sets a bank account's active flag to false (soft-delete).
+#[tauri::command]
+pub async fn archive_bank_account(
+    state: State<'_, DatabaseState>,
+    id: String,
+) -> Result<(), String> {
+    sqlx::query("UPDATE bank_accounts SET active = 0, updated_at = unixepoch() WHERE id = ?")
+        .bind(&id)
+        .execute(&state.pool)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 // ============================================================================
 // Bank Transaction Commands
 // ============================================================================

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -495,6 +495,7 @@ pub fn run() {
             // Bank & card transaction capture (GIV-825)
             api::bank::get_bank_accounts,
             api::bank::save_bank_account,
+            api::bank::archive_bank_account,
             api::bank::get_bank_transactions,
             api::bank::save_bank_transactions,
             api::bank::get_import_batches,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,9 @@ const ClassificationQueue = React.lazy(
 const ClassificationRules = React.lazy(
   () => import('./app/classification/ClassificationRules')
 )
+const BankAccountManager = React.lazy(
+  () => import('./app/bank-accounts/BankAccountManager')
+)
 const AccountingPeriods = React.lazy(
   () => import('./app/accounting-periods/AccountingPeriods')
 )
@@ -213,6 +216,7 @@ const MainRoutes: React.FC = () => (
       <Route path="/transactions/edit/:id" element={<TransactionForm />} />
       <Route path="/wallets" element={<Balances />} />
       <Route path="/wallet-manager" element={<WalletManager />} />
+      <Route path="/bank-accounts" element={<BankAccountManager />} />
       <Route path="/entities" element={<Entities />} />
       <Route path="/team" element={<Team />} />
       <Route path="/reports" element={<Reports />} />

--- a/src/app/bank-accounts/BankAccountManager.tsx
+++ b/src/app/bank-accounts/BankAccountManager.tsx
@@ -172,15 +172,7 @@ export default function BankAccountManager() {
 
   const handleArchive = useCallback(async (account: BankAccount) => {
     try {
-      await persistence.saveBankAccount({
-        ...account,
-        entity_id: account.entity_id ?? undefined,
-        masked_account_number: account.masked_account_number ?? undefined,
-        opening_balance: account.opening_balance ?? undefined,
-        opening_balance_date: account.opening_balance_date ?? undefined,
-        external_source: account.external_source ?? undefined,
-        external_account_id: account.external_account_id ?? undefined,
-      })
+      await persistence.archiveBankAccount(account.id)
       setAccounts(prev => prev.filter(a => a.id !== account.id))
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to archive account')
@@ -1004,10 +996,10 @@ function StatementUpload({
         <div className="text-center py-8">
           <CheckCircle className="w-10 h-10 mx-auto mb-3 text-green-500 opacity-60" />
           <p className="text-[#11202B] dark:text-[#EAF3F2] font-medium">
-            All transactions are duplicates
+            No transactions found in this file
           </p>
           <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE] mt-1">
-            This statement has already been fully imported.
+            The file could not be parsed or contains no transactions.
           </p>
         </div>
       )}

--- a/src/app/bank-accounts/BankAccountManager.tsx
+++ b/src/app/bank-accounts/BankAccountManager.tsx
@@ -16,6 +16,7 @@ import {
   type BankAccount,
   type BankAccountInput,
   type BankAccountType,
+  type BankTransaction,
   type ImportBatchInput,
   type BankTransactionInput,
   type StatementProfile,
@@ -88,6 +89,89 @@ function formatAmount(amount: string): string {
   if (Number.isNaN(n)) return amount
   const abs = Math.abs(n).toFixed(2)
   return n < 0 ? `-$${abs}` : `$${abs}`
+}
+
+function resolveCsvColumnMap(
+  content: string,
+  profiles: StatementProfile[],
+  selectedProfileId: string
+): { colMap: CsvColumnMap; profile: StatementProfile | undefined } | { error: string } {
+  const profile = profiles.find(p => p.id === selectedProfileId)
+  const inferred = profile
+    ? columnMapFromProfile(profile)
+    : inferColumnMap(content.split('\n')[0]?.split(',') ?? [])
+
+  const valid =
+    inferred &&
+    'date' in inferred &&
+    'amount' in inferred &&
+    inferred.date &&
+    inferred.amount
+
+  if (!valid) {
+    return {
+      error:
+        'Could not infer CSV columns. Please select a statement profile or ensure your CSV has Date and Amount columns.',
+    }
+  }
+
+  return { colMap: inferred as CsvColumnMap, profile }
+}
+
+function buildParseOptions(
+  format: string,
+  bankAccountId: string,
+  content: string,
+  profiles: StatementProfile[],
+  selectedProfileId: string,
+  currency: string,
+  existingIds: Set<string>
+):
+  | { options: Parameters<typeof parseStatement>[2] }
+  | { error: string } {
+  if (format !== 'csv') {
+    return {
+      options: { bankAccountId, existingExternalIds: existingIds },
+    }
+  }
+
+  const resolved = resolveCsvColumnMap(content, profiles, selectedProfileId)
+  if ('error' in resolved) return resolved
+
+  const { colMap, profile } = resolved
+  return {
+    options: {
+      bankAccountId,
+      columnMap: colMap,
+      dateFormat: profile?.date_format ?? 'MM/DD/YYYY',
+      amountSignConvention:
+        (profile?.amount_sign_convention as
+          | 'signed'
+          | 'debit_positive'
+          | 'debit_negative') ?? 'signed',
+      currencyDefault: profile?.currency_default ?? currency,
+      existingExternalIds: existingIds,
+    },
+  }
+}
+
+function buildPreviewState(
+  result: ParseResult,
+  existing: BankTransaction[]
+): { parseResult: ParseResult; previewRows: PreviewRow[] } {
+  const dedupResult = dedup(result.transactions, existing)
+  const allTx = [...dedupResult.unique, ...dedupResult.duplicates]
+  return {
+    parseResult: {
+      ...result,
+      transactions: allTx,
+      duplicateCount: dedupResult.duplicateCount,
+    },
+    previewRows: allTx.map(tx => ({
+      ...tx,
+      _selected: !tx._isDuplicate,
+    })),
+  }
 }
 
 /** @returns BankAccountManager page component */
@@ -236,62 +320,24 @@ export default function BankAccountManager() {
         const existing = await persistence.getBankTransactions(uploadAccount.id)
         const existingIds = buildExternalIdSet(existing)
 
-        let result: ParseResult
-        if (format === 'csv') {
-          const profile = profiles.find(p => p.id === selectedProfileId)
-          const inferred = profile
-            ? columnMapFromProfile(profile)
-            : inferColumnMap(content.split('\n')[0]?.split(',') ?? [])
-
-          const colMap: CsvColumnMap | null =
-            inferred &&
-            'date' in inferred &&
-            'amount' in inferred &&
-            inferred.date &&
-            inferred.amount
-              ? (inferred as CsvColumnMap)
-              : null
-
-          if (!colMap) {
-            setError(
-              'Could not infer CSV columns. Please select a statement profile or ensure your CSV has Date and Amount columns.'
-            )
-            return
-          }
-
-          result = parseStatement(content, format, {
-            bankAccountId: uploadAccount.id,
-            columnMap: colMap,
-            dateFormat: profile?.date_format ?? 'MM/DD/YYYY',
-            amountSignConvention:
-              (profile?.amount_sign_convention as
-                | 'signed'
-                | 'debit_positive'
-                | 'debit_negative') ?? 'signed',
-            currencyDefault:
-              profile?.currency_default ?? uploadAccount.currency,
-            existingExternalIds: existingIds,
-          })
-        } else {
-          result = parseStatement(content, format, {
-            bankAccountId: uploadAccount.id,
-            existingExternalIds: existingIds,
-          })
+        const opts = buildParseOptions(
+          format,
+          uploadAccount.id,
+          content,
+          profiles,
+          selectedProfileId,
+          uploadAccount.currency,
+          existingIds
+        )
+        if ('error' in opts) {
+          setError(opts.error)
+          return
         }
 
-        const dedupResult = dedup(result.transactions, existing)
-        const allTx = [...dedupResult.unique, ...dedupResult.duplicates]
-        const rows: PreviewRow[] = allTx.map(tx => ({
-          ...tx,
-          _selected: !tx._isDuplicate,
-        }))
-
-        setParseResult({
-          ...result,
-          transactions: allTx,
-          duplicateCount: dedupResult.duplicateCount,
-        })
-        setPreviewRows(rows)
+        const result = parseStatement(content, format, opts.options)
+        const preview = buildPreviewState(result, existing)
+        setParseResult(preview.parseResult)
+        setPreviewRows(preview.previewRows)
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to parse file')
       }

--- a/src/app/bank-accounts/BankAccountManager.tsx
+++ b/src/app/bank-accounts/BankAccountManager.tsx
@@ -174,6 +174,418 @@ function buildPreviewState(
   }
 }
 
+interface PreviewRowComponentProps {
+  row: PreviewRow
+  index: number
+  onToggle: (i: number) => void
+  onEditPayee: (i: number, v: string) => void
+  onEditMemo: (i: number, v: string) => void
+}
+
+const PreviewRowComponent = React.memo(function PreviewRowComponent({
+  row,
+  index,
+  onToggle,
+  onEditPayee,
+  onEditMemo,
+}: PreviewRowComponentProps) {
+  const handleToggle = useCallback(() => onToggle(index), [onToggle, index])
+  const handlePayeeChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) =>
+      onEditPayee(index, e.target.value),
+    [onEditPayee, index]
+  )
+  const handleMemoChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) =>
+      onEditMemo(index, e.target.value),
+    [onEditMemo, index]
+  )
+
+  const amount = Number.parseFloat(row.amount)
+  const amountColor =
+    amount < 0
+      ? 'text-red-500 dark:text-red-400'
+      : 'text-green-600 dark:text-green-400'
+
+  return (
+    <tr
+      className={`border-t border-[rgba(95,227,192,0.08)] ${
+        row._isDuplicate ? 'opacity-40' : ''
+      } ${row._selected ? '' : 'bg-gray-50/50 dark:bg-gray-900/20'}`}
+    >
+      <td className="px-3 py-2">
+        <input
+          type="checkbox"
+          checked={row._selected}
+          onChange={handleToggle}
+          disabled={Boolean(row._isDuplicate)}
+          className="rounded border-[rgba(95,227,192,0.3)]"
+        />
+      </td>
+      <td className="px-3 py-2 text-[#11202B] dark:text-[#EAF3F2] whitespace-nowrap">
+        {formatDate(row.posted_date)}
+      </td>
+      <td className="px-3 py-2">
+        <input
+          type="text"
+          value={row._editedPayee ?? row.payee ?? ''}
+          onChange={handlePayeeChange}
+          className="w-full bg-transparent border-b border-transparent hover:border-[rgba(95,227,192,0.3)] focus:border-[#5FE3C0] focus:outline-none text-[#11202B] dark:text-[#EAF3F2] text-sm"
+        />
+      </td>
+      <td className="px-3 py-2">
+        <input
+          type="text"
+          value={row._editedMemo ?? row.memo ?? ''}
+          onChange={handleMemoChange}
+          className="w-full bg-transparent border-b border-transparent hover:border-[rgba(95,227,192,0.3)] focus:border-[#5FE3C0] focus:outline-none text-[#647D8B] dark:text-[#9FB4BE] text-sm"
+        />
+      </td>
+      <td
+        className={`px-3 py-2 text-right font-mono whitespace-nowrap ${amountColor}`}
+      >
+        {formatAmount(row.amount)}
+      </td>
+      <td className="px-3 py-2 text-[#647D8B] dark:text-[#9FB4BE] text-xs">
+        {row.tx_type ?? '—'}
+      </td>
+      <td className="px-3 py-2 text-center">
+        {row._isDuplicate ? (
+          <span className="text-xs px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300">
+            Duplicate
+          </span>
+        ) : (
+          <span className="text-xs px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#294050] dark:text-[#9CF1DC]">
+            New
+          </span>
+        )}
+      </td>
+    </tr>
+  )
+})
+
+interface AccountCardProps {
+  account: BankAccount
+  onEdit: (a: BankAccount) => void
+  onArchive: (a: BankAccount) => void
+  onUpload: (a: BankAccount) => void
+}
+
+const AccountCard = React.memo(function AccountCard({
+  account,
+  onEdit,
+  onArchive,
+  onUpload,
+}: AccountCardProps) {
+  const handleEdit = useCallback(() => onEdit(account), [onEdit, account])
+  const handleArchive = useCallback(
+    () => onArchive(account),
+    [onArchive, account]
+  )
+  const handleUpload = useCallback(() => onUpload(account), [onUpload, account])
+
+  const typeLabel =
+    ACCOUNT_TYPES.find(t => t.value === account.account_type)?.label ??
+    account.account_type
+
+  return (
+    <div className="ledger-card border border-[rgba(95,227,192,0.15)] rounded-xl p-5">
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-lg bg-[#294050] flex items-center justify-center">
+            <Landmark className="w-5 h-5 text-[#5FE3C0]" />
+          </div>
+          <div>
+            <h3 className="font-semibold text-[#11202B] dark:text-[#EAF3F2]">
+              {account.account_nickname}
+            </h3>
+            <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE]">
+              {account.institution_name}
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-1">
+          <button
+            onClick={handleEdit}
+            className="p-1.5 rounded-md hover:bg-[#EAF3F2] dark:hover:bg-[#1E2F3C] transition-colors"
+            title="Edit account"
+          >
+            <Pencil className="w-4 h-4 text-[#647D8B]" />
+          </button>
+          <button
+            onClick={handleArchive}
+            className="p-1.5 rounded-md hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+            title="Archive account"
+          >
+            <Archive className="w-4 h-4 text-[#647D8B] hover:text-red-500" />
+          </button>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2 mb-4 text-xs">
+        <span className="px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#294050] dark:text-[#9CF1DC]">
+          {typeLabel}
+        </span>
+        <span className="px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#294050] dark:text-[#9CF1DC]">
+          {account.currency}
+        </span>
+        {account.masked_account_number && (
+          <span className="px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#647D8B] dark:text-[#9FB4BE]">
+            ****{account.masked_account_number}
+          </span>
+        )}
+        <span className="px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#647D8B] dark:text-[#9FB4BE]">
+          GL {account.gl_account_number}
+        </span>
+      </div>
+      <button
+        onClick={handleUpload}
+        className="w-full btn-secondary flex items-center justify-center gap-2 text-sm"
+      >
+        <Upload className="w-4 h-4" />
+        Import Statement
+      </button>
+    </div>
+  )
+})
+
+interface StatementUploadProps {
+  account: BankAccount
+  dragOver: boolean
+  parseResult: ParseResult | null
+  previewRows: PreviewRow[]
+  importing: boolean
+  selectedCount: number
+  profiles: StatementProfile[]
+  selectedProfileId: string
+  fileInputRef: React.RefObject<HTMLInputElement | null>
+  onDragOver: (e: React.DragEvent) => void
+  onDragLeave: () => void
+  onDrop: (e: React.DragEvent) => void
+  onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onToggleRow: (i: number) => void
+  onEditPayee: (i: number, v: string) => void
+  onEditMemo: (i: number, v: string) => void
+  onSelectAllToggle: () => void
+  onConfirm: () => void
+  onCancel: () => void
+  onProfileChange: (e: React.ChangeEvent<HTMLSelectElement>) => void
+}
+
+function StatementUpload({
+  account,
+  dragOver,
+  parseResult,
+  previewRows,
+  importing,
+  selectedCount,
+  profiles,
+  selectedProfileId,
+  fileInputRef,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onFileSelect,
+  onToggleRow,
+  onEditPayee,
+  onEditMemo,
+  onSelectAllToggle,
+  onConfirm,
+  onCancel,
+  onProfileChange,
+}: StatementUploadProps) {
+  const handleBrowseClick = useCallback(() => {
+    fileInputRef.current?.click()
+  }, [fileInputRef])
+
+  return (
+    <div className="ledger-card border border-[rgba(95,227,192,0.15)] rounded-xl p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-3">
+          <FileText className="w-5 h-5 text-[#5FE3C0]" />
+          <h2 className="text-lg font-semibold text-[#11202B] dark:text-[#EAF3F2]">
+            Import Statement — {account.account_nickname}
+          </h2>
+        </div>
+        <button
+          onClick={onCancel}
+          className="text-[#647D8B] hover:text-[#11202B] dark:hover:text-[#EAF3F2]"
+        >
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+
+      {/* CSV profile selector */}
+      {profiles.length > 0 && (
+        <div className="mb-4">
+          <label htmlFor="profile_select" className={labelClassName}>
+            Statement Profile (for CSV)
+          </label>
+          <select
+            id="profile_select"
+            className={inputClassName}
+            value={selectedProfileId}
+            onChange={onProfileChange}
+          >
+            <option value="">Auto-detect columns</option>
+            {profiles.map(p => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+                {p.institution_name ? ` (${p.institution_name})` : ''}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* Drop zone */}
+      {!parseResult && (
+        <div
+          onDragOver={onDragOver}
+          onDragLeave={onDragLeave}
+          onDrop={onDrop}
+          className={`border-2 border-dashed rounded-xl p-12 text-center transition-colors cursor-pointer ${
+            dragOver
+              ? 'border-[#5FE3C0] bg-[#5FE3C0]/10'
+              : 'border-[rgba(95,227,192,0.3)] hover:border-[#5FE3C0]/50'
+          }`}
+          onClick={handleBrowseClick}
+          role="button"
+          tabIndex={0}
+        >
+          <Upload className="w-10 h-10 mx-auto mb-3 text-[#5FE3C0] opacity-60" />
+          <p className="text-[#11202B] dark:text-[#EAF3F2] font-medium mb-1">
+            Drag & drop a statement file here
+          </p>
+          <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE]">
+            OFX, QFX, QBO, or CSV files supported
+          </p>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".ofx,.qfx,.qbo,.csv"
+            onChange={onFileSelect}
+            className="hidden"
+          />
+        </div>
+      )}
+
+      {/* Preview grid */}
+      {parseResult && previewRows.length > 0 && (
+        <div>
+          <div className="flex items-center justify-between mb-3">
+            <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE]">
+              {parseResult.totalCount} transaction
+              {parseResult.totalCount !== 1 ? 's' : ''} parsed
+              {parseResult.duplicateCount > 0 && (
+                <span className="text-amber-500">
+                  {' '}
+                  ({parseResult.duplicateCount} duplicate
+                  {parseResult.duplicateCount !== 1 ? 's' : ''})
+                </span>
+              )}
+              {' — '}
+              <span className="font-medium text-[#11202B] dark:text-[#EAF3F2]">
+                {selectedCount} selected
+              </span>
+            </p>
+            <label className="flex items-center gap-2 text-sm text-[#647D8B] cursor-pointer">
+              <input
+                type="checkbox"
+                checked={previewRows.every(r => r._selected || r._isDuplicate)}
+                onChange={onSelectAllToggle}
+                className="rounded border-[rgba(95,227,192,0.3)]"
+              />
+              Select all
+            </label>
+          </div>
+          <div className="overflow-x-auto rounded-lg border border-[rgba(95,227,192,0.15)]">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-[#EAF3F2] dark:bg-[#1E2F3C]">
+                  <th scope="col" className="px-3 py-2 text-left w-10" />
+                  <th
+                    scope="col"
+                    className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium"
+                  >
+                    Date
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium"
+                  >
+                    Payee
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium"
+                  >
+                    Memo
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-3 py-2 text-right text-[#294050] dark:text-[#9CF1DC] font-medium"
+                  >
+                    Amount
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium"
+                  >
+                    Type
+                  </th>
+                  <th
+                    scope="col"
+                    className="px-3 py-2 text-center text-[#294050] dark:text-[#9CF1DC] font-medium"
+                  >
+                    Status
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {previewRows.map((row, idx) => (
+                  <PreviewRowComponent
+                    key={row.external_id ?? `row-${idx}`}
+                    row={row}
+                    index={idx}
+                    onToggle={onToggleRow}
+                    onEditPayee={onEditPayee}
+                    onEditMemo={onEditMemo}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex items-center gap-3 mt-4">
+            <button
+              onClick={onConfirm}
+              disabled={importing || selectedCount === 0}
+              className="btn-primary flex items-center gap-2 disabled:opacity-50"
+            >
+              {importing && <Loader className="w-4 h-4 animate-spin" />}
+              Import {selectedCount} Transaction{selectedCount !== 1 ? 's' : ''}
+            </button>
+            <button onClick={onCancel} className="btn-secondary">
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {parseResult && previewRows.length === 0 && (
+        <div className="text-center py-8">
+          <CheckCircle className="w-10 h-10 mx-auto mb-3 text-green-500 opacity-60" />
+          <p className="text-[#11202B] dark:text-[#EAF3F2] font-medium">
+            No transactions found in this file
+          </p>
+          <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE] mt-1">
+            The file could not be parsed or contains no transactions.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
 /** @returns BankAccountManager page component */
 export default function BankAccountManager() {
   const { entities } = useEntity()
@@ -730,415 +1142,3 @@ export default function BankAccountManager() {
     </div>
   )
 }
-
-interface AccountCardProps {
-  account: BankAccount
-  onEdit: (a: BankAccount) => void
-  onArchive: (a: BankAccount) => void
-  onUpload: (a: BankAccount) => void
-}
-
-const AccountCard = React.memo(function AccountCard({
-  account,
-  onEdit,
-  onArchive,
-  onUpload,
-}: AccountCardProps) {
-  const handleEdit = useCallback(() => onEdit(account), [onEdit, account])
-  const handleArchive = useCallback(
-    () => onArchive(account),
-    [onArchive, account]
-  )
-  const handleUpload = useCallback(() => onUpload(account), [onUpload, account])
-
-  const typeLabel =
-    ACCOUNT_TYPES.find(t => t.value === account.account_type)?.label ??
-    account.account_type
-
-  return (
-    <div className="ledger-card border border-[rgba(95,227,192,0.15)] rounded-xl p-5">
-      <div className="flex items-start justify-between mb-3">
-        <div className="flex items-center gap-3">
-          <div className="w-10 h-10 rounded-lg bg-[#294050] flex items-center justify-center">
-            <Landmark className="w-5 h-5 text-[#5FE3C0]" />
-          </div>
-          <div>
-            <h3 className="font-semibold text-[#11202B] dark:text-[#EAF3F2]">
-              {account.account_nickname}
-            </h3>
-            <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE]">
-              {account.institution_name}
-            </p>
-          </div>
-        </div>
-        <div className="flex gap-1">
-          <button
-            onClick={handleEdit}
-            className="p-1.5 rounded-md hover:bg-[#EAF3F2] dark:hover:bg-[#1E2F3C] transition-colors"
-            title="Edit account"
-          >
-            <Pencil className="w-4 h-4 text-[#647D8B]" />
-          </button>
-          <button
-            onClick={handleArchive}
-            className="p-1.5 rounded-md hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
-            title="Archive account"
-          >
-            <Archive className="w-4 h-4 text-[#647D8B] hover:text-red-500" />
-          </button>
-        </div>
-      </div>
-      <div className="flex flex-wrap gap-2 mb-4 text-xs">
-        <span className="px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#294050] dark:text-[#9CF1DC]">
-          {typeLabel}
-        </span>
-        <span className="px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#294050] dark:text-[#9CF1DC]">
-          {account.currency}
-        </span>
-        {account.masked_account_number && (
-          <span className="px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#647D8B] dark:text-[#9FB4BE]">
-            ****{account.masked_account_number}
-          </span>
-        )}
-        <span className="px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#647D8B] dark:text-[#9FB4BE]">
-          GL {account.gl_account_number}
-        </span>
-      </div>
-      <button
-        onClick={handleUpload}
-        className="w-full btn-secondary flex items-center justify-center gap-2 text-sm"
-      >
-        <Upload className="w-4 h-4" />
-        Import Statement
-      </button>
-    </div>
-  )
-})
-
-interface StatementUploadProps {
-  account: BankAccount
-  dragOver: boolean
-  parseResult: ParseResult | null
-  previewRows: PreviewRow[]
-  importing: boolean
-  selectedCount: number
-  profiles: StatementProfile[]
-  selectedProfileId: string
-  fileInputRef: React.RefObject<HTMLInputElement | null>
-  onDragOver: (e: React.DragEvent) => void
-  onDragLeave: () => void
-  onDrop: (e: React.DragEvent) => void
-  onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void
-  onToggleRow: (i: number) => void
-  onEditPayee: (i: number, v: string) => void
-  onEditMemo: (i: number, v: string) => void
-  onSelectAllToggle: () => void
-  onConfirm: () => void
-  onCancel: () => void
-  onProfileChange: (e: React.ChangeEvent<HTMLSelectElement>) => void
-}
-
-function StatementUpload({
-  account,
-  dragOver,
-  parseResult,
-  previewRows,
-  importing,
-  selectedCount,
-  profiles,
-  selectedProfileId,
-  fileInputRef,
-  onDragOver,
-  onDragLeave,
-  onDrop,
-  onFileSelect,
-  onToggleRow,
-  onEditPayee,
-  onEditMemo,
-  onSelectAllToggle,
-  onConfirm,
-  onCancel,
-  onProfileChange,
-}: StatementUploadProps) {
-  const handleBrowseClick = useCallback(() => {
-    fileInputRef.current?.click()
-  }, [fileInputRef])
-
-  return (
-    <div className="ledger-card border border-[rgba(95,227,192,0.15)] rounded-xl p-6">
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-3">
-          <FileText className="w-5 h-5 text-[#5FE3C0]" />
-          <h2 className="text-lg font-semibold text-[#11202B] dark:text-[#EAF3F2]">
-            Import Statement — {account.account_nickname}
-          </h2>
-        </div>
-        <button
-          onClick={onCancel}
-          className="text-[#647D8B] hover:text-[#11202B] dark:hover:text-[#EAF3F2]"
-        >
-          <X className="w-5 h-5" />
-        </button>
-      </div>
-
-      {/* CSV profile selector */}
-      {profiles.length > 0 && (
-        <div className="mb-4">
-          <label htmlFor="profile_select" className={labelClassName}>
-            Statement Profile (for CSV)
-          </label>
-          <select
-            id="profile_select"
-            className={inputClassName}
-            value={selectedProfileId}
-            onChange={onProfileChange}
-          >
-            <option value="">Auto-detect columns</option>
-            {profiles.map(p => (
-              <option key={p.id} value={p.id}>
-                {p.name}
-                {p.institution_name ? ` (${p.institution_name})` : ''}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
-
-      {/* Drop zone */}
-      {!parseResult && (
-        <div
-          onDragOver={onDragOver}
-          onDragLeave={onDragLeave}
-          onDrop={onDrop}
-          className={`border-2 border-dashed rounded-xl p-12 text-center transition-colors cursor-pointer ${
-            dragOver
-              ? 'border-[#5FE3C0] bg-[#5FE3C0]/10'
-              : 'border-[rgba(95,227,192,0.3)] hover:border-[#5FE3C0]/50'
-          }`}
-          onClick={handleBrowseClick}
-          role="button"
-          tabIndex={0}
-        >
-          <Upload className="w-10 h-10 mx-auto mb-3 text-[#5FE3C0] opacity-60" />
-          <p className="text-[#11202B] dark:text-[#EAF3F2] font-medium mb-1">
-            Drag & drop a statement file here
-          </p>
-          <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE]">
-            OFX, QFX, QBO, or CSV files supported
-          </p>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".ofx,.qfx,.qbo,.csv"
-            onChange={onFileSelect}
-            className="hidden"
-          />
-        </div>
-      )}
-
-      {/* Preview grid */}
-      {parseResult && previewRows.length > 0 && (
-        <div>
-          <div className="flex items-center justify-between mb-3">
-            <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE]">
-              {parseResult.totalCount} transaction
-              {parseResult.totalCount !== 1 ? 's' : ''} parsed
-              {parseResult.duplicateCount > 0 && (
-                <span className="text-amber-500">
-                  {' '}
-                  ({parseResult.duplicateCount} duplicate
-                  {parseResult.duplicateCount !== 1 ? 's' : ''})
-                </span>
-              )}
-              {' — '}
-              <span className="font-medium text-[#11202B] dark:text-[#EAF3F2]">
-                {selectedCount} selected
-              </span>
-            </p>
-            <label className="flex items-center gap-2 text-sm text-[#647D8B] cursor-pointer">
-              <input
-                type="checkbox"
-                checked={previewRows.every(r => r._selected || r._isDuplicate)}
-                onChange={onSelectAllToggle}
-                className="rounded border-[rgba(95,227,192,0.3)]"
-              />
-              Select all
-            </label>
-          </div>
-          <div className="overflow-x-auto rounded-lg border border-[rgba(95,227,192,0.15)]">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="bg-[#EAF3F2] dark:bg-[#1E2F3C]">
-                  <th scope="col" className="px-3 py-2 text-left w-10" />
-                  <th
-                    scope="col"
-                    className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium"
-                  >
-                    Date
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium"
-                  >
-                    Payee
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium"
-                  >
-                    Memo
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-3 py-2 text-right text-[#294050] dark:text-[#9CF1DC] font-medium"
-                  >
-                    Amount
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium"
-                  >
-                    Type
-                  </th>
-                  <th
-                    scope="col"
-                    className="px-3 py-2 text-center text-[#294050] dark:text-[#9CF1DC] font-medium"
-                  >
-                    Status
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {previewRows.map((row, idx) => (
-                  <PreviewRowComponent
-                    key={row.external_id ?? `row-${idx}`}
-                    row={row}
-                    index={idx}
-                    onToggle={onToggleRow}
-                    onEditPayee={onEditPayee}
-                    onEditMemo={onEditMemo}
-                  />
-                ))}
-              </tbody>
-            </table>
-          </div>
-          <div className="flex items-center gap-3 mt-4">
-            <button
-              onClick={onConfirm}
-              disabled={importing || selectedCount === 0}
-              className="btn-primary flex items-center gap-2 disabled:opacity-50"
-            >
-              {importing && <Loader className="w-4 h-4 animate-spin" />}
-              Import {selectedCount} Transaction{selectedCount !== 1 ? 's' : ''}
-            </button>
-            <button onClick={onCancel} className="btn-secondary">
-              Cancel
-            </button>
-          </div>
-        </div>
-      )}
-
-      {parseResult && previewRows.length === 0 && (
-        <div className="text-center py-8">
-          <CheckCircle className="w-10 h-10 mx-auto mb-3 text-green-500 opacity-60" />
-          <p className="text-[#11202B] dark:text-[#EAF3F2] font-medium">
-            No transactions found in this file
-          </p>
-          <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE] mt-1">
-            The file could not be parsed or contains no transactions.
-          </p>
-        </div>
-      )}
-    </div>
-  )
-}
-
-interface PreviewRowComponentProps {
-  row: PreviewRow
-  index: number
-  onToggle: (i: number) => void
-  onEditPayee: (i: number, v: string) => void
-  onEditMemo: (i: number, v: string) => void
-}
-
-const PreviewRowComponent = React.memo(function PreviewRowComponent({
-  row,
-  index,
-  onToggle,
-  onEditPayee,
-  onEditMemo,
-}: PreviewRowComponentProps) {
-  const handleToggle = useCallback(() => onToggle(index), [onToggle, index])
-  const handlePayeeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      onEditPayee(index, e.target.value),
-    [onEditPayee, index]
-  )
-  const handleMemoChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) =>
-      onEditMemo(index, e.target.value),
-    [onEditMemo, index]
-  )
-
-  const amount = Number.parseFloat(row.amount)
-  const amountColor =
-    amount < 0
-      ? 'text-red-500 dark:text-red-400'
-      : 'text-green-600 dark:text-green-400'
-
-  return (
-    <tr
-      className={`border-t border-[rgba(95,227,192,0.08)] ${
-        row._isDuplicate ? 'opacity-40' : ''
-      } ${row._selected ? '' : 'bg-gray-50/50 dark:bg-gray-900/20'}`}
-    >
-      <td className="px-3 py-2">
-        <input
-          type="checkbox"
-          checked={row._selected}
-          onChange={handleToggle}
-          disabled={Boolean(row._isDuplicate)}
-          className="rounded border-[rgba(95,227,192,0.3)]"
-        />
-      </td>
-      <td className="px-3 py-2 text-[#11202B] dark:text-[#EAF3F2] whitespace-nowrap">
-        {formatDate(row.posted_date)}
-      </td>
-      <td className="px-3 py-2">
-        <input
-          type="text"
-          value={row._editedPayee ?? row.payee ?? ''}
-          onChange={handlePayeeChange}
-          className="w-full bg-transparent border-b border-transparent hover:border-[rgba(95,227,192,0.3)] focus:border-[#5FE3C0] focus:outline-none text-[#11202B] dark:text-[#EAF3F2] text-sm"
-        />
-      </td>
-      <td className="px-3 py-2">
-        <input
-          type="text"
-          value={row._editedMemo ?? row.memo ?? ''}
-          onChange={handleMemoChange}
-          className="w-full bg-transparent border-b border-transparent hover:border-[rgba(95,227,192,0.3)] focus:border-[#5FE3C0] focus:outline-none text-[#647D8B] dark:text-[#9FB4BE] text-sm"
-        />
-      </td>
-      <td
-        className={`px-3 py-2 text-right font-mono whitespace-nowrap ${amountColor}`}
-      >
-        {formatAmount(row.amount)}
-      </td>
-      <td className="px-3 py-2 text-[#647D8B] dark:text-[#9FB4BE] text-xs">
-        {row.tx_type ?? '—'}
-      </td>
-      <td className="px-3 py-2 text-center">
-        {row._isDuplicate ? (
-          <span className="text-xs px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300">
-            Duplicate
-          </span>
-        ) : (
-          <span className="text-xs px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#294050] dark:text-[#9CF1DC]">
-            New
-          </span>
-        )}
-      </td>
-    </tr>
-  )
-})

--- a/src/app/bank-accounts/BankAccountManager.tsx
+++ b/src/app/bank-accounts/BankAccountManager.tsx
@@ -75,15 +75,17 @@ interface PreviewRow extends ParsedTransaction {
   _editedMemo?: string
 }
 
+/** Formats epoch milliseconds as a locale date string. */
 function formatDate(epochMs: number): string {
-  const d = new Date(epochMs)
-  return d.toLocaleDateString('en-US', {
+  const date = new Date(epochMs)
+  return date.toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
   })
 }
 
+/** Formats a numeric string as a dollar amount with sign. */
 function formatAmount(amount: string): string {
   const n = Number.parseFloat(amount)
   if (Number.isNaN(n)) return amount
@@ -91,6 +93,7 @@ function formatAmount(amount: string): string {
   return n < 0 ? `-$${abs}` : `$${abs}`
 }
 
+/** Resolves CSV column mapping from a profile or by inference. */
 function resolveCsvColumnMap(
   content: string,
   profiles: StatementProfile[],
@@ -120,6 +123,7 @@ function resolveCsvColumnMap(
   return { colMap: inferred as CsvColumnMap, profile }
 }
 
+/** Builds parse options for CSV or OFX/QFX statement formats. */
 function buildParseOptions(
   format: string,
   bankAccountId: string,
@@ -155,6 +159,7 @@ function buildParseOptions(
   }
 }
 
+/** Deduplicates parsed transactions and builds preview rows. */
 function buildPreviewState(
   result: ParseResult,
   existing: BankTransaction[]
@@ -371,6 +376,7 @@ interface StatementUploadProps {
   onProfileChange: (e: React.ChangeEvent<HTMLSelectElement>) => void
 }
 
+/** Statement upload panel with drag-drop, preview grid, and import. */
 function StatementUpload({
   account,
   dragOver,

--- a/src/app/bank-accounts/BankAccountManager.tsx
+++ b/src/app/bank-accounts/BankAccountManager.tsx
@@ -118,9 +118,11 @@ export default function BankAccountManager() {
       setLoading(true)
       setError(null)
       const data = await persistence.getBankAccounts()
-      setAccounts(data.filter((a) => a.active))
+      setAccounts(data.filter(a => a.active))
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load bank accounts')
+      setError(
+        err instanceof Error ? err.message : 'Failed to load bank accounts'
+      )
     } finally {
       setLoading(false)
     }
@@ -143,7 +145,7 @@ export default function BankAccountManager() {
   const handleFormChange = useCallback(
     (field: keyof AccountFormData) =>
       (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
-        setFormData((prev) => ({ ...prev, [field]: e.target.value }))
+        setFormData(prev => ({ ...prev, [field]: e.target.value }))
       },
     []
   )
@@ -168,28 +170,26 @@ export default function BankAccountManager() {
     setShowAddForm(true)
   }, [])
 
-  const handleArchive = useCallback(
-    async (account: BankAccount) => {
-      try {
-        await persistence.saveBankAccount({
-          ...account,
-          entity_id: account.entity_id ?? undefined,
-          masked_account_number: account.masked_account_number ?? undefined,
-          opening_balance: account.opening_balance ?? undefined,
-          opening_balance_date: account.opening_balance_date ?? undefined,
-          external_source: account.external_source ?? undefined,
-          external_account_id: account.external_account_id ?? undefined,
-        })
-        setAccounts((prev) => prev.filter((a) => a.id !== account.id))
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to archive account')
-      }
-    },
-    []
-  )
+  const handleArchive = useCallback(async (account: BankAccount) => {
+    try {
+      await persistence.saveBankAccount({
+        ...account,
+        entity_id: account.entity_id ?? undefined,
+        masked_account_number: account.masked_account_number ?? undefined,
+        opening_balance: account.opening_balance ?? undefined,
+        opening_balance_date: account.opening_balance_date ?? undefined,
+        external_source: account.external_source ?? undefined,
+        external_account_id: account.external_account_id ?? undefined,
+      })
+      setAccounts(prev => prev.filter(a => a.id !== account.id))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to archive account')
+    }
+  }, [])
 
   const handleSave = useCallback(async () => {
-    if (!formData.institution_name.trim() || !formData.account_nickname.trim()) return
+    if (!formData.institution_name.trim() || !formData.account_nickname.trim())
+      return
     setSaving(true)
     try {
       const input: BankAccountInput = {
@@ -198,7 +198,8 @@ export default function BankAccountManager() {
         account_type: formData.account_type,
         currency: formData.currency.trim() || 'USD',
         gl_account_number: formData.gl_account_number.trim() || '1000',
-        masked_account_number: formData.masked_account_number.trim() || undefined,
+        masked_account_number:
+          formData.masked_account_number.trim() || undefined,
         entity_id: formData.entity_id || undefined,
       }
       await persistence.saveBankAccount(input)
@@ -245,13 +246,17 @@ export default function BankAccountManager() {
 
         let result: ParseResult
         if (format === 'csv') {
-          const profile = profiles.find((p) => p.id === selectedProfileId)
+          const profile = profiles.find(p => p.id === selectedProfileId)
           const inferred = profile
             ? columnMapFromProfile(profile)
             : inferColumnMap(content.split('\n')[0]?.split(',') ?? [])
 
           const colMap: CsvColumnMap | null =
-            inferred && 'date' in inferred && 'amount' in inferred && inferred.date && inferred.amount
+            inferred &&
+            'date' in inferred &&
+            'amount' in inferred &&
+            inferred.date &&
+            inferred.amount
               ? (inferred as CsvColumnMap)
               : null
 
@@ -267,8 +272,12 @@ export default function BankAccountManager() {
             columnMap: colMap,
             dateFormat: profile?.date_format ?? 'MM/DD/YYYY',
             amountSignConvention:
-              (profile?.amount_sign_convention as 'signed' | 'debit_positive' | 'debit_negative') ?? 'signed',
-            currencyDefault: profile?.currency_default ?? uploadAccount.currency,
+              (profile?.amount_sign_convention as
+                | 'signed'
+                | 'debit_positive'
+                | 'debit_negative') ?? 'signed',
+            currencyDefault:
+              profile?.currency_default ?? uploadAccount.currency,
             existingExternalIds: existingIds,
           })
         } else {
@@ -280,12 +289,16 @@ export default function BankAccountManager() {
 
         const dedupResult = dedup(result.transactions, existing)
         const allTx = [...dedupResult.unique, ...dedupResult.duplicates]
-        const rows: PreviewRow[] = allTx.map((tx) => ({
+        const rows: PreviewRow[] = allTx.map(tx => ({
           ...tx,
           _selected: !tx._isDuplicate,
         }))
 
-        setParseResult({ ...result, transactions: allTx, duplicateCount: dedupResult.duplicateCount })
+        setParseResult({
+          ...result,
+          transactions: allTx,
+          duplicateCount: dedupResult.duplicateCount,
+        })
         setPreviewRows(rows)
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to parse file')
@@ -322,25 +335,29 @@ export default function BankAccountManager() {
   }, [])
 
   const handleToggleRow = useCallback((index: number) => {
-    setPreviewRows((prev) =>
-      prev.map((row, i) => (i === index ? { ...row, _selected: !row._selected } : row))
+    setPreviewRows(prev =>
+      prev.map((row, i) =>
+        i === index ? { ...row, _selected: !row._selected } : row
+      )
     )
   }, [])
 
   const handleEditPayee = useCallback((index: number, value: string) => {
-    setPreviewRows((prev) =>
-      prev.map((row, i) => (i === index ? { ...row, _editedPayee: value } : row))
+    setPreviewRows(prev =>
+      prev.map((row, i) =>
+        i === index ? { ...row, _editedPayee: value } : row
+      )
     )
   }, [])
 
   const handleEditMemo = useCallback((index: number, value: string) => {
-    setPreviewRows((prev) =>
+    setPreviewRows(prev =>
       prev.map((row, i) => (i === index ? { ...row, _editedMemo: value } : row))
     )
   }, [])
 
   const selectedCount = useMemo(
-    () => previewRows.filter((r) => r._selected).length,
+    () => previewRows.filter(r => r._selected).length,
     [previewRows]
   )
 
@@ -360,8 +377,8 @@ export default function BankAccountManager() {
       const savedBatch = await persistence.saveImportBatch(batch)
 
       const txInputs: BankTransactionInput[] = previewRows
-        .filter((r) => r._selected)
-        .map((row) => ({
+        .filter(r => r._selected)
+        .map(row => ({
           bank_account_id: uploadAccount.id,
           external_id: row.external_id,
           posted_date: row.posted_date,
@@ -379,11 +396,15 @@ export default function BankAccountManager() {
         }))
 
       const count = await persistence.saveBankTransactions(txInputs)
-      setImportSuccess(`Imported ${count} transaction${count !== 1 ? 's' : ''} successfully.`)
+      setImportSuccess(
+        `Imported ${count} transaction${count !== 1 ? 's' : ''} successfully.`
+      )
       setPreviewRows([])
       setParseResult(null)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to import transactions')
+      setError(
+        err instanceof Error ? err.message : 'Failed to import transactions'
+      )
     } finally {
       setImporting(false)
     }
@@ -404,9 +425,9 @@ export default function BankAccountManager() {
   )
 
   const handleSelectAllToggle = useCallback(() => {
-    const allSelected = previewRows.every((r) => r._selected || r._isDuplicate)
-    setPreviewRows((prev) =>
-      prev.map((row) =>
+    const allSelected = previewRows.every(r => r._selected || r._isDuplicate)
+    setPreviewRows(prev =>
+      prev.map(row =>
         row._isDuplicate ? row : { ...row, _selected: !allSelected }
       )
     )
@@ -418,7 +439,9 @@ export default function BankAccountManager() {
         <div className="max-w-7xl mx-auto">
           <div className="flex items-center justify-center py-20">
             <Loader className="w-6 h-6 animate-spin text-[#5FE3C0]" />
-            <span className="ml-3 text-[#9FB4BE]">Loading bank accounts...</span>
+            <span className="ml-3 text-[#9FB4BE]">
+              Loading bank accounts...
+            </span>
           </div>
         </div>
       </div>
@@ -436,14 +459,17 @@ export default function BankAccountManager() {
               Bank Accounts
             </h1>
           </div>
-          <button onClick={handleAddClick} className="btn-primary flex items-center gap-2">
+          <button
+            onClick={handleAddClick}
+            className="btn-primary flex items-center gap-2"
+          >
             <Plus className="w-4 h-4" />
             Add Account
           </button>
         </div>
         <p className="text-[#647D8B] dark:text-[#9FB4BE] mb-8">
-          Manage bank and card accounts, import statements, and review transactions
-          before posting.
+          Manage bank and card accounts, import statements, and review
+          transactions before posting.
         </p>
 
         {error && (
@@ -452,7 +478,10 @@ export default function BankAccountManager() {
             <div className="flex-1">
               <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
             </div>
-            <button onClick={() => setError(null)} className="text-red-400 hover:text-red-600">
+            <button
+              onClick={() => setError(null)}
+              className="text-red-400 hover:text-red-600"
+            >
               <X className="w-4 h-4" />
             </button>
           </div>
@@ -461,8 +490,13 @@ export default function BankAccountManager() {
         {importSuccess && (
           <div className="mb-6 p-4 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 flex items-start gap-3">
             <CheckCircle className="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" />
-            <p className="text-sm text-green-700 dark:text-green-300">{importSuccess}</p>
-            <button onClick={() => setImportSuccess(null)} className="text-green-400 hover:text-green-600">
+            <p className="text-sm text-green-700 dark:text-green-300">
+              {importSuccess}
+            </p>
+            <button
+              onClick={() => setImportSuccess(null)}
+              className="text-green-400 hover:text-green-600"
+            >
               <X className="w-4 h-4" />
             </button>
           </div>
@@ -511,7 +545,7 @@ export default function BankAccountManager() {
                   value={formData.account_type}
                   onChange={handleFormChange('account_type')}
                 >
-                  {ACCOUNT_TYPES.map((t) => (
+                  {ACCOUNT_TYPES.map(t => (
                     <option key={t.value} value={t.value}>
                       {t.label}
                     </option>
@@ -569,7 +603,7 @@ export default function BankAccountManager() {
                   onChange={handleFormChange('entity_id')}
                 >
                   <option value="">No entity</option>
-                  {entities.map((e) => (
+                  {entities.map(e => (
                     <option key={e.id} value={e.id}>
                       {e.name}
                     </option>
@@ -580,7 +614,11 @@ export default function BankAccountManager() {
             <div className="flex gap-3 mt-6">
               <button
                 onClick={handleSave}
-                disabled={saving || !formData.institution_name.trim() || !formData.account_nickname.trim()}
+                disabled={
+                  saving ||
+                  !formData.institution_name.trim() ||
+                  !formData.account_nickname.trim()
+                }
                 className="btn-primary flex items-center gap-2 disabled:opacity-50"
               >
                 {saving && <Loader className="w-4 h-4 animate-spin" />}
@@ -603,14 +641,17 @@ export default function BankAccountManager() {
             <p className="text-[#647D8B] dark:text-[#9FB4BE] mb-6">
               Add a bank or card account to start importing statements.
             </p>
-            <button onClick={handleAddClick} className="btn-primary inline-flex items-center gap-2">
+            <button
+              onClick={handleAddClick}
+              className="btn-primary inline-flex items-center gap-2"
+            >
               <Plus className="w-4 h-4" />
               Add Your First Account
             </button>
           </div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-            {accounts.map((account) => (
+            {accounts.map(account => (
               <AccountCard
                 key={account.id}
                 account={account}
@@ -666,11 +707,14 @@ const AccountCard = React.memo(function AccountCard({
   onUpload,
 }: AccountCardProps) {
   const handleEdit = useCallback(() => onEdit(account), [onEdit, account])
-  const handleArchive = useCallback(() => onArchive(account), [onArchive, account])
+  const handleArchive = useCallback(
+    () => onArchive(account),
+    [onArchive, account]
+  )
   const handleUpload = useCallback(() => onUpload(account), [onUpload, account])
 
   const typeLabel =
-    ACCOUNT_TYPES.find((t) => t.value === account.account_type)?.label ??
+    ACCOUNT_TYPES.find(t => t.value === account.account_type)?.label ??
     account.account_type
 
   return (
@@ -791,7 +835,10 @@ function StatementUpload({
             Import Statement — {account.account_nickname}
           </h2>
         </div>
-        <button onClick={onCancel} className="text-[#647D8B] hover:text-[#11202B] dark:hover:text-[#EAF3F2]">
+        <button
+          onClick={onCancel}
+          className="text-[#647D8B] hover:text-[#11202B] dark:hover:text-[#EAF3F2]"
+        >
           <X className="w-5 h-5" />
         </button>
       </div>
@@ -809,7 +856,7 @@ function StatementUpload({
             onChange={onProfileChange}
           >
             <option value="">Auto-detect columns</option>
-            {profiles.map((p) => (
+            {profiles.map(p => (
               <option key={p.id} value={p.id}>
                 {p.name}
                 {p.institution_name ? ` (${p.institution_name})` : ''}
@@ -856,11 +903,13 @@ function StatementUpload({
         <div>
           <div className="flex items-center justify-between mb-3">
             <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE]">
-              {parseResult.totalCount} transaction{parseResult.totalCount !== 1 ? 's' : ''} parsed
+              {parseResult.totalCount} transaction
+              {parseResult.totalCount !== 1 ? 's' : ''} parsed
               {parseResult.duplicateCount > 0 && (
                 <span className="text-amber-500">
                   {' '}
-                  ({parseResult.duplicateCount} duplicate{parseResult.duplicateCount !== 1 ? 's' : ''})
+                  ({parseResult.duplicateCount} duplicate
+                  {parseResult.duplicateCount !== 1 ? 's' : ''})
                 </span>
               )}
               {' — '}
@@ -871,7 +920,7 @@ function StatementUpload({
             <label className="flex items-center gap-2 text-sm text-[#647D8B] cursor-pointer">
               <input
                 type="checkbox"
-                checked={previewRows.every((r) => r._selected || r._isDuplicate)}
+                checked={previewRows.every(r => r._selected || r._isDuplicate)}
                 onChange={onSelectAllToggle}
                 className="rounded border-[rgba(95,227,192,0.3)]"
               />
@@ -883,22 +932,40 @@ function StatementUpload({
               <thead>
                 <tr className="bg-[#EAF3F2] dark:bg-[#1E2F3C]">
                   <th scope="col" className="px-3 py-2 text-left w-10" />
-                  <th scope="col" className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium">
+                  <th
+                    scope="col"
+                    className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium"
+                  >
                     Date
                   </th>
-                  <th scope="col" className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium">
+                  <th
+                    scope="col"
+                    className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium"
+                  >
                     Payee
                   </th>
-                  <th scope="col" className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium">
+                  <th
+                    scope="col"
+                    className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium"
+                  >
                     Memo
                   </th>
-                  <th scope="col" className="px-3 py-2 text-right text-[#294050] dark:text-[#9CF1DC] font-medium">
+                  <th
+                    scope="col"
+                    className="px-3 py-2 text-right text-[#294050] dark:text-[#9CF1DC] font-medium"
+                  >
                     Amount
                   </th>
-                  <th scope="col" className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium">
+                  <th
+                    scope="col"
+                    className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium"
+                  >
                     Type
                   </th>
-                  <th scope="col" className="px-3 py-2 text-center text-[#294050] dark:text-[#9CF1DC] font-medium">
+                  <th
+                    scope="col"
+                    className="px-3 py-2 text-center text-[#294050] dark:text-[#9CF1DC] font-medium"
+                  >
                     Status
                   </th>
                 </tr>
@@ -965,18 +1032,21 @@ const PreviewRowComponent = React.memo(function PreviewRowComponent({
 }: PreviewRowComponentProps) {
   const handleToggle = useCallback(() => onToggle(index), [onToggle, index])
   const handlePayeeChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onEditPayee(index, e.target.value),
+    (e: React.ChangeEvent<HTMLInputElement>) =>
+      onEditPayee(index, e.target.value),
     [onEditPayee, index]
   )
   const handleMemoChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => onEditMemo(index, e.target.value),
+    (e: React.ChangeEvent<HTMLInputElement>) =>
+      onEditMemo(index, e.target.value),
     [onEditMemo, index]
   )
 
   const amount = Number.parseFloat(row.amount)
-  const amountColor = amount < 0
-    ? 'text-red-500 dark:text-red-400'
-    : 'text-green-600 dark:text-green-400'
+  const amountColor =
+    amount < 0
+      ? 'text-red-500 dark:text-red-400'
+      : 'text-green-600 dark:text-green-400'
 
   return (
     <tr
@@ -1012,7 +1082,9 @@ const PreviewRowComponent = React.memo(function PreviewRowComponent({
           className="w-full bg-transparent border-b border-transparent hover:border-[rgba(95,227,192,0.3)] focus:border-[#5FE3C0] focus:outline-none text-[#647D8B] dark:text-[#9FB4BE] text-sm"
         />
       </td>
-      <td className={`px-3 py-2 text-right font-mono whitespace-nowrap ${amountColor}`}>
+      <td
+        className={`px-3 py-2 text-right font-mono whitespace-nowrap ${amountColor}`}
+      >
         {formatAmount(row.amount)}
       </td>
       <td className="px-3 py-2 text-[#647D8B] dark:text-[#9FB4BE] text-xs">

--- a/src/app/bank-accounts/BankAccountManager.tsx
+++ b/src/app/bank-accounts/BankAccountManager.tsx
@@ -95,7 +95,9 @@ function resolveCsvColumnMap(
   content: string,
   profiles: StatementProfile[],
   selectedProfileId: string
-): { colMap: CsvColumnMap; profile: StatementProfile | undefined } | { error: string } {
+):
+  | { colMap: CsvColumnMap; profile: StatementProfile | undefined }
+  | { error: string } {
   const profile = profiles.find(p => p.id === selectedProfileId)
   const inferred = profile
     ? columnMapFromProfile(profile)
@@ -126,9 +128,7 @@ function buildParseOptions(
   selectedProfileId: string,
   currency: string,
   existingIds: Set<string>
-):
-  | { options: Parameters<typeof parseStatement>[2] }
-  | { error: string } {
+): { options: Parameters<typeof parseStatement>[2] } | { error: string } {
   if (format !== 'csv') {
     return {
       options: { bankAccountId, existingExternalIds: existingIds },

--- a/src/app/bank-accounts/BankAccountManager.tsx
+++ b/src/app/bank-accounts/BankAccountManager.tsx
@@ -1,0 +1,1034 @@
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
+import {
+  Landmark,
+  Plus,
+  Upload,
+  FileText,
+  Pencil,
+  Archive,
+  AlertCircle,
+  CheckCircle,
+  X,
+  Loader,
+} from 'lucide-react'
+import {
+  persistence,
+  type BankAccount,
+  type BankAccountInput,
+  type BankAccountType,
+  type ImportBatchInput,
+  type BankTransactionInput,
+  type StatementProfile,
+} from '../../services/persistence'
+import {
+  detectFormat,
+  parseStatement,
+  dedup,
+  buildExternalIdSet,
+  columnMapFromProfile,
+  inferColumnMap,
+  type ParseResult,
+  type ParsedTransaction,
+  type CsvColumnMap,
+} from '../../services/parsers'
+import { useEntity } from '../../contexts/EntityContext'
+
+const ACCOUNT_TYPES: { value: BankAccountType; label: string }[] = [
+  { value: 'checking', label: 'Checking' },
+  { value: 'savings', label: 'Savings' },
+  { value: 'credit_card', label: 'Credit Card' },
+  { value: 'money_market', label: 'Money Market' },
+  { value: 'line_of_credit', label: 'Line of Credit' },
+  { value: 'other', label: 'Other' },
+]
+
+const inputClassName =
+  'w-full px-3 py-2 border border-[rgba(95,227,192,0.15)] rounded-lg bg-[#F7FAFA] dark:bg-[#11202B] text-[#11202B] dark:text-[#EAF3F2] focus:ring-2 focus:ring-[#5FE3C0] focus:outline-none'
+
+const labelClassName =
+  'block text-sm font-medium text-[#11202B] dark:text-[#9FB4BE] mb-1'
+
+interface AccountFormData {
+  institution_name: string
+  account_nickname: string
+  account_type: BankAccountType
+  currency: string
+  gl_account_number: string
+  masked_account_number: string
+  entity_id: string
+}
+
+const emptyForm: AccountFormData = {
+  institution_name: '',
+  account_nickname: '',
+  account_type: 'checking',
+  currency: 'USD',
+  gl_account_number: '1000',
+  masked_account_number: '',
+  entity_id: '',
+}
+
+interface PreviewRow extends ParsedTransaction {
+  _selected: boolean
+  _editedPayee?: string
+  _editedMemo?: string
+}
+
+function formatDate(epochMs: number): string {
+  const d = new Date(epochMs)
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function formatAmount(amount: string): string {
+  const n = Number.parseFloat(amount)
+  if (Number.isNaN(n)) return amount
+  const abs = Math.abs(n).toFixed(2)
+  return n < 0 ? `-$${abs}` : `$${abs}`
+}
+
+/** @returns BankAccountManager page component */
+export default function BankAccountManager() {
+  const { entities } = useEntity()
+  const [accounts, setAccounts] = useState<BankAccount[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [showAddForm, setShowAddForm] = useState(false)
+  const [editingAccount, setEditingAccount] = useState<BankAccount | null>(null)
+  const [formData, setFormData] = useState<AccountFormData>(emptyForm)
+  const [saving, setSaving] = useState(false)
+
+  const [uploadAccount, setUploadAccount] = useState<BankAccount | null>(null)
+  const [dragOver, setDragOver] = useState(false)
+  const [parseResult, setParseResult] = useState<ParseResult | null>(null)
+  const [previewRows, setPreviewRows] = useState<PreviewRow[]>([])
+  const [importing, setImporting] = useState(false)
+  const [importSuccess, setImportSuccess] = useState<string | null>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const [profiles, setProfiles] = useState<StatementProfile[]>([])
+  const [selectedProfileId, setSelectedProfileId] = useState<string>('')
+
+  const loadAccounts = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+      const data = await persistence.getBankAccounts()
+      setAccounts(data.filter((a) => a.active))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load bank accounts')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const loadProfiles = useCallback(async () => {
+    try {
+      const data = await persistence.getStatementProfiles()
+      setProfiles(data)
+    } catch {
+      // non-critical
+    }
+  }, [])
+
+  useEffect(() => {
+    loadAccounts()
+    loadProfiles()
+  }, [loadAccounts, loadProfiles])
+
+  const handleFormChange = useCallback(
+    (field: keyof AccountFormData) =>
+      (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+        setFormData((prev) => ({ ...prev, [field]: e.target.value }))
+      },
+    []
+  )
+
+  const handleAddClick = useCallback(() => {
+    setFormData(emptyForm)
+    setEditingAccount(null)
+    setShowAddForm(true)
+  }, [])
+
+  const handleEditClick = useCallback((account: BankAccount) => {
+    setFormData({
+      institution_name: account.institution_name,
+      account_nickname: account.account_nickname,
+      account_type: account.account_type,
+      currency: account.currency,
+      gl_account_number: account.gl_account_number,
+      masked_account_number: account.masked_account_number ?? '',
+      entity_id: account.entity_id ?? '',
+    })
+    setEditingAccount(account)
+    setShowAddForm(true)
+  }, [])
+
+  const handleArchive = useCallback(
+    async (account: BankAccount) => {
+      try {
+        await persistence.saveBankAccount({
+          ...account,
+          entity_id: account.entity_id ?? undefined,
+          masked_account_number: account.masked_account_number ?? undefined,
+          opening_balance: account.opening_balance ?? undefined,
+          opening_balance_date: account.opening_balance_date ?? undefined,
+          external_source: account.external_source ?? undefined,
+          external_account_id: account.external_account_id ?? undefined,
+        })
+        setAccounts((prev) => prev.filter((a) => a.id !== account.id))
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to archive account')
+      }
+    },
+    []
+  )
+
+  const handleSave = useCallback(async () => {
+    if (!formData.institution_name.trim() || !formData.account_nickname.trim()) return
+    setSaving(true)
+    try {
+      const input: BankAccountInput = {
+        institution_name: formData.institution_name.trim(),
+        account_nickname: formData.account_nickname.trim(),
+        account_type: formData.account_type,
+        currency: formData.currency.trim() || 'USD',
+        gl_account_number: formData.gl_account_number.trim() || '1000',
+        masked_account_number: formData.masked_account_number.trim() || undefined,
+        entity_id: formData.entity_id || undefined,
+      }
+      await persistence.saveBankAccount(input)
+      setShowAddForm(false)
+      setEditingAccount(null)
+      await loadAccounts()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save account')
+    } finally {
+      setSaving(false)
+    }
+  }, [formData, loadAccounts])
+
+  const handleCancelForm = useCallback(() => {
+    setShowAddForm(false)
+    setEditingAccount(null)
+  }, [])
+
+  const handleUploadClick = useCallback((account: BankAccount) => {
+    setUploadAccount(account)
+    setParseResult(null)
+    setPreviewRows([])
+    setImportSuccess(null)
+    setSelectedProfileId('')
+  }, [])
+
+  const processFile = useCallback(
+    async (file: File) => {
+      if (!uploadAccount) return
+      setError(null)
+      setImportSuccess(null)
+      try {
+        const content = await file.text()
+        const format = detectFormat(content, file.name)
+        if (!format) {
+          setError(
+            'Unsupported file format. Please upload OFX, QFX, QBO, or CSV files.'
+          )
+          return
+        }
+
+        const existing = await persistence.getBankTransactions(uploadAccount.id)
+        const existingIds = buildExternalIdSet(existing)
+
+        let result: ParseResult
+        if (format === 'csv') {
+          const profile = profiles.find((p) => p.id === selectedProfileId)
+          const inferred = profile
+            ? columnMapFromProfile(profile)
+            : inferColumnMap(content.split('\n')[0]?.split(',') ?? [])
+
+          const colMap: CsvColumnMap | null =
+            inferred && 'date' in inferred && 'amount' in inferred && inferred.date && inferred.amount
+              ? (inferred as CsvColumnMap)
+              : null
+
+          if (!colMap) {
+            setError(
+              'Could not infer CSV columns. Please select a statement profile or ensure your CSV has Date and Amount columns.'
+            )
+            return
+          }
+
+          result = parseStatement(content, format, {
+            bankAccountId: uploadAccount.id,
+            columnMap: colMap,
+            dateFormat: profile?.date_format ?? 'MM/DD/YYYY',
+            amountSignConvention:
+              (profile?.amount_sign_convention as 'signed' | 'debit_positive' | 'debit_negative') ?? 'signed',
+            currencyDefault: profile?.currency_default ?? uploadAccount.currency,
+            existingExternalIds: existingIds,
+          })
+        } else {
+          result = parseStatement(content, format, {
+            bankAccountId: uploadAccount.id,
+            existingExternalIds: existingIds,
+          })
+        }
+
+        const dedupResult = dedup(result.transactions, existing)
+        const allTx = [...dedupResult.unique, ...dedupResult.duplicates]
+        const rows: PreviewRow[] = allTx.map((tx) => ({
+          ...tx,
+          _selected: !tx._isDuplicate,
+        }))
+
+        setParseResult({ ...result, transactions: allTx, duplicateCount: dedupResult.duplicateCount })
+        setPreviewRows(rows)
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to parse file')
+      }
+    },
+    [uploadAccount, profiles, selectedProfileId]
+  )
+
+  const handleFileDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault()
+      setDragOver(false)
+      const file = e.dataTransfer.files[0]
+      if (file) processFile(file)
+    },
+    [processFile]
+  )
+
+  const handleFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0]
+      if (file) processFile(file)
+    },
+    [processFile]
+  )
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault()
+    setDragOver(true)
+  }, [])
+
+  const handleDragLeave = useCallback(() => {
+    setDragOver(false)
+  }, [])
+
+  const handleToggleRow = useCallback((index: number) => {
+    setPreviewRows((prev) =>
+      prev.map((row, i) => (i === index ? { ...row, _selected: !row._selected } : row))
+    )
+  }, [])
+
+  const handleEditPayee = useCallback((index: number, value: string) => {
+    setPreviewRows((prev) =>
+      prev.map((row, i) => (i === index ? { ...row, _editedPayee: value } : row))
+    )
+  }, [])
+
+  const handleEditMemo = useCallback((index: number, value: string) => {
+    setPreviewRows((prev) =>
+      prev.map((row, i) => (i === index ? { ...row, _editedMemo: value } : row))
+    )
+  }, [])
+
+  const selectedCount = useMemo(
+    () => previewRows.filter((r) => r._selected).length,
+    [previewRows]
+  )
+
+  const handleConfirmImport = useCallback(async () => {
+    if (!uploadAccount || selectedCount === 0) return
+    setImporting(true)
+    setError(null)
+    try {
+      const batch: ImportBatchInput = {
+        bank_account_id: uploadAccount.id,
+        filename: fileInputRef.current?.files?.[0]?.name,
+        format: parseResult?.format,
+        row_count: selectedCount,
+        duplicate_count: parseResult?.duplicateCount ?? 0,
+        status: 'committed',
+      }
+      const savedBatch = await persistence.saveImportBatch(batch)
+
+      const txInputs: BankTransactionInput[] = previewRows
+        .filter((r) => r._selected)
+        .map((row) => ({
+          bank_account_id: uploadAccount.id,
+          external_id: row.external_id,
+          posted_date: row.posted_date,
+          transaction_date: row.transaction_date,
+          amount: row.amount,
+          currency: row.currency,
+          payee: row._editedPayee ?? row.payee,
+          memo: row._editedMemo ?? row.memo,
+          reference_number: row.reference_number,
+          tx_type: row.tx_type,
+          running_balance: row.running_balance,
+          classification_status: 'unclassified',
+          raw_data: row.raw_data,
+          import_batch_id: savedBatch.id,
+        }))
+
+      const count = await persistence.saveBankTransactions(txInputs)
+      setImportSuccess(`Imported ${count} transaction${count !== 1 ? 's' : ''} successfully.`)
+      setPreviewRows([])
+      setParseResult(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to import transactions')
+    } finally {
+      setImporting(false)
+    }
+  }, [uploadAccount, selectedCount, previewRows, parseResult])
+
+  const handleCancelUpload = useCallback(() => {
+    setUploadAccount(null)
+    setParseResult(null)
+    setPreviewRows([])
+    setImportSuccess(null)
+  }, [])
+
+  const handleProfileChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      setSelectedProfileId(e.target.value)
+    },
+    []
+  )
+
+  const handleSelectAllToggle = useCallback(() => {
+    const allSelected = previewRows.every((r) => r._selected || r._isDuplicate)
+    setPreviewRows((prev) =>
+      prev.map((row) =>
+        row._isDuplicate ? row : { ...row, _selected: !allSelected }
+      )
+    )
+  }, [previewRows])
+
+  if (loading) {
+    return (
+      <div className="min-h-screen ledger-background p-6 md:p-10">
+        <div className="max-w-7xl mx-auto">
+          <div className="flex items-center justify-center py-20">
+            <Loader className="w-6 h-6 animate-spin text-[#5FE3C0]" />
+            <span className="ml-3 text-[#9FB4BE]">Loading bank accounts...</span>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen ledger-background p-6 md:p-10">
+      <div className="max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-2">
+          <div className="flex items-center gap-3">
+            <Landmark className="w-7 h-7 text-[#5FE3C0]" />
+            <h1 className="text-2xl font-bold text-[#11202B] dark:text-[#EAF3F2]">
+              Bank Accounts
+            </h1>
+          </div>
+          <button onClick={handleAddClick} className="btn-primary flex items-center gap-2">
+            <Plus className="w-4 h-4" />
+            Add Account
+          </button>
+        </div>
+        <p className="text-[#647D8B] dark:text-[#9FB4BE] mb-8">
+          Manage bank and card accounts, import statements, and review transactions
+          before posting.
+        </p>
+
+        {error && (
+          <div className="mb-6 p-4 rounded-lg bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 flex items-start gap-3">
+            <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+            </div>
+            <button onClick={() => setError(null)} className="text-red-400 hover:text-red-600">
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+
+        {importSuccess && (
+          <div className="mb-6 p-4 rounded-lg bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 flex items-start gap-3">
+            <CheckCircle className="w-5 h-5 text-green-500 flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-green-700 dark:text-green-300">{importSuccess}</p>
+            <button onClick={() => setImportSuccess(null)} className="text-green-400 hover:text-green-600">
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+        )}
+
+        {/* Add/Edit Form */}
+        {showAddForm && (
+          <div className="mb-8 ledger-card border border-[rgba(95,227,192,0.15)] p-6 rounded-xl">
+            <h2 className="text-lg font-semibold text-[#11202B] dark:text-[#EAF3F2] mb-4">
+              {editingAccount ? 'Edit Account' : 'Add Bank Account'}
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label htmlFor="institution" className={labelClassName}>
+                  Institution Name *
+                </label>
+                <input
+                  id="institution"
+                  type="text"
+                  className={inputClassName}
+                  value={formData.institution_name}
+                  onChange={handleFormChange('institution_name')}
+                  placeholder="e.g. Chase, Wells Fargo"
+                />
+              </div>
+              <div>
+                <label htmlFor="nickname" className={labelClassName}>
+                  Account Nickname *
+                </label>
+                <input
+                  id="nickname"
+                  type="text"
+                  className={inputClassName}
+                  value={formData.account_nickname}
+                  onChange={handleFormChange('account_nickname')}
+                  placeholder="e.g. Operating Account"
+                />
+              </div>
+              <div>
+                <label htmlFor="account_type" className={labelClassName}>
+                  Account Type
+                </label>
+                <select
+                  id="account_type"
+                  className={inputClassName}
+                  value={formData.account_type}
+                  onChange={handleFormChange('account_type')}
+                >
+                  {ACCOUNT_TYPES.map((t) => (
+                    <option key={t.value} value={t.value}>
+                      {t.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label htmlFor="currency" className={labelClassName}>
+                  Currency
+                </label>
+                <input
+                  id="currency"
+                  type="text"
+                  className={inputClassName}
+                  value={formData.currency}
+                  onChange={handleFormChange('currency')}
+                  placeholder="USD"
+                />
+              </div>
+              <div>
+                <label htmlFor="gl_account" className={labelClassName}>
+                  GL Account Number
+                </label>
+                <input
+                  id="gl_account"
+                  type="text"
+                  className={inputClassName}
+                  value={formData.gl_account_number}
+                  onChange={handleFormChange('gl_account_number')}
+                  placeholder="1000"
+                />
+              </div>
+              <div>
+                <label htmlFor="masked_account" className={labelClassName}>
+                  Account Last 4
+                </label>
+                <input
+                  id="masked_account"
+                  type="text"
+                  className={inputClassName}
+                  value={formData.masked_account_number}
+                  onChange={handleFormChange('masked_account_number')}
+                  placeholder="e.g. 4567"
+                  maxLength={4}
+                />
+              </div>
+              <div>
+                <label htmlFor="entity_select" className={labelClassName}>
+                  Entity (optional)
+                </label>
+                <select
+                  id="entity_select"
+                  className={inputClassName}
+                  value={formData.entity_id}
+                  onChange={handleFormChange('entity_id')}
+                >
+                  <option value="">No entity</option>
+                  {entities.map((e) => (
+                    <option key={e.id} value={e.id}>
+                      {e.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <div className="flex gap-3 mt-6">
+              <button
+                onClick={handleSave}
+                disabled={saving || !formData.institution_name.trim() || !formData.account_nickname.trim()}
+                className="btn-primary flex items-center gap-2 disabled:opacity-50"
+              >
+                {saving && <Loader className="w-4 h-4 animate-spin" />}
+                {editingAccount ? 'Update' : 'Add Account'}
+              </button>
+              <button onClick={handleCancelForm} className="btn-secondary">
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Account Cards */}
+        {accounts.length === 0 && !showAddForm ? (
+          <div className="ledger-card border border-[rgba(95,227,192,0.15)] rounded-xl p-12 text-center">
+            <Landmark className="w-12 h-12 mx-auto mb-4 text-[#5FE3C0] opacity-50" />
+            <h2 className="text-lg font-semibold text-[#11202B] dark:text-[#EAF3F2] mb-2">
+              No bank accounts yet
+            </h2>
+            <p className="text-[#647D8B] dark:text-[#9FB4BE] mb-6">
+              Add a bank or card account to start importing statements.
+            </p>
+            <button onClick={handleAddClick} className="btn-primary inline-flex items-center gap-2">
+              <Plus className="w-4 h-4" />
+              Add Your First Account
+            </button>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+            {accounts.map((account) => (
+              <AccountCard
+                key={account.id}
+                account={account}
+                onEdit={handleEditClick}
+                onArchive={handleArchive}
+                onUpload={handleUploadClick}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Statement Upload + Preview */}
+        {uploadAccount && (
+          <StatementUpload
+            account={uploadAccount}
+            dragOver={dragOver}
+            parseResult={parseResult}
+            previewRows={previewRows}
+            importing={importing}
+            selectedCount={selectedCount}
+            profiles={profiles}
+            selectedProfileId={selectedProfileId}
+            fileInputRef={fileInputRef}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleFileDrop}
+            onFileSelect={handleFileSelect}
+            onToggleRow={handleToggleRow}
+            onEditPayee={handleEditPayee}
+            onEditMemo={handleEditMemo}
+            onSelectAllToggle={handleSelectAllToggle}
+            onConfirm={handleConfirmImport}
+            onCancel={handleCancelUpload}
+            onProfileChange={handleProfileChange}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface AccountCardProps {
+  account: BankAccount
+  onEdit: (a: BankAccount) => void
+  onArchive: (a: BankAccount) => void
+  onUpload: (a: BankAccount) => void
+}
+
+const AccountCard = React.memo(function AccountCard({
+  account,
+  onEdit,
+  onArchive,
+  onUpload,
+}: AccountCardProps) {
+  const handleEdit = useCallback(() => onEdit(account), [onEdit, account])
+  const handleArchive = useCallback(() => onArchive(account), [onArchive, account])
+  const handleUpload = useCallback(() => onUpload(account), [onUpload, account])
+
+  const typeLabel =
+    ACCOUNT_TYPES.find((t) => t.value === account.account_type)?.label ??
+    account.account_type
+
+  return (
+    <div className="ledger-card border border-[rgba(95,227,192,0.15)] rounded-xl p-5">
+      <div className="flex items-start justify-between mb-3">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-lg bg-[#294050] flex items-center justify-center">
+            <Landmark className="w-5 h-5 text-[#5FE3C0]" />
+          </div>
+          <div>
+            <h3 className="font-semibold text-[#11202B] dark:text-[#EAF3F2]">
+              {account.account_nickname}
+            </h3>
+            <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE]">
+              {account.institution_name}
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-1">
+          <button
+            onClick={handleEdit}
+            className="p-1.5 rounded-md hover:bg-[#EAF3F2] dark:hover:bg-[#1E2F3C] transition-colors"
+            title="Edit account"
+          >
+            <Pencil className="w-4 h-4 text-[#647D8B]" />
+          </button>
+          <button
+            onClick={handleArchive}
+            className="p-1.5 rounded-md hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+            title="Archive account"
+          >
+            <Archive className="w-4 h-4 text-[#647D8B] hover:text-red-500" />
+          </button>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-2 mb-4 text-xs">
+        <span className="px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#294050] dark:text-[#9CF1DC]">
+          {typeLabel}
+        </span>
+        <span className="px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#294050] dark:text-[#9CF1DC]">
+          {account.currency}
+        </span>
+        {account.masked_account_number && (
+          <span className="px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#647D8B] dark:text-[#9FB4BE]">
+            ****{account.masked_account_number}
+          </span>
+        )}
+        <span className="px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#647D8B] dark:text-[#9FB4BE]">
+          GL {account.gl_account_number}
+        </span>
+      </div>
+      <button
+        onClick={handleUpload}
+        className="w-full btn-secondary flex items-center justify-center gap-2 text-sm"
+      >
+        <Upload className="w-4 h-4" />
+        Import Statement
+      </button>
+    </div>
+  )
+})
+
+interface StatementUploadProps {
+  account: BankAccount
+  dragOver: boolean
+  parseResult: ParseResult | null
+  previewRows: PreviewRow[]
+  importing: boolean
+  selectedCount: number
+  profiles: StatementProfile[]
+  selectedProfileId: string
+  fileInputRef: React.RefObject<HTMLInputElement | null>
+  onDragOver: (e: React.DragEvent) => void
+  onDragLeave: () => void
+  onDrop: (e: React.DragEvent) => void
+  onFileSelect: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onToggleRow: (i: number) => void
+  onEditPayee: (i: number, v: string) => void
+  onEditMemo: (i: number, v: string) => void
+  onSelectAllToggle: () => void
+  onConfirm: () => void
+  onCancel: () => void
+  onProfileChange: (e: React.ChangeEvent<HTMLSelectElement>) => void
+}
+
+function StatementUpload({
+  account,
+  dragOver,
+  parseResult,
+  previewRows,
+  importing,
+  selectedCount,
+  profiles,
+  selectedProfileId,
+  fileInputRef,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onFileSelect,
+  onToggleRow,
+  onEditPayee,
+  onEditMemo,
+  onSelectAllToggle,
+  onConfirm,
+  onCancel,
+  onProfileChange,
+}: StatementUploadProps) {
+  const handleBrowseClick = useCallback(() => {
+    fileInputRef.current?.click()
+  }, [fileInputRef])
+
+  return (
+    <div className="ledger-card border border-[rgba(95,227,192,0.15)] rounded-xl p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-3">
+          <FileText className="w-5 h-5 text-[#5FE3C0]" />
+          <h2 className="text-lg font-semibold text-[#11202B] dark:text-[#EAF3F2]">
+            Import Statement — {account.account_nickname}
+          </h2>
+        </div>
+        <button onClick={onCancel} className="text-[#647D8B] hover:text-[#11202B] dark:hover:text-[#EAF3F2]">
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+
+      {/* CSV profile selector */}
+      {profiles.length > 0 && (
+        <div className="mb-4">
+          <label htmlFor="profile_select" className={labelClassName}>
+            Statement Profile (for CSV)
+          </label>
+          <select
+            id="profile_select"
+            className={inputClassName}
+            value={selectedProfileId}
+            onChange={onProfileChange}
+          >
+            <option value="">Auto-detect columns</option>
+            {profiles.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}
+                {p.institution_name ? ` (${p.institution_name})` : ''}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* Drop zone */}
+      {!parseResult && (
+        <div
+          onDragOver={onDragOver}
+          onDragLeave={onDragLeave}
+          onDrop={onDrop}
+          className={`border-2 border-dashed rounded-xl p-12 text-center transition-colors cursor-pointer ${
+            dragOver
+              ? 'border-[#5FE3C0] bg-[#5FE3C0]/10'
+              : 'border-[rgba(95,227,192,0.3)] hover:border-[#5FE3C0]/50'
+          }`}
+          onClick={handleBrowseClick}
+          role="button"
+          tabIndex={0}
+        >
+          <Upload className="w-10 h-10 mx-auto mb-3 text-[#5FE3C0] opacity-60" />
+          <p className="text-[#11202B] dark:text-[#EAF3F2] font-medium mb-1">
+            Drag & drop a statement file here
+          </p>
+          <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE]">
+            OFX, QFX, QBO, or CSV files supported
+          </p>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".ofx,.qfx,.qbo,.csv"
+            onChange={onFileSelect}
+            className="hidden"
+          />
+        </div>
+      )}
+
+      {/* Preview grid */}
+      {parseResult && previewRows.length > 0 && (
+        <div>
+          <div className="flex items-center justify-between mb-3">
+            <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE]">
+              {parseResult.totalCount} transaction{parseResult.totalCount !== 1 ? 's' : ''} parsed
+              {parseResult.duplicateCount > 0 && (
+                <span className="text-amber-500">
+                  {' '}
+                  ({parseResult.duplicateCount} duplicate{parseResult.duplicateCount !== 1 ? 's' : ''})
+                </span>
+              )}
+              {' — '}
+              <span className="font-medium text-[#11202B] dark:text-[#EAF3F2]">
+                {selectedCount} selected
+              </span>
+            </p>
+            <label className="flex items-center gap-2 text-sm text-[#647D8B] cursor-pointer">
+              <input
+                type="checkbox"
+                checked={previewRows.every((r) => r._selected || r._isDuplicate)}
+                onChange={onSelectAllToggle}
+                className="rounded border-[rgba(95,227,192,0.3)]"
+              />
+              Select all
+            </label>
+          </div>
+          <div className="overflow-x-auto rounded-lg border border-[rgba(95,227,192,0.15)]">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-[#EAF3F2] dark:bg-[#1E2F3C]">
+                  <th scope="col" className="px-3 py-2 text-left w-10" />
+                  <th scope="col" className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium">
+                    Date
+                  </th>
+                  <th scope="col" className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium">
+                    Payee
+                  </th>
+                  <th scope="col" className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium">
+                    Memo
+                  </th>
+                  <th scope="col" className="px-3 py-2 text-right text-[#294050] dark:text-[#9CF1DC] font-medium">
+                    Amount
+                  </th>
+                  <th scope="col" className="px-3 py-2 text-left text-[#294050] dark:text-[#9CF1DC] font-medium">
+                    Type
+                  </th>
+                  <th scope="col" className="px-3 py-2 text-center text-[#294050] dark:text-[#9CF1DC] font-medium">
+                    Status
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {previewRows.map((row, idx) => (
+                  <PreviewRowComponent
+                    key={row.external_id ?? `row-${idx}`}
+                    row={row}
+                    index={idx}
+                    onToggle={onToggleRow}
+                    onEditPayee={onEditPayee}
+                    onEditMemo={onEditMemo}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="flex items-center gap-3 mt-4">
+            <button
+              onClick={onConfirm}
+              disabled={importing || selectedCount === 0}
+              className="btn-primary flex items-center gap-2 disabled:opacity-50"
+            >
+              {importing && <Loader className="w-4 h-4 animate-spin" />}
+              Import {selectedCount} Transaction{selectedCount !== 1 ? 's' : ''}
+            </button>
+            <button onClick={onCancel} className="btn-secondary">
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {parseResult && previewRows.length === 0 && (
+        <div className="text-center py-8">
+          <CheckCircle className="w-10 h-10 mx-auto mb-3 text-green-500 opacity-60" />
+          <p className="text-[#11202B] dark:text-[#EAF3F2] font-medium">
+            All transactions are duplicates
+          </p>
+          <p className="text-sm text-[#647D8B] dark:text-[#9FB4BE] mt-1">
+            This statement has already been fully imported.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface PreviewRowComponentProps {
+  row: PreviewRow
+  index: number
+  onToggle: (i: number) => void
+  onEditPayee: (i: number, v: string) => void
+  onEditMemo: (i: number, v: string) => void
+}
+
+const PreviewRowComponent = React.memo(function PreviewRowComponent({
+  row,
+  index,
+  onToggle,
+  onEditPayee,
+  onEditMemo,
+}: PreviewRowComponentProps) {
+  const handleToggle = useCallback(() => onToggle(index), [onToggle, index])
+  const handlePayeeChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onEditPayee(index, e.target.value),
+    [onEditPayee, index]
+  )
+  const handleMemoChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => onEditMemo(index, e.target.value),
+    [onEditMemo, index]
+  )
+
+  const amount = Number.parseFloat(row.amount)
+  const amountColor = amount < 0
+    ? 'text-red-500 dark:text-red-400'
+    : 'text-green-600 dark:text-green-400'
+
+  return (
+    <tr
+      className={`border-t border-[rgba(95,227,192,0.08)] ${
+        row._isDuplicate ? 'opacity-40' : ''
+      } ${row._selected ? '' : 'bg-gray-50/50 dark:bg-gray-900/20'}`}
+    >
+      <td className="px-3 py-2">
+        <input
+          type="checkbox"
+          checked={row._selected}
+          onChange={handleToggle}
+          disabled={Boolean(row._isDuplicate)}
+          className="rounded border-[rgba(95,227,192,0.3)]"
+        />
+      </td>
+      <td className="px-3 py-2 text-[#11202B] dark:text-[#EAF3F2] whitespace-nowrap">
+        {formatDate(row.posted_date)}
+      </td>
+      <td className="px-3 py-2">
+        <input
+          type="text"
+          value={row._editedPayee ?? row.payee ?? ''}
+          onChange={handlePayeeChange}
+          className="w-full bg-transparent border-b border-transparent hover:border-[rgba(95,227,192,0.3)] focus:border-[#5FE3C0] focus:outline-none text-[#11202B] dark:text-[#EAF3F2] text-sm"
+        />
+      </td>
+      <td className="px-3 py-2">
+        <input
+          type="text"
+          value={row._editedMemo ?? row.memo ?? ''}
+          onChange={handleMemoChange}
+          className="w-full bg-transparent border-b border-transparent hover:border-[rgba(95,227,192,0.3)] focus:border-[#5FE3C0] focus:outline-none text-[#647D8B] dark:text-[#9FB4BE] text-sm"
+        />
+      </td>
+      <td className={`px-3 py-2 text-right font-mono whitespace-nowrap ${amountColor}`}>
+        {formatAmount(row.amount)}
+      </td>
+      <td className="px-3 py-2 text-[#647D8B] dark:text-[#9FB4BE] text-xs">
+        {row.tx_type ?? '—'}
+      </td>
+      <td className="px-3 py-2 text-center">
+        {row._isDuplicate ? (
+          <span className="text-xs px-2 py-0.5 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300">
+            Duplicate
+          </span>
+        ) : (
+          <span className="text-xs px-2 py-0.5 rounded-full bg-[#EAF3F2] dark:bg-[#1E2F3C] text-[#294050] dark:text-[#9CF1DC]">
+            New
+          </span>
+        )}
+      </td>
+    </tr>
+  )
+})

--- a/src/components/layout/Navigation.tsx
+++ b/src/components/layout/Navigation.tsx
@@ -21,6 +21,7 @@ import {
   BookOpen,
   Scale,
   CalendarDays,
+  Landmark,
 } from 'lucide-react'
 import PacioliWhiteLogo from '../../assets/Pacioli_logo_white.svg'
 import PacioliBlackLogo from '../../assets/pacioli_logo_black.svg'
@@ -747,6 +748,7 @@ const Navigation: React.FC<NavigationProps> = ({
     },
     { name: 'Periods', href: '/accounting-periods', icon: CalendarDays },
     { name: 'Wallets', href: '/wallets', icon: Wallet },
+    { name: 'Bank Accounts', href: '/bank-accounts', icon: Landmark },
     { name: 'Entities', href: '/entities', icon: Building2 },
     {
       name: 'Reports',
@@ -819,6 +821,7 @@ const Navigation: React.FC<NavigationProps> = ({
     },
     { name: 'Periods', href: '/accounting-periods', icon: CalendarDays },
     { name: 'Wallets', href: '/wallets', icon: Wallet },
+    { name: 'Bank Accounts', href: '/bank-accounts', icon: Landmark },
     { name: 'Entities', href: '/entities', icon: Building2 },
     { name: 'Tax Reports', href: '/reports', icon: FileText },
     {

--- a/src/services/persistence/indexedDBPersistence.ts
+++ b/src/services/persistence/indexedDBPersistence.ts
@@ -1250,6 +1250,7 @@ class IndexedDBPersistenceService implements PersistenceService {
     })
   }
 
+  /** Soft-deletes a bank account by setting active to false. */
   async archiveBankAccount(id: string): Promise<void> {
     const db = await this.ensureDB()
     return new Promise((resolve, reject) => {

--- a/src/services/persistence/indexedDBPersistence.ts
+++ b/src/services/persistence/indexedDBPersistence.ts
@@ -1250,6 +1250,28 @@ class IndexedDBPersistenceService implements PersistenceService {
     })
   }
 
+  async archiveBankAccount(id: string): Promise<void> {
+    const db = await this.ensureDB()
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORES.BANK_ACCOUNTS, 'readwrite')
+      const store = tx.objectStore(STORES.BANK_ACCOUNTS)
+      const getReq = store.get(id)
+      getReq.onsuccess = () => {
+        const account = getReq.result as BankAccount | undefined
+        if (!account) {
+          reject(new Error(`Bank account ${id} not found`))
+          return
+        }
+        account.active = false
+        account.updated_at = Math.floor(Date.now() / 1000)
+        const putReq = store.put(account)
+        putReq.onsuccess = () => resolve()
+        putReq.onerror = () => reject(putReq.error)
+      }
+      getReq.onerror = () => reject(getReq.error)
+    })
+  }
+
   // ============================================================================
   // Bank Transaction Operations (GIV-825)
   // ============================================================================

--- a/src/services/persistence/tauriPersistence.ts
+++ b/src/services/persistence/tauriPersistence.ts
@@ -254,6 +254,10 @@ export const tauriPersistence: PersistenceService = {
     return invoke<BankAccount>('save_bank_account', { account })
   },
 
+  archiveBankAccount: (id: string): Promise<void> => {
+    return invoke<void>('archive_bank_account', { id })
+  },
+
   // Bank Transaction Operations (GIV-825)
   getBankTransactions: (
     bankAccountId: string,

--- a/src/services/persistence/tauriPersistence.ts
+++ b/src/services/persistence/tauriPersistence.ts
@@ -254,8 +254,8 @@ export const tauriPersistence: PersistenceService = {
     return invoke<BankAccount>('save_bank_account', { account })
   },
 
-  archiveBankAccount: (id: string): Promise<void> => {
-    return invoke<void>('archive_bank_account', { id })
+  archiveBankAccount: async (id: string): Promise<void> => {
+    await invoke('archive_bank_account', { id })
   },
 
   // Bank Transaction Operations (GIV-825)

--- a/src/services/persistence/types.ts
+++ b/src/services/persistence/types.ts
@@ -462,6 +462,7 @@ export interface PersistenceService {
   // Bank account operations (GIV-825)
   getBankAccounts(): Promise<BankAccount[]>
   saveBankAccount(account: BankAccountInput): Promise<BankAccount>
+  archiveBankAccount(id: string): Promise<void>
 
   // Bank transaction operations (GIV-825)
   getBankTransactions(


### PR DESCRIPTION
## Summary

- New `/bank-accounts` route with full bank account CRUD (add/edit/archive), multi-entity support, and GL account mapping
- Statement upload via drag-drop or file picker, supporting OFX/QFX/QBO/CSV formats with automatic format detection
- Preview grid showing parsed rows with dedup detection, inline payee/memo editing, select/deselect per row, and confirm/cancel before commit
- Import batch tracking via `saveImportBatch` for audit trail
- Nav item "Bank Accounts" added after "Wallets" in both organization and individual navigation
- Web + desktop parity (no `DesktopOnlyRoute` gate per PRD §7 — post-to-journal stays desktop-gated in GIV-828/829)

## Files changed (3 files, +1041)

| File | Change |
|------|--------|
| `src/app/bank-accounts/BankAccountManager.tsx` | New page component |
| `src/App.tsx` | Lazy import + route registration |
| `src/components/layout/Navigation.tsx` | Landmark icon + nav item in both nav arrays |

## Dependencies

- GIV-825 (bank tables + PersistenceService methods) — merged
- GIV-826 (OFX/QFX/QBO + CSV parsers) — merged

## Test plan

- [ ] Navigate to Bank Accounts from sidebar
- [ ] Add a bank account (fill institution, nickname, account type, currency)
- [ ] Edit an existing account
- [ ] Archive an account
- [ ] Upload an OFX/QFX statement → verify preview grid shows parsed transactions
- [ ] Upload a CSV statement → verify auto-column inference or profile selection works
- [ ] Verify duplicate detection highlights previously imported transactions
- [ ] Edit payee/memo inline in preview grid
- [ ] Confirm import → verify transactions saved and success message shown
- [ ] Cancel import → verify no transactions saved
- [ ] Verify nav item appears in both org and individual nav modes
- [ ] Verify the page works in web build (not desktop-gated)

**UX review with CPO** requested before merge per GIV-827 spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)