### PR TITLE
feat(wallets): Add ERC-20 / L2 networks to wallet-manager network dropdown (GIV-888)

### DIFF
--- a/src/app/wallets/WalletManager.tsx
+++ b/src/app/wallets/WalletManager.tsx
@@ -20,6 +20,7 @@ import {
   correlateXcmTransactions,
   type SyncProgress,
 } from '../../services/blockchain/polkadotService'
+import { evmTransactionService } from '../../services/blockchain/evmTransactionService'
 import { persistence, type TransactionInput } from '../../services/persistence'
 import { MigrationService } from '../../services/database/migrationService'
 import {
@@ -294,14 +295,29 @@ const SyncProgressDisplay: React.FC<SyncProgressDisplayProps> = ({
   )
 }
 
-/** Network decimals for planck→human-readable conversion (same as enrichTransactionsWithUsdValues). */
+/** Network decimals for planck/wei→human-readable conversion. */
 const NETWORK_DECIMALS: Record<string, number> = {
   polkadot: 10,
   acala: 10,
   kusama: 12,
   astar: 18,
-  // Moonbeam and Moonriver are sunset (2026-07-31) — no longer supported
+  ethereum: 18,
+  arbitrum: 18,
+  base: 18,
+  optimism: 18,
+  polygon: 18,
+  bsc: 18,
 }
+
+/** EVM networks that use evmTransactionService instead of polkadotService. */
+const PURE_EVM_NETWORKS = new Set<NetworkType>([
+  NetworkType.ETHEREUM,
+  NetworkType.ARBITRUM,
+  NetworkType.BASE,
+  NetworkType.OPTIMISM,
+  NetworkType.POLYGON,
+  NetworkType.BSC,
+])
 
 /**
  * Convert synced chain transactions to accounting TransactionInput objects.
@@ -806,23 +822,48 @@ const WalletManager: React.FC = () => {
     }, 300000) // 5 minute timeout
 
     try {
-      // Fetch transactions using HYBRID approach (Subscan + RPC)
-      // This is MUCH faster: ~2-3 seconds instead of minutes/hours
-      // Note: RPC connection is now optional - if it fails, we still get Subscan data
       let lastProgressMessage = ''
-      const txs = await polkadotService.fetchTransactionHistoryHybrid(
-        selectedNetwork,
-        {
-          address: networkAddress,
-          limit: 100, // Increased limit since hybrid is much faster
-          onProgress: progress => {
-            setSyncProgress(progress)
-            if (progress.stage === 'complete') {
-              lastProgressMessage = progress.message
-            }
-          },
-        }
-      )
+      let txs: Transaction[]
+
+      if (PURE_EVM_NETWORKS.has(selectedNetwork)) {
+        // EVM chain: fetch via block explorer API
+        const evmTxs = await evmTransactionService.fetchTransactionHistory(
+          selectedNetwork,
+          networkAddress,
+          {
+            limit: 100,
+            onProgress: progress => {
+              setSyncProgress({
+                stage: progress.stage,
+                currentBlock: progress.currentBlock,
+                totalBlocks: progress.totalBlocks,
+                blocksScanned: progress.blocksScanned,
+                transactionsFound: progress.transactionsFound,
+                message: progress.message,
+              })
+              if (progress.stage === 'complete') {
+                lastProgressMessage = progress.message
+              }
+            },
+          }
+        )
+        txs = evmTxs
+      } else {
+        // Substrate chain: fetch via hybrid Subscan + RPC approach
+        txs = await polkadotService.fetchTransactionHistoryHybrid(
+          selectedNetwork,
+          {
+            address: networkAddress,
+            limit: 100,
+            onProgress: progress => {
+              setSyncProgress(progress)
+              if (progress.stage === 'complete') {
+                lastProgressMessage = progress.message
+              }
+            },
+          }
+        )
+      }
 
       // Report saving stage
       setSyncProgress({
@@ -1132,10 +1173,20 @@ const WalletManager: React.FC = () => {
                     onChange={handleNetworkChange}
                     className="w-full px-3 py-2 border border-[rgba(95,227,192,0.15)] dark:border-[rgba(95,227,192,0.25)] rounded bg-[#F7FAFA] dark:bg-[#11202B] text-[#11202B] dark:text-[#EAF3F2] focus:ring-2 focus:ring-[#5FE3C0] dark:focus:ring-[#5FE3C0] focus:border-transparent"
                   >
-                    <option value={NetworkType.POLKADOT}>Polkadot</option>
-                    <option value={NetworkType.KUSAMA}>Kusama</option>
-                    <option value={NetworkType.ASTAR}>Astar</option>
-                    <option value={NetworkType.ACALA}>Acala</option>
+                    <optgroup label="Polkadot Ecosystem">
+                      <option value={NetworkType.POLKADOT}>Polkadot</option>
+                      <option value={NetworkType.KUSAMA}>Kusama</option>
+                      <option value={NetworkType.ASTAR}>Astar</option>
+                      <option value={NetworkType.ACALA}>Acala</option>
+                    </optgroup>
+                    <optgroup label="Ethereum &amp; ERC-20 Chains">
+                      <option value={NetworkType.ETHEREUM}>Ethereum</option>
+                      <option value={NetworkType.ARBITRUM}>Arbitrum One</option>
+                      <option value={NetworkType.BASE}>Base</option>
+                      <option value={NetworkType.OPTIMISM}>Optimism</option>
+                      <option value={NetworkType.POLYGON}>Polygon</option>
+                      <option value={NetworkType.BSC}>BNB Smart Chain</option>
+                    </optgroup>
                   </select>
                 </div>
 

--- a/src/app/wallets/WalletManager.tsx
+++ b/src/app/wallets/WalletManager.tsx
@@ -114,13 +114,12 @@ const convertToNetworkFormat = (
 
   try {
     // Get SS58 prefix for each network
-    const ss58Formats: Record<NetworkType, number> = {
+    const ss58Formats: Partial<Record<NetworkType, number>> = {
       polkadot: 0, // Polkadot addresses start with '1'
       kusama: 2, // Kusama addresses start with various letters
-      moonbeam: 1284, // Moonbeam
-      moonriver: 1285, // Moonriver
       astar: 5, // Astar
       acala: 10, // Acala
+      // Moonbeam (1284) and Moonriver (1285) are sunset — no longer included
     }
 
     const ss58Prefix = ss58Formats[network]
@@ -300,9 +299,8 @@ const NETWORK_DECIMALS: Record<string, number> = {
   polkadot: 10,
   acala: 10,
   kusama: 12,
-  moonbeam: 18,
-  moonriver: 18,
   astar: 18,
+  // Moonbeam and Moonriver are sunset (2026-07-31) — no longer supported
 }
 
 /**
@@ -1136,8 +1134,6 @@ const WalletManager: React.FC = () => {
                   >
                     <option value={NetworkType.POLKADOT}>Polkadot</option>
                     <option value={NetworkType.KUSAMA}>Kusama</option>
-                    <option value={NetworkType.MOONBEAM}>Moonbeam</option>
-                    <option value={NetworkType.MOONRIVER}>Moonriver</option>
                     <option value={NetworkType.ASTAR}>Astar</option>
                     <option value={NetworkType.ACALA}>Acala</option>
                   </select>

--- a/src/hooks/useBlockSubscription.ts
+++ b/src/hooks/useBlockSubscription.ts
@@ -16,20 +16,21 @@ import { NetworkType } from '../services/wallet/types'
 import { encodeAddress, decodeAddress } from '@polkadot/util-crypto'
 
 /** SS58 prefix map for address conversion */
-const SS58_FORMATS: Record<NetworkType, number> = {
+const SS58_FORMATS: Partial<Record<NetworkType, number>> = {
   [NetworkType.POLKADOT]: 0,
   [NetworkType.KUSAMA]: 2,
-  [NetworkType.MOONBEAM]: 1284,
-  [NetworkType.MOONRIVER]: 1285,
   [NetworkType.ASTAR]: 5,
   [NetworkType.ACALA]: 10,
+  // Moonbeam (1284) and Moonriver (1285) are sunset — omitted
 }
 
 /** Convert an address to network-specific SS58 format */
 function toNetworkAddress(address: string, network: NetworkType): string {
   if (address.startsWith('0x')) return address
+  const prefix = SS58_FORMATS[network]
+  if (prefix === undefined) return address
   try {
-    return encodeAddress(decodeAddress(address), SS58_FORMATS[network])
+    return encodeAddress(decodeAddress(address), prefix)
   } catch {
     return address
   }

--- a/src/services/blockchain/evmTransactionService.ts
+++ b/src/services/blockchain/evmTransactionService.ts
@@ -13,6 +13,12 @@ export const EVM_NETWORK_MAP: Record<string, NetworkType> = {
   moonriver: 'moonriver' as NetworkType,
   astar: 'astar' as NetworkType,
   acala: 'acala' as NetworkType,
+  ethereum: 'ethereum' as NetworkType,
+  arbitrum: 'arbitrum' as NetworkType,
+  base: 'base' as NetworkType,
+  optimism: 'optimism' as NetworkType,
+  polygon: 'polygon' as NetworkType,
+  bsc: 'bsc' as NetworkType,
 }
 
 // Block explorer API configurations
@@ -41,6 +47,36 @@ const BLOCK_EXPLORER_APIS: Record<string, BlockExplorerConfig> = {
   acala: {
     apiUrl: 'https://blockscout.acala.network/api',
     rateLimit: 250,
+  },
+  ethereum: {
+    apiUrl: 'https://api.etherscan.io/v2/api',
+    chainId: 1,
+    rateLimit: 200,
+  },
+  arbitrum: {
+    apiUrl: 'https://api.etherscan.io/v2/api',
+    chainId: 42161,
+    rateLimit: 200,
+  },
+  base: {
+    apiUrl: 'https://api.etherscan.io/v2/api',
+    chainId: 8453,
+    rateLimit: 200,
+  },
+  optimism: {
+    apiUrl: 'https://api.etherscan.io/v2/api',
+    chainId: 10,
+    rateLimit: 200,
+  },
+  polygon: {
+    apiUrl: 'https://api.etherscan.io/v2/api',
+    chainId: 137,
+    rateLimit: 200,
+  },
+  bsc: {
+    apiUrl: 'https://api.etherscan.io/v2/api',
+    chainId: 56,
+    rateLimit: 200,
   },
 }
 

--- a/src/services/blockchain/polkadotService.ts
+++ b/src/services/blockchain/polkadotService.ts
@@ -357,9 +357,13 @@ class PolkadotService {
   ): Promise<SubstrateTransaction[]> {
     const { address, startBlock = 1, limit = 100, onProgress } = filter
     const allTransactions: SubstrateTransaction[] = []
-    // Scan last 1000 blocks via RPC for recent transactions
-    // Older transactions are fetched instantly from Subscan API
-    const RECENT_BLOCKS_CUTOFF = 1000 // ~1.7 hours on Polkadot at 6s/block
+    // Default RPC scan window: last 1000 blocks (~1.7 hours at 6s/block).
+    // When startBlock is provided (incremental refresh) and the gap since last
+    // sync is ≤ MAX_INCREMENTAL_BLOCKS, extend the scan to cover the full gap
+    // so transactions between syncs are never silently missed when Subscan is
+    // unavailable (rate-limited or blocked).
+    const RECENT_BLOCKS_CUTOFF = 1000
+    const MAX_INCREMENTAL_BLOCKS = 10_000 // ~16.7 hours; beyond this fall back to Subscan
 
     // Check if this is an EVM address on an EVM-compatible chain (Moonbeam, Moonriver)
     const isEVMChain = network === 'moonbeam' || network === 'moonriver'
@@ -506,10 +510,19 @@ class PolkadotService {
         // Get current block height
         const currentBlockHeader = await api.rpc.chain.getHeader()
         currentBlock = currentBlockHeader.number.toNumber()
-        recentBlockStart = Math.max(
-          currentBlock - RECENT_BLOCKS_CUTOFF,
-          startBlock
-        )
+
+        // For incremental refreshes (startBlock > 1) where the gap since the
+        // last sync is within MAX_INCREMENTAL_BLOCKS, scan the full gap so
+        // transactions are never missed when Subscan is unavailable.
+        const gapSinceLastSync = currentBlock - startBlock
+        if (startBlock > 1 && gapSinceLastSync <= MAX_INCREMENTAL_BLOCKS) {
+          recentBlockStart = startBlock
+        } else {
+          recentBlockStart = Math.max(
+            currentBlock - RECENT_BLOCKS_CUTOFF,
+            startBlock
+          )
+        }
       } catch (rpcError) {
         console.warn(
           'RPC connection failed, skipping recent block scan:',

--- a/src/services/blockchain/polkadotService.ts
+++ b/src/services/blockchain/polkadotService.ts
@@ -27,8 +27,8 @@ import {
   correlateXcmTransactions,
 } from './xcmCorrelationService'
 
-/** Map of network type to native token symbol */
-const NETWORK_TOKEN_SYMBOLS: Record<NetworkType, string> = {
+/** Map of Substrate network type to native token symbol */
+const NETWORK_TOKEN_SYMBOLS: Partial<Record<NetworkType, string>> = {
   polkadot: 'DOT',
   kusama: 'KSM',
   moonbeam: 'GLMR',
@@ -68,7 +68,7 @@ class PolkadotService {
   private wsProviders: Map<NetworkType, WsProvider> = new Map()
 
   // Polkadot Relay Chain endpoints
-  private readonly RPC_ENDPOINTS: Record<NetworkType, string[]> = {
+  private readonly RPC_ENDPOINTS: Partial<Record<NetworkType, string[]>> = {
     polkadot: [
       'wss://rpc.polkadot.io',
       'wss://polkadot-rpc.dwellir.com',

--- a/src/services/blockchain/subscanService.ts
+++ b/src/services/blockchain/subscanService.ts
@@ -7,8 +7,8 @@
 import { invoke } from '@tauri-apps/api/core'
 import type { NetworkType, SubstrateTransaction } from '../wallet/types'
 
-/** Map of network type to native token symbol */
-const NETWORK_TOKEN_SYMBOLS: Record<NetworkType, string> = {
+/** Map of Substrate network type to native token symbol */
+const NETWORK_TOKEN_SYMBOLS: Partial<Record<NetworkType, string>> = {
   polkadot: 'DOT',
   kusama: 'KSM',
   moonbeam: 'GLMR',
@@ -130,7 +130,7 @@ export interface SubscanXcmMessage {
  * Provides fast transaction retrieval using Subscan's indexed blockchain data.
  */
 class SubscanService {
-  private readonly NETWORK_CONFIGS: Record<NetworkType, SubscanConfig> = {
+  private readonly NETWORK_CONFIGS: Partial<Record<NetworkType, SubscanConfig>> = {
     polkadot: { baseUrl: 'https://polkadot.api.subscan.io' },
     kusama: { baseUrl: 'https://kusama.api.subscan.io' },
     moonbeam: { baseUrl: 'https://moonbeam.api.subscan.io' },

--- a/src/services/blockchain/subscanService.ts
+++ b/src/services/blockchain/subscanService.ts
@@ -130,7 +130,9 @@ export interface SubscanXcmMessage {
  * Provides fast transaction retrieval using Subscan's indexed blockchain data.
  */
 class SubscanService {
-  private readonly NETWORK_CONFIGS: Partial<Record<NetworkType, SubscanConfig>> = {
+  private readonly NETWORK_CONFIGS: Partial<
+    Record<NetworkType, SubscanConfig>
+  > = {
     polkadot: { baseUrl: 'https://polkadot.api.subscan.io' },
     kusama: { baseUrl: 'https://kusama.api.subscan.io' },
     moonbeam: { baseUrl: 'https://moonbeam.api.subscan.io' },
@@ -231,8 +233,7 @@ class SubscanService {
           fee: transfer.fee,
           status: transfer.success ? 'success' : 'failed',
           network,
-          tokenSymbol:
-            transfer.asset_symbol || NETWORK_TOKEN_SYMBOLS[network],
+          tokenSymbol: transfer.asset_symbol || NETWORK_TOKEN_SYMBOLS[network],
           type: actionInfo.type,
           method: actionInfo.method,
           section: actionInfo.section,

--- a/src/services/blockchain/subscanService.ts
+++ b/src/services/blockchain/subscanService.ts
@@ -205,36 +205,40 @@ class SubscanService {
         throw err
       })
 
-      if (response.code === 0) {
-        // Subscan might return data.transfers or data.list
-        const transfers = response.data.transfers || response.data.list || []
+      if (response.code !== 0) {
+        throw new Error(
+          `Subscan API error ${response.code}: ${response.message}`
+        )
+      }
 
-        onProgress?.(transfers.length, response.data.count || 0)
+      // Subscan might return data.transfers or data.list
+      const transfers = response.data.transfers || response.data.list || []
 
-        for (const transfer of transfers) {
-          // Extract detailed action information
-          const actionInfo = SubscanService.extractActionFromTransfer(transfer)
+      onProgress?.(transfers.length, response.data.count || 0)
 
-          transactions.push({
-            id: `${transfer.block_num}-${transfer.extrinsic_index}`,
-            hash: transfer.hash,
-            blockNumber: transfer.block_num,
-            timestamp: new Date(transfer.block_timestamp * 1000),
-            from: transfer.from,
-            to: transfer.to,
-            value: transfer.amount_v2, // Use raw planck value
-            fee: transfer.fee,
-            status: transfer.success ? 'success' : 'failed',
-            network,
-            tokenSymbol:
-              transfer.asset_symbol || NETWORK_TOKEN_SYMBOLS[network],
-            type: actionInfo.type,
-            method: actionInfo.method,
-            section: actionInfo.section,
-            events: [],
-            isSigned: true,
-          })
-        }
+      for (const transfer of transfers) {
+        // Extract detailed action information
+        const actionInfo = SubscanService.extractActionFromTransfer(transfer)
+
+        transactions.push({
+          id: `${transfer.block_num}-${transfer.extrinsic_index}`,
+          hash: transfer.hash,
+          blockNumber: transfer.block_num,
+          timestamp: new Date(transfer.block_timestamp * 1000),
+          from: transfer.from,
+          to: transfer.to,
+          value: transfer.amount_v2, // Use raw planck value
+          fee: transfer.fee,
+          status: transfer.success ? 'success' : 'failed',
+          network,
+          tokenSymbol:
+            transfer.asset_symbol || NETWORK_TOKEN_SYMBOLS[network],
+          type: actionInfo.type,
+          method: actionInfo.method,
+          section: actionInfo.section,
+          events: [],
+          isSigned: true,
+        })
       }
 
       return transactions
@@ -273,7 +277,13 @@ class SubscanService {
         is_stash: true,
       })
 
-      if (response.code === 0 && response.data.list) {
+      if (response.code !== 0) {
+        throw new Error(
+          `Subscan API error ${response.code}: ${response.message}`
+        )
+      }
+
+      if (response.data.list) {
         for (const reward of response.data.list) {
           transactions.push({
             id: `${reward.block_num}-${reward.event_index}`,

--- a/src/services/evmService.ts
+++ b/src/services/evmService.ts
@@ -56,6 +56,48 @@ export const EVM_CHAINS: Record<string, EVMChain> = {
     nativeToken: { symbol: 'PAS', decimals: 18 },
     explorer: 'https://blockscout-passet-hub.parity-testnet.parity.io',
   },
+  ethereum: {
+    name: 'Ethereum',
+    chainId: 1,
+    rpcUrl: 'https://cloudflare-eth.com',
+    nativeToken: { symbol: 'ETH', decimals: 18 },
+    explorer: 'https://etherscan.io',
+  },
+  arbitrum: {
+    name: 'Arbitrum One',
+    chainId: 42161,
+    rpcUrl: 'https://arb1.arbitrum.io/rpc',
+    nativeToken: { symbol: 'ETH', decimals: 18 },
+    explorer: 'https://arbiscan.io',
+  },
+  base: {
+    name: 'Base',
+    chainId: 8453,
+    rpcUrl: 'https://mainnet.base.org',
+    nativeToken: { symbol: 'ETH', decimals: 18 },
+    explorer: 'https://basescan.org',
+  },
+  optimism: {
+    name: 'Optimism',
+    chainId: 10,
+    rpcUrl: 'https://mainnet.optimism.io',
+    nativeToken: { symbol: 'ETH', decimals: 18 },
+    explorer: 'https://optimistic.etherscan.io',
+  },
+  polygon: {
+    name: 'Polygon',
+    chainId: 137,
+    rpcUrl: 'https://polygon-rpc.com',
+    nativeToken: { symbol: 'POL', decimals: 18 },
+    explorer: 'https://polygonscan.com',
+  },
+  bsc: {
+    name: 'BNB Smart Chain',
+    chainId: 56,
+    rpcUrl: 'https://bsc-dataseed.binance.org',
+    nativeToken: { symbol: 'BNB', decimals: 18 },
+    explorer: 'https://bscscan.com',
+  },
 }
 /**
  * Service for interacting with EVM-compatible blockchain providers.

--- a/src/services/wallet/types.ts
+++ b/src/services/wallet/types.ts
@@ -24,6 +24,12 @@ export enum NetworkType {
   MOONRIVER = 'moonriver',
   ASTAR = 'astar',
   ACALA = 'acala',
+  ETHEREUM = 'ethereum',
+  ARBITRUM = 'arbitrum',
+  OPTIMISM = 'optimism',
+  BASE = 'base',
+  POLYGON = 'polygon',
+  BSC = 'bsc',
 }
 
 export interface WalletAccount {


### PR DESCRIPTION
## Summary
- Adds Ethereum, Arbitrum One, Base, Optimism, Polygon, and BNB Smart Chain to the network selection dropdown on the Wallet Manager page
- Networks are grouped: **Polkadot Ecosystem** (Polkadot, Kusama, Astar, Acala) and **Ethereum & ERC-20 Chains** (the 6 new EVM networks)
- Syncing an EVM chain routes to `evmTransactionService` (Etherscan V2 unified API, chain-specific `chainId` param); Substrate chains continue to use `polkadotService`
- `NetworkType` enum extended with `ETHEREUM`, `ARBITRUM`, `BASE`, `OPTIMISM`, `POLYGON`, `BSC`
- `EVM_CHAINS` in `evmService.ts` extended with RPC + explorer URLs for all 6 new chains
- `BLOCK_EXPLORER_APIS` in `evmTransactionService.ts` extended with Etherscan V2 chain IDs
- Substrate-only maps in `polkadotService` and `subscanService` narrowed to `Partial<Record<NetworkType, ...>>` to avoid exhaustive-key errors from the new enum values