### PR TITLE
fix(wallets): fix Polkadot sync + remove sunset Moonbeam/Moonriver networks (GIV-888)

### DIFF
--- a/src/app/wallets/WalletManager.tsx
+++ b/src/app/wallets/WalletManager.tsx
@@ -114,13 +114,12 @@ const convertToNetworkFormat = (
 
   try {
     // Get SS58 prefix for each network
-    const ss58Formats: Record<NetworkType, number> = {
+    const ss58Formats: Partial<Record<NetworkType, number>> = {
       polkadot: 0, // Polkadot addresses start with '1'
       kusama: 2, // Kusama addresses start with various letters
-      moonbeam: 1284, // Moonbeam
-      moonriver: 1285, // Moonriver
       astar: 5, // Astar
       acala: 10, // Acala
+      // Moonbeam (1284) and Moonriver (1285) are sunset — no longer included
     }
 
     const ss58Prefix = ss58Formats[network]
@@ -300,9 +299,8 @@ const NETWORK_DECIMALS: Record<string, number> = {
   polkadot: 10,
   acala: 10,
   kusama: 12,
-  moonbeam: 18,
-  moonriver: 18,
   astar: 18,
+  // Moonbeam and Moonriver are sunset (2026-07-31) — no longer supported
 }
 
 /**
@@ -1136,8 +1134,6 @@ const WalletManager: React.FC = () => {
                   >
                     <option value={NetworkType.POLKADOT}>Polkadot</option>
                     <option value={NetworkType.KUSAMA}>Kusama</option>
-                    <option value={NetworkType.MOONBEAM}>Moonbeam</option>
-                    <option value={NetworkType.MOONRIVER}>Moonriver</option>
                     <option value={NetworkType.ASTAR}>Astar</option>
                     <option value={NetworkType.ACALA}>Acala</option>
                   </select>

--- a/src/hooks/useBlockSubscription.ts
+++ b/src/hooks/useBlockSubscription.ts
@@ -16,20 +16,21 @@ import { NetworkType } from '../services/wallet/types'
 import { encodeAddress, decodeAddress } from '@polkadot/util-crypto'
 
 /** SS58 prefix map for address conversion */
-const SS58_FORMATS: Record<NetworkType, number> = {
+const SS58_FORMATS: Partial<Record<NetworkType, number>> = {
   [NetworkType.POLKADOT]: 0,
   [NetworkType.KUSAMA]: 2,
-  [NetworkType.MOONBEAM]: 1284,
-  [NetworkType.MOONRIVER]: 1285,
   [NetworkType.ASTAR]: 5,
   [NetworkType.ACALA]: 10,
+  // Moonbeam (1284) and Moonriver (1285) are sunset — omitted
 }
 
 /** Convert an address to network-specific SS58 format */
 function toNetworkAddress(address: string, network: NetworkType): string {
   if (address.startsWith('0x')) return address
+  const prefix = SS58_FORMATS[network]
+  if (prefix === undefined) return address
   try {
-    return encodeAddress(decodeAddress(address), SS58_FORMATS[network])
+    return encodeAddress(decodeAddress(address), prefix)
   } catch {
     return address
   }

--- a/src/services/blockchain/polkadotService.ts
+++ b/src/services/blockchain/polkadotService.ts
@@ -357,9 +357,13 @@ class PolkadotService {
   ): Promise<SubstrateTransaction[]> {
     const { address, startBlock = 1, limit = 100, onProgress } = filter
     const allTransactions: SubstrateTransaction[] = []
-    // Scan last 1000 blocks via RPC for recent transactions
-    // Older transactions are fetched instantly from Subscan API
-    const RECENT_BLOCKS_CUTOFF = 1000 // ~1.7 hours on Polkadot at 6s/block
+    // Default RPC scan window: last 1000 blocks (~1.7 hours at 6s/block).
+    // When startBlock is provided (incremental refresh) and the gap since last
+    // sync is ≤ MAX_INCREMENTAL_BLOCKS, extend the scan to cover the full gap
+    // so transactions between syncs are never silently missed when Subscan is
+    // unavailable (rate-limited or blocked).
+    const RECENT_BLOCKS_CUTOFF = 1000
+    const MAX_INCREMENTAL_BLOCKS = 10_000 // ~16.7 hours; beyond this fall back to Subscan
 
     // Check if this is an EVM address on an EVM-compatible chain (Moonbeam, Moonriver)
     const isEVMChain = network === 'moonbeam' || network === 'moonriver'
@@ -506,10 +510,19 @@ class PolkadotService {
         // Get current block height
         const currentBlockHeader = await api.rpc.chain.getHeader()
         currentBlock = currentBlockHeader.number.toNumber()
-        recentBlockStart = Math.max(
-          currentBlock - RECENT_BLOCKS_CUTOFF,
-          startBlock
-        )
+
+        // For incremental refreshes (startBlock > 1) where the gap since the
+        // last sync is within MAX_INCREMENTAL_BLOCKS, scan the full gap so
+        // transactions are never missed when Subscan is unavailable.
+        const gapSinceLastSync = currentBlock - startBlock
+        if (startBlock > 1 && gapSinceLastSync <= MAX_INCREMENTAL_BLOCKS) {
+          recentBlockStart = startBlock
+        } else {
+          recentBlockStart = Math.max(
+            currentBlock - RECENT_BLOCKS_CUTOFF,
+            startBlock
+          )
+        }
       } catch (rpcError) {
         console.warn(
           'RPC connection failed, skipping recent block scan:',

--- a/src/services/blockchain/subscanService.ts
+++ b/src/services/blockchain/subscanService.ts
@@ -231,8 +231,7 @@ class SubscanService {
           fee: transfer.fee,
           status: transfer.success ? 'success' : 'failed',
           network,
-          tokenSymbol:
-            transfer.asset_symbol || NETWORK_TOKEN_SYMBOLS[network],
+          tokenSymbol: transfer.asset_symbol || NETWORK_TOKEN_SYMBOLS[network],
           type: actionInfo.type,
           method: actionInfo.method,
           section: actionInfo.section,

--- a/src/services/blockchain/subscanService.ts
+++ b/src/services/blockchain/subscanService.ts
@@ -205,36 +205,40 @@ class SubscanService {
         throw err
       })
 
-      if (response.code === 0) {
-        // Subscan might return data.transfers or data.list
-        const transfers = response.data.transfers || response.data.list || []
+      if (response.code !== 0) {
+        throw new Error(
+          `Subscan API error ${response.code}: ${response.message}`
+        )
+      }
 
-        onProgress?.(transfers.length, response.data.count || 0)
+      // Subscan might return data.transfers or data.list
+      const transfers = response.data.transfers || response.data.list || []
 
-        for (const transfer of transfers) {
-          // Extract detailed action information
-          const actionInfo = SubscanService.extractActionFromTransfer(transfer)
+      onProgress?.(transfers.length, response.data.count || 0)
 
-          transactions.push({
-            id: `${transfer.block_num}-${transfer.extrinsic_index}`,
-            hash: transfer.hash,
-            blockNumber: transfer.block_num,
-            timestamp: new Date(transfer.block_timestamp * 1000),
-            from: transfer.from,
-            to: transfer.to,
-            value: transfer.amount_v2, // Use raw planck value
-            fee: transfer.fee,
-            status: transfer.success ? 'success' : 'failed',
-            network,
-            tokenSymbol:
-              transfer.asset_symbol || NETWORK_TOKEN_SYMBOLS[network],
-            type: actionInfo.type,
-            method: actionInfo.method,
-            section: actionInfo.section,
-            events: [],
-            isSigned: true,
-          })
-        }
+      for (const transfer of transfers) {
+        // Extract detailed action information
+        const actionInfo = SubscanService.extractActionFromTransfer(transfer)
+
+        transactions.push({
+          id: `${transfer.block_num}-${transfer.extrinsic_index}`,
+          hash: transfer.hash,
+          blockNumber: transfer.block_num,
+          timestamp: new Date(transfer.block_timestamp * 1000),
+          from: transfer.from,
+          to: transfer.to,
+          value: transfer.amount_v2, // Use raw planck value
+          fee: transfer.fee,
+          status: transfer.success ? 'success' : 'failed',
+          network,
+          tokenSymbol:
+            transfer.asset_symbol || NETWORK_TOKEN_SYMBOLS[network],
+          type: actionInfo.type,
+          method: actionInfo.method,
+          section: actionInfo.section,
+          events: [],
+          isSigned: true,
+        })
       }
 
       return transactions
@@ -273,7 +277,13 @@ class SubscanService {
         is_stash: true,
       })
 
-      if (response.code === 0 && response.data.list) {
+      if (response.code !== 0) {
+        throw new Error(
+          `Subscan API error ${response.code}: ${response.message}`
+        )
+      }
+
+      if (response.data.list) {
         for (const reward of response.data.list) {
           transactions.push({
             id: `${reward.block_num}-${reward.event_index}`,


### PR DESCRIPTION
## Summary

- **Network dropdown updated**: Removed Moonbeam and Moonriver from the WalletManager sync network selector — both networks were sunset on 2026-07-31 (GIV-750/751). Updated `NETWORK_DECIMALS` and `ss58Formats` maps in the same file.
- **Subscan silent error fixed**: `fetchTransfers` and `fetchRewards` now throw on non-zero Subscan API response codes (rate-limit 10004, auth errors, etc.) instead of silently returning `[]`. Previously this caused the hybrid sync to report "0 transactions found" with no user-visible error when Subscan was rate-limited.
- **Incremental RPC scan window extended**: For incremental refreshes (real-time sync via `useBlockSubscription`), when the gap since the last sync is ≤ 10 000 blocks (~16.7 h), the RPC block scan now covers the full gap from `startBlock` rather than being capped at the last 1000 blocks (~1.7 h). This prevents transactions being silently missed when Subscan is unavailable.
- **`useBlockSubscription` SS58 map cleaned up**: Removed Moonbeam/Moonriver entries; guarded `toNetworkAddress` against undefined prefix.

## Root cause

Two independent bugs combined to produce "not syncing recent transactions":

1. Subscan rate-limits unauthenticated requests at 5 req/hour. The `/api/v2/scan/transfers` endpoint returns `{"code": 10004, ...}` with HTTP 200 when rate-limited. The service was not checking `code != 0`, so it returned `[]` silently — the caller couldn't distinguish "zero transfers" from "rate limited".

2. After Subscan's silent failure, the hybrid fetch fell through to the RPC path which only scanned the last 1000 blocks (~1.7 h). If a user's actual recent transactions were older than that (e.g., last week), neither source found them and the sync reported 0 results.

## Test plan
- [ ] Open `/wallet-manager` — Moonbeam and Moonriver no longer appear in the Network dropdown
- [ ] Sync a Polkadot address without a Subscan API key → should now see a visible "Subscan API error 10004" warning rather than a silent 0-transaction result
- [ ] Sync a Polkadot address that has transactions older than ~1.7 hours since last sync — verify transactions are found via the extended RPC window
- [ ] TypeScript: `npx tsc --noEmit` passes (verified)
- [ ] Unit tests: `npx vitest run src/services/__tests__/polkadotService.test.ts` — 6/6 pass (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)